### PR TITLE
add titles to thesauri and force overwrite during initialization

### DIFF
--- a/src/main/config/codelist/local/thesauri/place/EC_Geographic_Scope.rdf
+++ b/src/main/config/codelist/local/thesauri/place/EC_Geographic_Scope.rdf
@@ -2,7 +2,14 @@
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:ns2="http://www.w3.org/2004/02/skos/core#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <skos:ConceptScheme>
+      <dc:title>ECCC Geographic Scope</dc:title>
+      <dc:description></dc:description>
+    </skos:ConceptScheme>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#000">
 	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -10,34 +17,34 @@
 	<ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
 	<ns2:prefLabel xml:lang="fr">National (CA)</ns2:prefLabel>
 	<ns2:prefLabel xml:lang="en">National (CA)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#001">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
 	<ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
 	<ns2:prefLabel xml:lang="fr">Atlantique</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Atlantic</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#002">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Atlantique - Nouveau-Brunswick (NB)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Atlantic - New Brunswick (NB)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#003">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Atlantique - Terre-Neuve-et-Labrador (NL)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Atlantic - Newfoundland and Labrador (NL)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#004">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Atlantique - Nouvelle-Écosse (NS)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Atlantic - Nova Scotia (NS)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#005">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Atlantique - Île-du-Prince-Édouard (PE)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Atlantic - Prince Edward Island (PE)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#006">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Ontario (ON)</ns2:prefLabel>
@@ -47,27 +54,27 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Territories</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Territories</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#008">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Colombie-Britannique (BC)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">British Columbia (BC)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#009">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Territoires - Yukon (YT)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Territories - Yukon (YT)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#010">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Prairies</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Prairie</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#011">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Prairies - Alberta (AB)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Prairie - Alberta (AB)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#012">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
@@ -79,19 +86,19 @@
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Territoires - Territoires du Nord-Ouest (NT)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Territories - Northwest Territories (NT)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#014">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Territoires - Nunavut (NU)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Territories - Nunavut (NU)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#015">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">Prairies - Saskatchewan (SK)</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Prairie - Saskatchewan (SK)</ns2:prefLabel>
-  </rdf:Description> 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#016">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
@@ -253,113 +260,113 @@
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Okanagan–Similkameen</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Okanagan–Similkameen</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#042">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Columbia</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Columbia</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#043">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Yukon</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Yukon</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#044">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Paix–Athabasca</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Peace–Athabasca</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#045">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Bas Mackenzie</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Lower Mackenzie</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#046">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Missouri</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Missouri</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#047">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Saskatchewan Nord</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - North Saskatchewan</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#048">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Saskatchewan Sud</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - South Saskatchewan</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#049">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Assiniboine–Rouge</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Assiniboine–Red</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#050">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Winnipeg</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Winnipeg</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#051">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Bas Saskatchewan–Nelson</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Lower Saskatchewan–Nelson</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#052">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Churchill</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Churchill</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#053">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Nord de l'Ontario</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Northern Ontario</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#054">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Grands Lacs</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Great Lakes</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#055">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Des Outaouais</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Ottawa</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#056">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Saint–Laurent</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - St. Lawrence</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#057">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Saint-Jean–St-Croix</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Saint John–St. Croix</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#058">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Côte des provinces maritimes</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Maritime Coastal</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#059">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     <ns2:prefLabel xml:lang="fr">L'eau - Régions de drainage - Terre-Neuve–Labrador</ns2:prefLabel>
     <ns2:prefLabel xml:lang="en">Water - Drainage regions - Newfoundland–Labrador</ns2:prefLabel>
-  </rdf:Description>	 
+  </rdf:Description>
 </rdf:RDF>

--- a/src/main/config/codelist/local/thesauri/theme/EC_Content_Scope.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Content_Scope.rdf
@@ -2,7 +2,14 @@
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:ns2="http://www.w3.org/2004/02/skos/core#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+  <skos:ConceptScheme rdf:about="http://geonetwork-opensource.org/thesaurus/naturalearth-and-seavox">
+    <dc:title>EC Content Scope</dc:title>
+    <dc:description></dc:description>
+  </skos:ConceptScheme>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/contentscope#addapplicabledatacontent">
     <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
@@ -31,13 +38,13 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:prefLabel xml:lang="en">Party (Individual/Organization)</ns2:prefLabel>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/contentscope#facility">
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:prefLabel xml:lang="fr">Fonctionnalité</ns2:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:prefLabel xml:lang="en">Facility</ns2:prefLabel>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/contentscope#substance">
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:prefLabel xml:lang="fr">Substance</ns2:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/src/main/config/codelist/local/thesauri/theme/EC_Core_Subject.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Core_Subject.rdf
@@ -2,8 +2,11 @@
 <rdf:RDF
         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
 >
   <skos:ConceptScheme rdf:about="http://www.thesaurus.gc.ca/#CoreSubjectThesaurus">
