### PR TITLE
use new GN-core multi-entry-combiner for organization name

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -85,10 +85,7 @@
 
     </for>
 
-    <!--<for name="gmd:referenceSystemInfo" addDirective="data-gn-crs-selector"/>-->
-
-
-<!--    <for name="gmd:organisationName" use="data-gn-organisation-entry-selector-ec"/>-->
+<!--      gmd:organisationName == see layout-custom-fields-->
 
     <for name="gmd:contact" addDirective="data-gn-directory-entry-selector">
       <directiveAttributes
@@ -211,7 +208,6 @@
       <name>gmd:metadataStandardName</name>
       <name>gmd:title</name>
       <name>gmd:abstract</name>
-      <name>gmd:organisationName</name>
       <name>gmd:country</name>
       <name>gmd:name</name>
       <name>gmd:administrativeArea</name>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -194,12 +194,12 @@
           },
 
           {
-            "type": "thesurus",
+            "type": "thesaurus",
             "heading": {
               "eng": "Government of Canada Organization",
               "fra": "Organisation du Gouvernement du Canada"
             },
-            "thesurus": "external.theme.EC_Government_Titles"
+            "thesaurus": "external.theme.EC_Government_Titles"
           },
 
           {

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -120,8 +120,8 @@
       Creates this (actual values of the metadata record);
 
         <values>
-            <value ref="15" lang="eng">Government of Canada; Library of Parliament; david place2</value>
-            <value ref="18" lang="fra">Gouvernement du Canada; Bibliothèque du Parlement; chez david2</value>
+            <value ref="15" lang="eng">Government of Canada; Organization of Public Services and Procurement Canada; Defence and Marine Procurement</value>
+            <value ref="18" lang="fra">Gouvernement du Canada; Organisation de Services publics et Approvisionnement Canada; Approvisionnement maritime et de défense</value>
         </values>
 
         Handles the Default language/non-default languages and duplication.


### PR DESCRIPTION
The diff is a bit more complicated because I edited some already commented out code (from the EC).

The only changes in layout-custom-fields is the addition of this template - <xsl:template mode="mode-iso19139" match="gmd:organisationName" priority="2000">

I made some very minor changes to config-edit because if you don't mark something as multi-lingual, the multilingual sections will be removed by update-fixed-info!

This just converts the gmd:organizationName into a custom HTML fragment.  There is a new multi-entry-combiner directive in GN-core that this directly uses.

There is a full example (config and html fragment) that this produces in MultiEntryCombiner.js - see PR, below).

You need these GN-core PRs (backported to 3.10.x) to use this;
https://github.com/geonetwork/core-geonetwork/pull/4597 (contains the directive)
https://github.com/geonetwork/core-geonetwork/pull/4596 (fixes to the keyword picker so it can be used by the multi-entry-combiner directive)