### PR TITLE
Fix problem related to autodetect

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
@@ -38,7 +38,7 @@
 
 	<autodetect xmlns:gmd="http://www.isotc211.org/2005/gmd"
               xmlns:gco="http://www.isotc211.org/2005/gco">
-	    <elements type="search">
+	    <elements>
         <gmd:metadataStandardName>
           <gco:CharacterString>North American Profile of ISO 19115:2003 - Geographic information - Metadata|Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées</gco:CharacterString>
         </gmd:metadataStandardName>


### PR DESCRIPTION
Fix problem related to autodetect which was causing iso1939 records to be identified as hnap in the unit test.

Seems like **type "search"** only checks the element which matches both iso1939 and hnap and it chooses the hnap version in the unit tests.
I believe we want it to also match the text so the option was removed - it seems to have fixed the issue.

Related to issue #25 