+      <dc:title>Government of Canada Core Subject Thesaurus</dc:title>
+      <dc:description></dc:description>
   </skos:ConceptScheme>
 
   <skos:Concept rdf:about="http://www.thesaurus.gc.ca/concept/#Abbreviations">

--- a/src/main/config/codelist/local/thesauri/theme/EC_Data_Usage_Scope.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Data_Usage_Scope.rdf
@@ -2,14 +2,21 @@
 <rdf:RDF
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:ns2="http://www.w3.org/2004/02/skos/core#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
-  
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+   <skos:ConceptScheme>
+     <dc:title>ECCC Data Usage Scope</dc:title>
+     <dc:description></dc:description>
+   </skos:ConceptScheme>
+
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/datausage#enforcementcompliance">
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:prefLabel xml:lang="fr">Application de la loi et conformité</ns2:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:prefLabel xml:lang="en">Enforcement/Compliance</ns2:prefLabel>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/datausage#environmentalmonitoring">
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:prefLabel xml:lang="fr">Surveillance environnementale</ns2:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -27,7 +34,7 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:prefLabel xml:lang="en">Permitting</ns2:prefLabel>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/datausage#regulation">
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:prefLabel xml:lang="fr">Réglementation</ns2:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -39,7 +46,7 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:prefLabel xml:lang="en">Scientific Research</ns2:prefLabel>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/datausage#strategicpolicypeportingdecisionmaking">
     <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote><ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote><ns2:prefLabel xml:lang="fr">Politique stratégique et prise de décisions</ns2:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/src/main/config/codelist/local/thesauri/theme/EC_Government_Names.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Government_Names.rdf
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:ns2="http://www.w3.org/2004/02/skos/core#">
+         xmlns:ns2="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+   <skos:ConceptScheme>
+     <dc:title>ECCC Government Names</dc:title>
+     <dc:description></dc:description>
+   </skos:ConceptScheme>
 
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentName#GovCan">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/src/main/config/codelist/local/thesauri/theme/EC_Government_Titles.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Government_Titles.rdf
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:ns2="http://www.w3.org/2004/02/skos/core#"
-    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+    <skos:ConceptScheme>
+      <dc:title>ECCC Government Titles</dc:title>
+      <dc:description></dc:description>
+    </skos:ConceptScheme>
 
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#AANDC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -29,7 +35,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#APA">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Atlantic Pilotage Authority Canada</ns2:prefLabel>
@@ -37,7 +43,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#AECL">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Atomic Energy of Canada Limited</ns2:prefLabel>
@@ -45,7 +51,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#BWBC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Blue Water Bridge Canada</ns2:prefLabel>
@@ -53,7 +59,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#BDC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Business Development Bank of Canada</ns2:prefLabel>
@@ -61,7 +67,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CBSA">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canada Border Services Agency</ns2:prefLabel>
@@ -69,7 +75,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CDIC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canada Deposit Insurance Corporation</ns2:prefLabel>
@@ -77,7 +83,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CDEV">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canada Development Investment Corporation</ns2:prefLabel>
@@ -85,7 +91,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CERIA">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canada Emission Reduction Incentives Agency</ns2:prefLabel>
@@ -93,7 +99,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CEIC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canada Employment Insurance Commission</ns2:prefLabel>
@@ -101,7 +107,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CSIFB">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canada Employment Insurance Financing Board</ns2:prefLabel>
@@ -190,7 +196,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CCC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Commercial Corporation</ns2:prefLabel>
@@ -198,7 +204,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CDC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Dairy Commission</ns2:prefLabel>
@@ -238,7 +244,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#PCH">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Heritage</ns2:prefLabel>
@@ -254,7 +260,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CIHR">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Institutes of Health Research</ns2:prefLabel>
@@ -262,7 +268,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CICS">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Intergovernmental Conference Secretariat</ns2:prefLabel>
@@ -270,7 +276,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CIDA">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian International Development Agency</ns2:prefLabel>
@@ -294,7 +300,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CMC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Museum of Civilization</ns2:prefLabel>
@@ -302,7 +308,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CMIP">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Museum of Immigration at Pier 21</ns2:prefLabel>
@@ -310,7 +316,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#CMN">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Canadian Museum of Nature</ns2:prefLabel>
@@ -839,7 +845,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#OIC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Offices of the Information and Privacy Commissioners of Canada</ns2:prefLabel>
@@ -847,7 +853,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#OPC">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Offices of the Information and Privacy Commissioners of Canada</ns2:prefLabel>
@@ -991,7 +997,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
    </rdf:Description>
-   
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#RT">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Ridley Terminals Inc.</ns2:prefLabel>
@@ -999,7 +1005,7 @@
         <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>
         <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
     </rdf:Description>
-    
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentTitle#Mint">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <ns2:prefLabel xml:lang="en">Royal Canadian Mint</ns2:prefLabel>

