### PR TITLE
better handling of 'eng; CAN' language

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -228,11 +228,10 @@
                                         gmd:LocalisedCharacterString[
                                           @locale = concat('#', $currentLanguageId)]) = 0"/>
 
-
             <xsl:choose>
               <xsl:when test="$ptFreeElementDoesNotExist and
                               $text != '' and
-                              $code = $metadataLanguage">
+                              substring($code,1,3) = substring($metadataLanguage,1,3)">
               <value ref="lang_{@id}_{$theElement/parent::node()/gn:element/@ref}"
                        lang="{@id}">
                   <xsl:value-of select="$text"/>


### PR DESCRIPTION
Changed this because $metadataLanguage was "eng; CAN"
which didn't match $code ("eng").

This should fix this problem.