### PR TITLE
undo changes to schema detection (PR 31)

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
@@ -38,7 +38,7 @@
 
 	<autodetect xmlns:gmd="http://www.isotc211.org/2005/gmd"
               xmlns:gco="http://www.isotc211.org/2005/gco">
-	    <elements>
+	    <elements type="search">
         <gmd:metadataStandardName>
           <gco:CharacterString>North American Profile of ISO 19115:2003 - Geographic information - Metadata|Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées</gco:CharacterString>
         </gmd:metadataStandardName>


### PR DESCRIPTION
This PR reverts PR #31 

This was causing some issues with the sample.  Most notably;

[INFO] Started Jetty Server
Error on line 1043 of default.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the first argument of name()
  (<gmd:fileName/>, <gmd:fileDescription/>, ...) 
2020-05-04 08:25:09,068 ERROR [geonetwork.index] - Indexing stylesheet contains errors: A sequence of more than one item is not allowed as the first argument of name() (<gmd:fileName/>, <gmd:fileDescription/>, ...)      Marking the metadata as _indexingError=1 in index

When starting fresh and adding in the samples.

@ianwallen - this reverts #31 -- could you work with @josegar74 to fix the issue that #31 was trying to fix?