### PR TITLE
add freetext keyword multiple section support

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -151,7 +151,9 @@
 
       Exclude all thesaurus already used in the metadata:
       -->
-      <directiveAttributes data-include="xpath::string-join(gmd:MD_Metadata/gmd:identificationInfo
+      <directiveAttributes
+        data-always-create-new-freekeyword-section="true"
+        data-include="xpath::string-join(gmd:MD_Metadata/gmd:identificationInfo
                                           //gmd:thesaurusName/*/gmd:identifier/*/
                                             gmd:code/gmx:Anchor/
                                               concat('-', substring-after(text()[. != ''], 'geonetwork.thesaurus.')), ',')"/>


### PR DESCRIPTION
Requires: https://github.com/geonetwork/core-geonetwork/pull/4737

This activates the ability to add multiple freetext sections (i.e. multiple "type"s).