### PR TITLE
fix how multilingual elements are being referensed

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -153,7 +153,7 @@
                 gmd:LocalisedCharacterString[@locale = concat('#',$currentLanguageId)]) = 0">
             <!--don't put in default language if already there-->
               <xsl:if test="not($hasDefaultValue) or $currentLanguageId != $metadataLanguage ">
-                 <value ref="lang_{@id}_{$theElement/parent::node()/gn:element/@ref}"
+                 <value ref="lang_{@id}_{$theElement/gn:element/@ref}"
                     lang="{@id}"></value>
               </xsl:if>
           </xsl:if>
@@ -172,6 +172,14 @@
       {
       <xsl:for-each select="$values/values/value">
         "<xsl:value-of select="@lang"/>":"<xsl:value-of select="."/>" <xsl:if test="not(position() = last())">,</xsl:if>
+      </xsl:for-each>
+      }
+    </xsl:variable>
+
+    <xsl:variable name="refs_json">
+      {
+      <xsl:for-each select="$values/values/value">
+        "<xsl:value-of select="@lang"/>":"<xsl:value-of select="@ref"/>" <xsl:if test="not(position() = last())">,</xsl:if>
       </xsl:for-each>
       }
     </xsl:variable>
@@ -219,6 +227,7 @@
       {
         "combiner":"; ",
         "root_id":"<xsl:value-of select="gn:element/@ref"/>",
+        "refs":<xsl:copy-of select="$refs_json"/>,
         "defaultLang":"<xsl:copy-of select="$metadataLanguage"/>",
         "values": <xsl:copy-of select="$json_values"/>,
         "config":<xsl:copy-of select="$json_config"/>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -200,22 +200,20 @@
                       select="normalize-space(gco:CharacterString|gmx:Anchor)"/>
 
         <values>
-          <!--
-          CharacterString is not edited anymore, but it's PT_FreeText
-          counterpart is.
 
-          Or the PT_FreeText element matching the main language
           <xsl:if test="gco:CharacterString">
             <value ref="{$theElement/gn:element/@ref}" lang="{$metadataLanguage}">
               <xsl:value-of select="gco:CharacterString"/>
             </value>
-          </xsl:if>-->
+          </xsl:if>
 
           <!-- the existing translation -->
           <xsl:for-each select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
-            <value ref="{gn:element/@ref}" lang="{substring-after(@locale, '#')}">
-              <xsl:value-of select="."/>
-            </value>
+            <xsl:if test="not($metadataLanguage = substring-after(@locale, '#'))">
+              <value ref="{gn:element/@ref}" lang="{substring-after(@locale, '#')}">
+                <xsl:value-of select="."/>
+              </value>
+            </xsl:if>
           </xsl:for-each>
 
           <!-- and create field for none translated language -->
@@ -232,17 +230,19 @@
 
 
             <xsl:choose>
-              <xsl:when test="$ptFreeElementDoesNotExist and
-                              $text != '' and
-                              $code = $metadataLanguage">
-              <value ref="lang_{@id}_{$theElement/parent::node()/gn:element/@ref}"
-                       lang="{@id}">
-                  <xsl:value-of select="$text"/>
-                </value>
-              </xsl:when>
+<!--              <xsl:when test="$ptFreeElementDoesNotExist and-->
+<!--                              $text != '' and-->
+<!--                              $code = $metadataLanguage">-->
+<!--              <value ref="lang_{@id}_{$theElement/parent::node()/gn:element/@ref}"-->
+<!--                       lang="{@id}">-->
+<!--                  <xsl:value-of select="$text"/>-->
+<!--                </value>-->
+<!--              </xsl:when>-->
               <xsl:when test="$ptFreeElementDoesNotExist">
-                <value ref="lang_{@id}_{$theElement/parent::node()/gn:element/@ref}"
-                     lang="{@id}"></value>
+                <xsl:if test="not($metadataLanguage = @id)">
+                  <value ref="lang_{@id}_{$theElement/parent::node()/gn:element/@ref}"
+                       lang="{@id}"></value>
+                </xsl:if>
               </xsl:when>
             </xsl:choose>
           </xsl:for-each>


### PR DESCRIPTION
@josegar74 - this does was we talked about this morning.
However,
a) I had to do a little more since it was sending BOTH the <charstring> and the corresponding (same lang) _lang_eng_XYZ
b) I have updated the multi-edit-combiner-directive to work in the same manner

This REQUIRES;
 https://github.com/geonetwork/core-geonetwork/pull/4664