### PR TITLE
improve org name selector (and bug fix)

### DIFF
--- a/src/main/config/codelist/local/thesauri/theme/EC_Org_Names.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Org_Names.rdf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/OrgNames#GOC">
+        <ns2:scopeNote
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition
+        </ns2:scopeNote>
+        <ns2:scopeNote
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition
+        </ns2:scopeNote>
+        <ns2:prefLabel
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Gouvernement du Canada
+        </ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Government of Canada
+        </ns2:prefLabel>
+    </rdf:Description>
+
+</rdf:RDF>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -182,14 +182,15 @@
     <xsl:variable name="json_config">
       [
           {
-            "type": "fixedValue",
+            "type": "thesaurus",
             "heading": {
-                "eng": "",
-                "fra": ""
+                "eng": "Main Organization Enitity",
+                "fra": "Main Organization Enitity (fr)"
             },
-            "values": {
-              "eng": "Government of Canada",
-              "fra": "Gouvernement du Canada"
+            "thesaurus": "external.theme.EC_Org_Names",
+            "defaultValues": {
+                  "eng": "Government of Canada",
+                  "fra": "Gouvernement du Canada"
             }
           },
 

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -184,8 +184,8 @@
           {
             "type": "thesaurus",
             "heading": {
-                "eng": "Main Organization Enitity",
-                "fra": "Main Organization Enitity (fr)"
+                "eng": "",
+                "fra": ""
             },
             "thesaurus": "external.theme.EC_Org_Names",
             "defaultValues": {
@@ -197,8 +197,8 @@
           {
             "type": "thesaurus",
             "heading": {
-              "eng": "Government of Canada Organization",
-              "fra": "Organisation du Gouvernement du Canada"
+              "eng": "Department/Agency",
+              "fra": "Département/agence"
             },
             "thesaurus": "external.theme.EC_Government_Titles"
           },
@@ -226,7 +226,7 @@
     </xsl:variable>
 
 
-    <div class="form-group gn-field gn-{$cls}"  >
+    <div class="form-group gn-field gn-control gn-{$cls}"  >
       <label for="orgname" class="col-sm-2 control-label" data-gn-field-tooltip="iso19139.ca.HNAP|gmd:organisationName" ><xsl:copy-of select="$labelConfig/label"/></label>
 
       <div data-gn-multientry-combiner="{$json}"

--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -388,10 +388,10 @@
       <!-- Add nileason if text is empty -->
       <xsl:variable name="isMainLanguageEmpty"
                     select="if ($isMultilingual and not($excluded))
-                            then ($valueInPtFreeTextForMainLanguage = '' and normalize-space(gco:CharacterString|gmx:Anchor) = '')
+                            then ($valueInPtFreeTextForMainLanguage = '' and normalize-space(gmx:Anchor) = '')
                             else if ($valueInPtFreeTextForMainLanguage != '')
                             then $valueInPtFreeTextForMainLanguage = ''
-                            else normalize-space(gco:CharacterString|gmx:Anchor) = ''"/>
+                            else normalize-space(gmx:Anchor) = ''"/>
 
       <!-- TODO ? Removes @nilReason from parents of gmx:Anchor if anchor has @xlink:href attribute filled. -->
       <xsl:variable name="isEmptyAnchor"
@@ -472,7 +472,16 @@
             <xsl:otherwise>
 
               <!-- Populate PT_FreeText for default language if not existing and it is not null. -->
-              <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
+              <xsl:choose>
+                <xsl:when test="$valueInPtFreeTextForMainLanguage !='' or not($isMainLanguageEmpty)">
+                  <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <gco:CharacterString></gco:CharacterString>
+                </xsl:otherwise>
+              </xsl:choose>
+
+
                 <!-- only put this in if there's stuff to put in, otherwise we get a <gmd:PT_FreeText/> in output -->
                 <xsl:if test="(normalize-space(gco:CharacterString|gmx:Anchor) != '') or gmd:PT_FreeText">
                   <gmd:PT_FreeText>


### PR DESCRIPTION
Changes to Org name selector;

a) changed the first part ("Government of Canada") to be a keyword picker that defaults to "Government of Canada".  The included thesaurus can be added to.  Users can just type in whatever they want as well.

b) fixed an issue with saving.  Problem was when removing the default language value.  The change wouldn't actually take place.
