### PR TITLE
removed getMappedLang as it was not longer needed since the 3.10.2 co…

### DIFF
--- a/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
+++ b/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
@@ -206,46 +206,6 @@ public class XslUtilHnap {
         }
         return defaultValue;
     }
-
-    /**
-     * These two functions map {"eng; CAN":"#", "fra":"fra"} to '{"eng":"#eng; CAN", "fre" : "#fra"}' in utility-tpl-multilingual.xsl
-     *
-     * @param lang  hnap language code
-     * @return  iso639 language code
-     */
-    public static
-    @Nonnull
-    String getMappedLang(String lang) {
-        switch(lang) {
-            case "eng; CAN":
-                return "eng";
-
-            case "fra":
-            case "fra; CAN":
-                return "fre";
-
-            default:
-                return lang;
-        }
-    }
-
-    /**
-     * Substitute id with lang if id is absent
-     * @param lang
-     * @param id
-     * @return
-     */
-    public static
-    @Nonnull String getMappLangId(String lang, String id) {
-        if (id == null || id.isEmpty()) {
-            return getMappedLang(lang); // convert eng; CAN --> eng    OR  fra; CAN --> fra
-        }
-        else {
-            return id;
-        }
-    }
-
-    /**
      * Get thesauriDir from system config value
      * @return Code list folder path. i.e. C:\dev\src\geonetwork-catalog\web\target\geonetwork\WEB-INF\data\config\codelist
      */

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -84,14 +84,25 @@
             <xsl:variable name="mainLanguageId"
                           select="$metadata/gmd:locale/gmd:PT_Locale[
                                 gmd:languageCode/gmd:LanguageCode/@codeListValue = $mainLanguage]/@id"/>
-            <lang><xsl:value-of select="concat('&quot;', $mainLanguage, '&quot;:&quot;#', $mainLanguageId[1], '&quot;')"/></lang>
+            <xsl:variable name="lang_ISO639_2B">
+               <xsl:choose>
+                  <xsl:when test="$mainLanguage = 'fra'">fre</xsl:when>
+                  <xsl:otherwise><xsl:value-of select="$mainLanguage"/></xsl:otherwise>
+               </xsl:choose>
+            </xsl:variable>
+
+            <lang><xsl:value-of select="concat('&quot;', $lang_ISO639_2B, '&quot;:&quot;#', $mainLanguageId[1], '&quot;')"/></lang>
           </xsl:if>
 
           <xsl:for-each
             select="$metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue != $mainLanguage]">
-            <xsl:variable name="codelistValue" select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
-            <lang><xsl:value-of select="concat('&quot;', gmd:languageCode/gmd:LanguageCode/@codeListValue, '&quot;:&quot;#', @id, '&quot;')"/></lang>
-
+            <xsl:variable name="lang_ISO639_2B">
+               <xsl:choose>
+                  <xsl:when test="gmd:languageCode/gmd:LanguageCode/@codeListValue = 'fra'">fre</xsl:when>
+                  <xsl:otherwise><xsl:value-of select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/></xsl:otherwise>
+               </xsl:choose>
+            </xsl:variable>
+            <lang><xsl:value-of select="concat('&quot;', $lang_ISO639_2B, '&quot;:&quot;#', @id, '&quot;')"/></lang>
           </xsl:for-each>
         </xsl:otherwise>
       </xsl:choose>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -84,25 +84,19 @@
             <xsl:variable name="mainLanguageId"
                           select="$metadata/gmd:locale/gmd:PT_Locale[
                                 gmd:languageCode/gmd:LanguageCode/@codeListValue = $mainLanguage]/@id"/>
-
-            <lang>
-              <xsl:value-of
-                select="concat('&quot;', XslUtilHnap:getMappedLang($mainLanguage), '&quot;:&quot;#', XslUtilHnap:getMappLangId($mainLanguage, $mainLanguageId), '&quot;')"/>
-            </lang>
+            <lang><xsl:value-of select="concat('&quot;', $mainLanguage, '&quot;:&quot;#', $mainLanguageId[1], '&quot;')"/></lang>
           </xsl:if>
 
           <xsl:for-each
             select="$metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue != $mainLanguage]">
             <xsl:variable name="codelistValue" select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
-            <lang>
-              <xsl:value-of
-                select="concat('&quot;', XslUtilHnap:getMappedLang($codelistValue), '&quot;:&quot;#', XslUtilHnap:getMappLangId($codelistValue, @id), '&quot;')"/>
-            </lang>
+            <lang><xsl:value-of select="concat('&quot;', gmd:languageCode/gmd:LanguageCode/@codeListValue, '&quot;:&quot;#', @id, '&quot;')"/></lang>
+
           </xsl:for-each>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:text>{</xsl:text><xsl:value-of select="string-join(distinct-values($langs/lang), ',')"/><xsl:text>}</xsl:text>
+    <xsl:text>{</xsl:text><xsl:value-of select="string-join($langs/lang, ',')"/><xsl:text>}</xsl:text>
   </xsl:template>
 
   <!-- Get the list of other languages -->


### PR DESCRIPTION
Removed getMappedLang as it was not longer needed for the 3.10.2

Also getMappedLang seems to break an api test in the unit test. I did not identify why it was causing the issue but when removed, it seems to have fixed the issue.