### PR TITLE
Auto move thesuruses to data dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,19 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/config/codelist/local/thesauri/theme</directory>
+        <targetPath>thesarus/theme</targetPath>
+      </resource>
+      <resource>
+        <directory>src/main/config/codelist/local/thesauri/place</directory>
+        <targetPath>thesarus/place</targetPath>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
     <testResources>
       <testResource>
         <directory>src/test/resources/org/fao/geonet</directory>

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializer.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializer.java
@@ -1,0 +1,69 @@
+package ca.gc.schemas.iso19139hnap.init;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.ThesaurusManager;
+import org.fao.geonet.utils.Log;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+/**
+ * This class is for setting up a schema.
+ * <p>
+ * It watches the system startup and gives us the opportunity to do any setup required at the appropriate time.
+ * <p>
+ * See config-spring-geonetwork.xml in this schema
+ */
+public class SchemaInitializer implements
+    ApplicationListener<GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent> {
+
+
+    private static String resourceTypeDir = "external"; // "local" or "external"
+    private static String jarRDFPattern = "thesarus/**/*.rdf"; //find rdf files in the JAR
+
+    // for each of the RDF files included in this JAR, if its not in the corresponding location in datadir, then we copy it in
+    public void ConfigureThesauruses(Path thesauriDir) throws IOException {
+        PathMatchingResourcePatternResolver resolver =
+            new PathMatchingResourcePatternResolver(Thread.currentThread().getContextClassLoader());
+        //for each of the .rdf files
+        for (Resource r : resolver.getResources(jarRDFPattern)) {
+            String fname = r.getFilename(); //i.e. thesaurus/theme/EC_ISO_Countries.rdf
+            String[] subDirs = r.getURI().toURL().getPath().split(Pattern.quote(File.separator));
+            String dir = subDirs[subDirs.length - 2]; // ie. "theme"
+            ///put in - WEB-INF/data/config/codelist/external/thesauri/theme/EC_ISO_Countries.rdf
+            //ensure that dirs exist
+            Files.createDirectories(Paths.get(thesauriDir.toString(), resourceTypeDir, "thesauri", dir));
+            //full path to put the .rdf
+            Path correspondingDataDirFile = Paths.get(thesauriDir.toString(), resourceTypeDir, "thesauri", dir, fname);
+            if (!Files.exists(correspondingDataDirFile)) {
+                //need to copy it in...
+                Log.info(Geonet.THESAURUS, "ISO19139.HNAP: SchemaInitializer: need to copy in Thesaurus: " + fname);
+                try (InputStream is = r.getInputStream()) { //auto close
+                    java.nio.file.Files.copy(is, correspondingDataDirFile);
+                }
+            }
+        }
+    }
+
+
+    //when the data dir is configured, we're good to copy in our thesauruses
+    @Override
+    public void onApplicationEvent(GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent event) {
+        Path thesauriDir = event.getSource().getThesauriDir();
+        try {
+            ConfigureThesauruses(thesauriDir);
+        } catch (IOException e) {
+            Log.error(Geonet.THESAURUS, "SchemaInitializer: preloading RDF files", e);
+        }
+    }
+}

--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -3,7 +3,16 @@
   xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:util="http://www.springframework.org/schema/util"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+  xmlns:context="http://www.springframework.org/schema/context"
+>
+
+  <context:component-scan base-package="ca.gc.schemas.iso19139hnap.init"/>
+
+  <bean id="iso19139.ca.HNAP.startup"
+        class="ca.gc.schemas.iso19139hnap.init.SchemaInitializer"
+        >
+  </bean>
 
   <bean id="iso19139.ca.HNAPSchemaPlugin"
         class="org.fao.geonet.schema.iso19139.ISO19139SchemaPlugin">


### PR DESCRIPTION
1) JAR: move schema's thesauruses to resources in jar (see `pom.xml`)
2) SPRING: config-spring-geonetwork.xml modified to setup `SchemaInitializer`
3) JAVA: new `SchemaInitializer` class
    * when the GN datadir is setup, this will be notified (`onApplicationEvent`)
   * it will see if the JAR's thesauruses are in the data dir, if not, it will copy them in