### PR TITLE
adding setting for controlling org name GUI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
         <targetPath>thesarus/place</targetPath>
       </resource>
       <resource>
+        <directory>src/main/config/translations</directory>
+        <targetPath>META-INF/catalog/locales</targetPath>
+      </resource>
+      <resource>
         <directory>src/main/resources</directory>
       </resource>
     </resources>

--- a/src/main/config/translations/en-schema-iso19139.ca.HNAP.json
+++ b/src/main/config/translations/en-schema-iso19139.ca.HNAP.json
@@ -1,0 +1,5 @@
+{
+  "schema": "Schema-Specific Settings",
+  "schema/iso19139.ca.HNAP": "ISO19139 HNAP Settings",
+  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Use 'Government of Canada' Organization Selector"
+}

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java
@@ -1,0 +1,50 @@
+package ca.gc.schemas.iso19139hnap.init;
+
+import ca.gc.schema.iso19139hnap.util.XslUtilHnap;
+import org.fao.geonet.domain.Setting;
+import org.fao.geonet.domain.SettingDataType;
+import org.fao.geonet.events.server.ServerStartup;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.repository.SettingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+
+import javax.annotation.PostConstruct;
+
+
+/**
+ * Creates Settings in the Settings table
+ * With a default value
+ */
+public class SchemaInitializerSettings implements
+    ApplicationListener<ServerStartup> {
+    @Autowired
+    private SettingRepository _settingRepository;
+
+    @PostConstruct
+    public void init() {
+    }
+
+    private void addSetting(String key,SettingDataType type, String value, int position ) {
+        if (_settingRepository.findOne(key) == null) {
+            Setting setting = new Setting();
+            setting.setDataType(type);
+            setting.setName(key);
+            setting.setPosition(position);
+            setting.setValue(value);
+            _settingRepository.save(setting);
+        }
+    }
+
+    private void addSettings() {
+        addSetting("schema/"+ XslUtilHnap.HNAP_SCHEMA_NAME+"/UseGovernmentOfCanadaOrganisationName",
+            SettingDataType.BOOLEAN,"true",1);
+    }
+
+    //when the server starts up, we are ready to
+    @Override
+    public void onApplicationEvent(ServerStartup event) {
+        addSettings();
+    }
+}

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java
@@ -19,6 +19,10 @@ import javax.annotation.PostConstruct;
  */
 public class SchemaInitializerSettings implements
     ApplicationListener<ServerStartup> {
+
+    final private static String HNAP_SCHEMA_NAME = "iso19139.ca.HNAP";
+
+
     @Autowired
     private SettingRepository _settingRepository;
 
@@ -38,7 +42,7 @@ public class SchemaInitializerSettings implements
     }
 
     private void addSettings() {
-        addSetting("schema/"+ XslUtilHnap.HNAP_SCHEMA_NAME+"/UseGovernmentOfCanadaOrganisationName",
+        addSetting("schema/"+ HNAP_SCHEMA_NAME+"/UseGovernmentOfCanadaOrganisationName",
             SettingDataType.BOOLEAN,"true",1);
     }
 

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerThesauri.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerThesauri.java
@@ -1,18 +1,24 @@
 package ca.gc.schemas.iso19139hnap.init;
 
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Setting;
+import org.fao.geonet.domain.SettingDataType;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.repository.SettingRepository;
 import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
-import java.io.File;
+import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.SQLException;
 import java.util.regex.Pattern;
 
 /**
@@ -22,8 +28,13 @@ import java.util.regex.Pattern;
  * <p>
  * See config-spring-geonetwork.xml in this schema
  */
-public class SchemaInitializer implements
+public class SchemaInitializerThesauri implements
     ApplicationListener<GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent> {
+
+    @PostConstruct
+    public void init()
+    {
+    }
 
 
     private static String resourceTypeDir = "external"; // "local" or "external"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -17,9 +17,10 @@
                 xmlns:saxon="http://saxon.sf.net/"
                 xmlns:exslt="http://exslt.org/common" exclude-result-prefixes="#all">
 
+
   <xsl:variable name="thesauriDir" select="/root/gui/thesaurusDir" />
   <xsl:variable name="resourceFormatsTh" select="document(concat('file:///', replace(concat($thesauriDir, '/local/thesauri/theme/EC_Resource_Formats.rdf'), '\\', '/')))" />
-
+  <xsl:variable name="UseGOCOrganisationName" select="/root/gui/settings/schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName"/>
 
   <!-- Hide thesaurus name in default view -->
   <xsl:template mode="mode-iso19139" priority="2005" match="gmd:thesaurusName[$tab='default']" />
@@ -106,8 +107,7 @@
     a) basic shell HTML so it can be displayed in the editor (see MultiEntryCombiner.js for HTML example).
     b) sets up the JSON configuration (see MultiEntryCombiner.js for example JSON).
 -->
-  <xsl:template mode="mode-iso19139" match="gmd:organisationName" priority="2000">
-
+  <xsl:template mode="mode-iso19139" match="gmd:organisationName[$UseGOCOrganisationName = 'true']" priority="3000"  >
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -114,6 +114,8 @@
                 match="*[gco:CharacterString|gco:Integer|gco:Decimal|
        gco:Boolean|gco:Real|gco:Measure|gco:Length|gco:Distance|gco:Angle|gmx:FileName|
        gco:Scale|gco:Record|gco:RecordType|gmx:MimeFileType|gmd:URL|gco:LocalName|gmd:PT_FreeText]">
+
+
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>

--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -9,10 +9,16 @@
 
   <context:component-scan base-package="ca.gc.schemas.iso19139hnap.init"/>
 
+  <!-- copies in thesauri -->
   <bean id="iso19139.ca.HNAP.startup"
-        class="ca.gc.schemas.iso19139hnap.init.SchemaInitializer"
-        >
+        class="ca.gc.schemas.iso19139hnap.init.SchemaInitializerThesauri">
   </bean>
+
+  <!-- copy in any  settings -->
+  <bean id="iso19139.ca.HNAP.startup.settings"
+        class="ca.gc.schemas.iso19139hnap.init.SchemaInitializerSettings">
+  </bean>
+
 
   <bean id="iso19139.ca.HNAPSchemaPlugin"
         class="org.fao.geonet.schema.iso19139.ISO19139SchemaPlugin">


### PR DESCRIPTION
This allows for a setting to control if the keyword-picker based org name selector is used or not.

See https://github.com/geonetwork/core-geonetwork/pull/4631