### PR TITLE
add publisher info from RDFs to citedResponsibleParty

### DIFF
--- a/src/main/config/codelist/local/thesauri/place/EC_Geographic_Scope.rdf
+++ b/src/main/config/codelist/local/thesauri/place/EC_Geographic_Scope.rdf
@@ -11,6 +11,10 @@
        <dc:title xml:lang="en">ECCC Geographic Scope EN</dc:title>
        <dc:title xml:lang="fr">ECCC Geographic Scope FR</dc:title>
       <dc:description></dc:description>
+
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
     </skos:ConceptScheme>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GeographicScope#000">

--- a/src/main/config/codelist/local/thesauri/theme/EC_Content_Scope.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Content_Scope.rdf
@@ -10,6 +10,8 @@
     <dc:title>ECCC Content Scope</dc:title>
        <dc:title xml:lang="en">ECCC Content Scope EN</dc:title>
        <dc:title xml:lang="fr">ECCC Content Scope FR</dc:title>
+    <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+    <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
     <dc:description></dc:description>
   </skos:ConceptScheme>
 

--- a/src/main/config/codelist/local/thesauri/theme/EC_Core_Subject.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Core_Subject.rdf
@@ -8,7 +8,11 @@
       <dc:title>Government of Canada Core Subject Thesaurus</dc:title>
       <dc:title xml:lang="en">Government of Canada Core Subject Thesaurus</dc:title>
       <dc:title xml:lang="fr">Thésaurus des sujets de base du gouvernement du Canada</dc:title>
-      <dc:description></dc:description>
+
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
+    <dc:description></dc:description>
   </skos:ConceptScheme>
 
   <skos:Concept rdf:about="http://www.thesaurus.gc.ca/concept/#Abbreviations">

--- a/src/main/config/codelist/local/thesauri/theme/EC_Data_Usage_Scope.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Data_Usage_Scope.rdf
@@ -10,6 +10,8 @@
      <dc:title>ECCC Data Usage Scope</dc:title>
        <dc:title xml:lang="en">ECCC Data Usage Scope EN</dc:title>
        <dc:title xml:lang="fr">ECCC Data Usage Scope FR</dc:title>
+     <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+     <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
      <dc:description></dc:description>
    </skos:ConceptScheme>
 

--- a/src/main/config/codelist/local/thesauri/theme/EC_Government_Names.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Government_Names.rdf
@@ -8,7 +8,11 @@
      <dc:title>ECCC Government Names</dc:title>
        <dc:title xml:lang="en">ECCC Government Names EN</dc:title>
        <dc:title xml:lang="fr">ECCC Government Names FR</dc:title>
+       <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+       <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
      <dc:description></dc:description>
+
    </skos:ConceptScheme>
 
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/GovernmentName#GovCan">

--- a/src/main/config/codelist/local/thesauri/theme/EC_Government_Titles.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Government_Titles.rdf
@@ -9,6 +9,9 @@
       <dc:title>ECCC Government Titles</dc:title>
        <dc:title xml:lang="en">ECCC Government Titles EN</dc:title>
        <dc:title xml:lang="fr">ECCC Government Titles FR</dc:title>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
       <dc:description></dc:description>
     </skos:ConceptScheme>
 

--- a/src/main/config/codelist/local/thesauri/theme/EC_ISO_Countries.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_ISO_Countries.rdf
@@ -8,6 +8,9 @@
         <dc:title>ECCC ISO Countries</dc:title>
        <dc:title xml:lang="en">ECCC ISO Countries EN</dc:title>
        <dc:title xml:lang="fr">ECCC ISO Countries FR</dc:title>
+        <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+        <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
         <dc:description></dc:description>
       </skos:ConceptScheme>
 

--- a/src/main/config/codelist/local/thesauri/theme/EC_Information_Category.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Information_Category.rdf
@@ -7,7 +7,10 @@
         <dc:title>ECCC Information Category</dc:title>
        <dc:title xml:lang="en">ECCC Information Category EN</dc:title>
        <dc:title xml:lang="fr">ECCC Information Category FR</dc:title>
-        <dc:description></dc:description>
+    <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+    <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
+    <dc:description></dc:description>
   </ns2:ConceptScheme>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/informationcategory#air">

--- a/src/main/config/codelist/local/thesauri/theme/EC_Org_Names.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Org_Names.rdf
@@ -8,6 +8,9 @@
         <dc:title>ECCC Organization Names</dc:title>
        <dc:title xml:lang="en">ECCC Organization Names EN</dc:title>
        <dc:title xml:lang="fr">ECCC Organization Names FR</dc:title>
+        <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+        <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
         <dc:description></dc:description>
       </skos:ConceptScheme>
 

