### PR TITLE
Fix bug in spring file.

### DIFF
--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -3,9 +3,11 @@
   xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:util="http://www.springframework.org/schema/util"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
   xmlns:context="http://www.springframework.org/schema/context"
->
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.2.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
   <context:component-scan base-package="ca.gc.schemas.iso19139hnap.init"/>
 


### PR DESCRIPTION
It was generating the following error.

org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException: Line 10 in XML document from URL [file:/C:/Projects/TADAP/geonetwork-dev/schemas/iso19139.ca.HNAP/target/classes/config-spring-geonetwork.xml] is invalid; nested exception is org.xml.sax.SAXParseException; lineNumber: 10; columnNumber: 75; cvc-complex-type.2.4.c: The matching wildcard is strict, but no declaration can be found for element 'context:component-scan'.

This was caused when trying to run unit test from service module GetKeywordByIdTest

See discussion https://github.com/metadata101/iso19139.ca.HNAP/pull/56#discussion_r450872749 more details