### PR TITLE
make language JSON correct

### DIFF
--- a/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
+++ b/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
@@ -238,7 +238,7 @@ public class XslUtilHnap {
     public static
     @Nonnull String getMappLangId(String lang, String id) {
         if (id == null || id.isEmpty()) {
-            return lang;
+            return getMappedLang(lang); // convert eng; CAN --> eng    OR  fra; CAN --> fra
         }
         else {
             return id;

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -102,7 +102,7 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:text>{</xsl:text><xsl:value-of select="string-join($langs/lang, ',')"/><xsl:text>}</xsl:text>
+    <xsl:text>{</xsl:text><xsl:value-of select="string-join(distinct-values($langs/lang), ',')"/><xsl:text>}</xsl:text>
   </xsl:template>
 
   <!-- Get the list of other languages -->


### PR DESCRIPTION
I noticed that the data-gn-multilingual-field attribute had "weird" values.  For example;
```json
{
   "eng":"#eng; CAN",
    "fre":"#fra",
    "eng":"#eng"
}
```
This is incorrect, it should be:
```json
{
   "eng":"#eng",
   "fre":"#fra"
}
```
This PR fixes this;

a) update java code so it converts, for document default language, `"eng":"#eng; CAN"` to `"eng":"#eng"`
b) The above creates `{"eng":"#eng","fre":"#fra","eng":"#eng"}` so I added a `distinct-values()` to remove the duplicated value.