--- a/src/main/config/codelist/local/thesauri/theme/EC_Resource_ContentTypes.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Resource_ContentTypes.rdf
@@ -7,6 +7,9 @@
       <dc:title>ECCC Resource Content Types</dc:title>
        <dc:title xml:lang="en">ECCC Resource Content Types EN</dc:title>
        <dc:title xml:lang="fr">ECCC Resource Content Types FR</dc:title>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
       <dc:description></dc:description>
     </skos:ConceptScheme>
 

--- a/src/main/config/codelist/local/thesauri/theme/EC_Resource_Formats.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Resource_Formats.rdf
@@ -8,6 +8,9 @@
        <dc:title xml:lang="en">ECCC Resource Formats EN</dc:title>
        <dc:title xml:lang="fr">ECCC Resource Formats FR</dc:title>
       <dc:description></dc:description>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
     </skos:ConceptScheme>
 
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourceformat#AI">

--- a/src/main/config/codelist/local/thesauri/theme/EC_States.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_States.rdf
@@ -8,6 +8,9 @@
        <dc:title xml:lang="en">ECCC States EN</dc:title>
        <dc:title xml:lang="fr">ECCC States FR</dc:title>
       <dc:description></dc:description>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
     </skos:ConceptScheme>
 
     <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/states#Alberta">

--- a/src/main/config/codelist/local/thesauri/theme/EC_Waf.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/EC_Waf.rdf
@@ -12,6 +12,9 @@
       <dc:title>ECCC Waf</dc:title>
        <dc:title xml:lang="en">ECCC Waf EN</dc:title>
        <dc:title xml:lang="fr">ECCC Waf FR</dc:title>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+
       <dc:description></dc:description>
     </skos:ConceptScheme>
 

--- a/src/main/plugin/iso19139.ca.HNAP/convert/thesaurus-transformation.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/convert/thesaurus-transformation.xsl
@@ -245,6 +245,32 @@
     </gmd:MD_Keywords>
   </xsl:template>
 
+  <!-- given a thesarus and language, find the most appropriate reponsible party name.
+  This will be in the dublin core section as "publisher"-->
+
+  <xsl:function name="geonet:getThesaurusResponsibleParty">
+    <xsl:param name="thesarus" />
+    <xsl:param name="lang1" />
+    <xsl:variable name="lang" select="lower-case($lang1)" />
+    <xsl:variable name="lang_2letter" select="lower-case(XslUtilHnap:twoCharLangCode($lang))" />
+
+    <xsl:variable name="thesaurusPublisherMultilingualNode" select="$thesarus/dublinCoreMultilinguals/dublinCoreMultilingual[lower-case(./lang) = $lang and ./tag='publisher']/value" />
+    <xsl:variable name="thesaurusPublisherMultilingualNode_2letter" select="$thesarus/dublinCoreMultilinguals/dublinCoreMultilingual[lower-case(./lang) = $lang_2letter and ./tag='publisher']/value" />
+
+    <xsl:choose>
+      <xsl:when test="$thesaurusPublisherMultilingualNode">
+        <xsl:value-of select="$thesaurusPublisherMultilingualNode"/>
+      </xsl:when>
+      <xsl:when test="$thesaurusPublisherMultilingualNode_2letter">
+        <xsl:value-of select="$thesaurusPublisherMultilingualNode_2letter"/>
+      </xsl:when>
+      <xsl:otherwise>
+        Unknown
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+
   <!-- given a thesarus and language, find the most appropriate title-->
   <xsl:function name="geonet:getThesaurusTitle">
     <xsl:param name="thesarus" />
@@ -377,6 +403,25 @@
                   </gmd:MD_Identifier>
                 </gmd:identifier>
               </xsl:if>
+
+
+          <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString><xsl:value-of select="geonet:getThesaurusResponsibleParty($currentThesaurusFull,$mdlang)"/></gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#{$altLang}"><xsl:value-of select="geonet:getThesaurusResponsibleParty($currentThesaurusFull,$altLang)"/></gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:organisationName>
+              <gmd:role>
+                <gmd:CI_RoleCode codeListValue="RI_409" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+
+
 
         </gmd:CI_Citation>
       </gmd:thesaurusName>


### PR DESCRIPTION
There's two things in this PR;

a) updated thesaurus-transform.xsl to add a <citedResponsibleParty> to hte thesaurusName/CI_Citation section
    * citedResponsibleParty/organisationName is taken from the RDF <dc:publisher> section
    * currently, role is hard-coded (unlikely to need changing)
b) I've added default <dc:publisher> info to all the .RDFs

This requires;
https://github.com/geonetwork/core-geonetwork/pull/4831