--- a/src/main/config/codelist/local/thesauri/theme/EC_ISO_Countries.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_ISO_Countries.rdf
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+      <skos:ConceptScheme>
+        <dc:title>ECCC ISO Countries</dc:title>
+        <dc:description></dc:description>
+      </skos:ConceptScheme>
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/countries#AFG">
         <ns2:scopeNote
             xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition

--- a/src/main/config/codelist/local/thesauri/theme/EC_Information_Category.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Information_Category.rdf
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"  xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns2="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-  <skos:ConceptScheme rdf:about="http://geonetwork-opensource.org/EC/informationcategory">
-  </skos:ConceptScheme>
+  <ns2:ConceptScheme rdf:about="http://geonetwork-opensource.org/EC/informationcategory">
+        <dc:title>ECCC Information Category</dc:title>
+        <dc:description></dc:description>
+  </ns2:ConceptScheme>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/informationcategory#air">
      <ns2:scopeNote xml:lang="fr">Air data is grouped into themes such as ambient gases and particles, precipitation chemistry and upper air.</ns2:scopeNote>

--- a/src/main/config/codelist/local/thesauri/theme/EC_Org_Names.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Org_Names.rdf
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+      <skos:ConceptScheme>
+        <dc:title>ECCC Organization Names</dc:title>
+        <dc:description></dc:description>
+      </skos:ConceptScheme>
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/OrgNames#GOC">
         <ns2:scopeNote
             xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition

--- a/src/main/config/codelist/local/thesauri/theme/EC_Resource_ContentTypes.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Resource_ContentTypes.rdf
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <skos:ConceptScheme>
+      <dc:title>ECCC Resource Content Types</dc:title>
+      <dc:description></dc:description>
+    </skos:ConceptScheme>
 
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcecontenttype#Dataset">
         <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"

--- a/src/main/config/codelist/local/thesauri/theme/EC_Resource_Formats.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Resource_Formats.rdf
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <skos:ConceptScheme>
+      <dc:title>ECCC Resource Formats</dc:title>
+      <dc:description></dc:description>
+    </skos:ConceptScheme>
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourceformat#AI">
         <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
             >Definition</ns2:scopeNote>

--- a/src/main/config/codelist/local/thesauri/theme/EC_States.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_States.rdf
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <skos:ConceptScheme>
+      <dc:title>ECCC States</dc:title>
+      <dc:description></dc:description>
+    </skos:ConceptScheme>
+
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/states#Alberta">
         <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
             >Definition</ns2:scopeNote>

--- a/src/main/config/codelist/local/thesauri/theme/EC_Waf.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Waf.rdf
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://ec.gc.ca/skos/datamart#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xml:base="http://ec.gc.ca/skos/datamart">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns="http://ec.gc.ca/skos/datamart#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xml:base="http://ec.gc.ca/skos/datamart"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <skos:ConceptScheme>
+      <dc:title>ECCC Waf</dc:title>
+      <dc:description></dc:description>
+    </skos:ConceptScheme>
+
   <owl:Ontology rdf:about="http://ec.gc.ca/skos/datamart">
     <owl:imports rdf:resource="http://www.w3.org/2008/05/skos" />
   </owl:Ontology>

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerThesauri.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerThesauri.java
@@ -31,6 +31,8 @@ import java.util.regex.Pattern;
 public class SchemaInitializerThesauri implements
     ApplicationListener<GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent> {
 
+    boolean OVERWRITE_EXISTING_THESAURI = true;
+
     @PostConstruct
     public void init()
     {
@@ -54,7 +56,9 @@ public class SchemaInitializerThesauri implements
             Files.createDirectories(Paths.get(thesauriDir.toString(), resourceTypeDir, "thesauri", dir));
             //full path to put the .rdf
             Path correspondingDataDirFile = Paths.get(thesauriDir.toString(), resourceTypeDir, "thesauri", dir, fname);
-            if (!Files.exists(correspondingDataDirFile)) {
+            if (!Files.exists(correspondingDataDirFile) || OVERWRITE_EXISTING_THESAURI) {
+                if (Files.exists(correspondingDataDirFile))
+                    Files.delete(correspondingDataDirFile);
                 //need to copy it in...
                 Log.info(Geonet.THESAURUS, "ISO19139.HNAP: SchemaInitializer: need to copy in Thesaurus: " + fname);
                 try (InputStream is = r.getInputStream()) { //auto close


### PR DESCRIPTION
There are two changes;

a) added <title> the rdfs.  
    * these will be used in the metadata record instead of "EC_Content_Scope.rdf"
    * these show up in the UI like this;
![image](https://user-images.githubusercontent.com/48937730/83904262-67bf5b80-a714-11ea-8bd1-b589e9c58256.png)
b) I've set the hnap schema initializer to always deploy new schemas (overwrite existing ones).  This should be ok since the external thesauri are considered read-only in GN (and, therefore, cannot be modified by users).

NOTE: looks like the editor deleted some trailing spaces.  Sorry for the fluff in the commit.