### PR TITLE
not put localized character string for default language (redundant)

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -23,7 +23,7 @@
   <xsl:include href="layout/utility-fn.xsl"/>
 
   <xsl:variable name="thesauriDir" select="XslUtilHnap:getThesauriDir()" />
-  <xsl:variable name="ecCoreThesaurus" select="document(concat('file:///', replace(concat($thesauriDir, '/local/thesauri/theme/EC_Core_Subject.rdf'), '\\', '/')))" />
+  <xsl:variable name="ecCoreThesaurus" select="document(concat('file:///', replace(concat($thesauriDir, '/external/thesauri/theme/EC_Core_Subject.rdf'), '\\', '/')))" />
 
   <xsl:variable name="coreThesaurusEng" select="'Government of Canada Core Subject Thesaurus'" />
   <xsl:variable name="coreThesaurusFre" select="'Thésaurus des sujets de base du gouvernement du Canada'" />
@@ -476,13 +476,14 @@
                 <!-- only put this in if there's stuff to put in, otherwise we get a <gmd:PT_FreeText/> in output -->
                 <xsl:if test="(normalize-space(gco:CharacterString|gmx:Anchor) != '') or gmd:PT_FreeText">
                   <gmd:PT_FreeText>
-                    <xsl:if test="normalize-space(gco:CharacterString|gmx:Anchor) != ''"> <!-- default lang-->
-                      <gmd:textGroup>
-                        <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">
-                          <xsl:value-of select="gco:CharacterString|gmx:Anchor"/>
-                        </gmd:LocalisedCharacterString>
-                      </gmd:textGroup>
-                    </xsl:if>
+                    <!-- do NOT put in the main language (again) -->
+<!--                    <xsl:if test="normalize-space(gco:CharacterString|gmx:Anchor) != ''"> &lt;!&ndash; default lang&ndash;&gt;-->
+<!--                      <gmd:textGroup>-->
+<!--                        <gmd:LocalisedCharacterString locale="#{$mainLanguageId}">-->
+<!--                          <xsl:value-of select="gco:CharacterString|gmx:Anchor"/>-->
+<!--                        </gmd:LocalisedCharacterString>-->
+<!--                      </gmd:textGroup>-->
+<!--                    </xsl:if>-->
                     <xsl:call-template name="populate-free-text"/> <!-- other langs -->
                   </gmd:PT_FreeText>
                 </xsl:if>
@@ -502,10 +503,8 @@
   <xsl:template name="populate-free-text">
     <xsl:variable name="freeText"
                   select="gmd:PT_FreeText/gmd:textGroup"/>
-    <!-- Loop on locales in order to preserve order.
-        Keep main language on top.
-        Translations having no locale are ignored. eg. when removing a lang. -->
-    <xsl:apply-templates select="$freeText[*/@locale = concat('#', $mainLanguageId)]"/>
+    <!-- dont put in main language - its aready in the main section -->
+<!--    <xsl:apply-templates select="$freeText[*/@locale = concat('#', $mainLanguageId)]"/>-->
 
     <xsl:for-each select="$locales[@id != $mainLanguageId]">
       <xsl:variable name="localId"


### PR DESCRIPTION
This will make it so that the document default language is not put in the alternative language sections.

```:xml
 <gmd:administrativeArea xsi:type="gmd:PT_FreeText_PropertyType">
    <gco:CharacterString>British Columbia</gco:CharacterString>
    <gmd:PT_FreeText>
        **<gmd:textGroup>
            <gmd:LocalisedCharacterString locale="#eng">British
                Columbia</gmd:LocalisedCharacterString>
        </gmd:textGroup>**
        <gmd:textGroup>
            <gmd:LocalisedCharacterString locale="#fra"
                >Colombie-Britannique</gmd:LocalisedCharacterString>
        </gmd:textGroup>
    </gmd:PT_FreeText>
</gmd:administrativeArea>
```

In this example, "British Columbia" is redundant - its in the default section ("CharacterString") and in the alternative section ("#eng").  This will remove the ("#eng") section (in bold).

I also noticed that it was referencing a thesaurus that was in "/local" - however, this is in the "external".