### PR TITLE
Add import converter for converting iso19139 to HNAP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
         <targetPath>thesarus/place</targetPath>
       </resource>
       <resource>
+        <directory>src/main/config/conversion</directory>
+        <targetPath>xsl/conversion</targetPath>
+      </resource>
+      <resource>
         <directory>src/main/config/translations</directory>
         <targetPath>META-INF/catalog/locales</targetPath>
       </resource>

--- a/src/main/config/conversion/import/iso19139-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139-to-iso19139.ca.HNAP.xsl
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="../../../WEB-INF/data/config/schema_plugins/iso19139.ca.HNAP/convert/ISO19139/fromISO19139.xsl"/>
+</xsl:stylesheet>

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerConverters.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerConverters.java
@@ -44,7 +44,7 @@ public class SchemaInitializerConverters implements
             Path correspondingDataDirFile = Paths.get(conversionPath.toString(), dir, fname);
             if (!Files.exists(correspondingDataDirFile)) {
                 //need to copy it in...
-                Log.info(Geonet.SCHEMA_MANAGER, "ISO19139.HNAP: SchemaInitializer: copying conversion files: " + fname + " to " + correspondingDataDirFile.toString());
+                Log.info(Geonet.SCHEMA_MANAGER, "ISO19139.HNAP: SchemaInitializerConverters: copying conversion files: " + fname + " to " + correspondingDataDirFile.toString());
                 try (InputStream is = r.getInputStream()) { //auto close
                     Files.copy(is, correspondingDataDirFile);
                 }
@@ -60,7 +60,7 @@ public class SchemaInitializerConverters implements
         try {
             ConfigureThesauruses(conversionPath);
         } catch (IOException e) {
-            Log.error(Geonet.SCHEMA_MANAGER, "SchemaInitializer: preloading conversion files", e);
+            Log.error(Geonet.SCHEMA_MANAGER, "SchemaInitializerConverters: preloading conversion files", e);
         }
     }
 }

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerConverters.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerConverters.java
@@ -1,0 +1,66 @@
+package ca.gc.schemas.iso19139hnap.init;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.utils.Log;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+/**
+ * This class is for setting up a schema conversion files
+ * <p>
+ * It watches the system startup and gives us the opportunity to do any setup required at the appropriate time.
+ * <p>
+ * See config-spring-geonetwork.xml in this schema
+ */
+public class SchemaInitializerConverters implements
+    ApplicationListener<GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent> {
+
+    private static final String conversionDir = "xsl/conversion/"; // "local" or "external"
+    private static String jarXSLPattern = conversionDir + "**/*.xsl"; //find xsl files in the JAR
+
+    // for each of the RDF files included in this JAR, if its not in the corresponding location in datadir, then we copy it in
+    public void ConfigureThesauruses(Path conversionPath) throws IOException {
+        PathMatchingResourcePatternResolver resolver =
+            new PathMatchingResourcePatternResolver(Thread.currentThread().getContextClassLoader());
+        //for each of the .rdf files
+        for (Resource r : resolver.getResources(jarXSLPattern)) {
+            String fname = r.getFilename(); //i.e. conversion/import/iso19139-to-iso19139.ca.HNAP.xsl
+            String[] subDirs = r.getURI().toURL().getPath().split(Pattern.quote("/"));
+            String dir = subDirs[subDirs.length - 2]; // ie. "import"
+            ///put in - xsl/conversion/import/iso19139-to-iso19139.ca.HNAP.xsl
+            //ensure that dirs exist
+            Files.createDirectories(Paths.get(conversionPath.toString(), dir));
+            //full path to put the .xsl
+            Path correspondingDataDirFile = Paths.get(conversionPath.toString(), dir, fname);
+            if (!Files.exists(correspondingDataDirFile)) {
+                //need to copy it in...
+                Log.info(Geonet.SCHEMA_MANAGER, "ISO19139.HNAP: SchemaInitializer: copying conversion files: " + fname + " to " + correspondingDataDirFile.toString());
+                try (InputStream is = r.getInputStream()) { //auto close
+                    Files.copy(is, correspondingDataDirFile);
+                }
+            }
+        }
+    }
+
+
+    //when the data dir is configured, we're good to copy in our conversion files
+    @Override
+    public void onApplicationEvent(GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent event) {
+        Path conversionPath = event.getSource().getWebappDir().resolve(conversionDir);
+        try {
+            ConfigureThesauruses(conversionPath);
+        } catch (IOException e) {
+            Log.error(Geonet.SCHEMA_MANAGER, "SchemaInitializer: preloading conversion files", e);
+        }
+    }
+}

--- a/src/main/plugin/iso19139.ca.HNAP/convert/ISO19139/fromISO19139.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/convert/ISO19139/fromISO19139.xsl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <!-- ISO19139 are compatible with HNAP however for to import to process then records as HNAP we need to ensure that the metadataStandardName is set correctly -->
+
+    <xsl:include href="../functions.xsl"/>
+
+    <xsl:variable name="metadataStandardNameEng"
+                  select="'North American Profile of ISO 19115:2003 - Geographic information - Metadata'"/>
+    <xsl:variable name="metadataStandardNameFre"
+                  select="'Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées'"/>
+    <xsl:variable name="metadataStandardVersion" select="'CAN/CGSB-171.100-2009'"/>
+
+
+    <!-- The default language is also added as gmd:locale
+   for multilingual metadata records. -->
+    <xsl:variable name="mainLanguage">
+        <xsl:call-template name="langId_from_gmdlanguage19139">
+            <xsl:with-param name="gmdlanguage" select="/root/*/gmd:language"/>
+        </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:template
+            match="gmd:metadataStandardName/gco:CharacterString[text()!=$metadataStandardNameEng and text()!=$metadataStandardNameFre]"
+            priority="10">
+        <xsl:copy>
+            <xsl:choose>
+                <xsl:when test="$mainLanguage='fra'">
+                    <xsl:value-of select="$metadataStandardNameFre"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$metadataStandardNameEng"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template
+            match="gmd:metadataStandardName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()!=$metadataStandardNameEng and text()!=$metadataStandardNameFre]"
+            priority="10">
+        <xsl:copy>
+
+            <xsl:choose>
+                <xsl:when test="$mainLanguage!='fra'">
+                    <xsl:value-of select="$metadataStandardNameFre"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$metadataStandardNameEng"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="gmd:metadataStandardVersion/gco:CharacterString[text()!=$metadataStandardVersion]"
+                  priority="10">
+        <xsl:copy>
+            <xsl:value-of select="$metadataStandardVersion"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -14,6 +14,11 @@
         class="ca.gc.schemas.iso19139hnap.init.SchemaInitializerThesauri">
   </bean>
 
+  <!-- copies in converters -->
+  <bean id="iso19139.ca.HNAP.SchemaInitializerConverters"
+        class="ca.gc.schemas.iso19139hnap.init.SchemaInitializerConverters">
+  </bean>
+
   <!-- copy in any  settings -->
   <bean id="iso19139.ca.HNAP.startup.settings"
         class="ca.gc.schemas.iso19139hnap.init.SchemaInitializerSettings">


### PR DESCRIPTION
I attempted to export and import some data from FGP and got some errors in the import.

I received some data which contains the following.
```
<gmd:metadataStandardName xsi:type="gmd:PT_FreeText_PropertyType">
    <gco:CharacterString>North American Profile of ISO 19115:2003 - Geographic information - Metadata</gco:CharacterString>
    <gmd:PT_FreeText>
      <gmd:textGroup>
        <gmd:LocalisedCharacterString locale="#fra">fra</gmd:LocalisedCharacterString>
      </gmd:textGroup>
    </gmd:PT_FreeText>
  </gmd:metadataStandardName>
  <gmd:metadataStandardVersion>
    <gco:CharacterString>NAP - CAN/CGSB-171.100-2009</gco:CharacterString>
  </gmd:metadataStandardVersion>

```

`NAP - CAN/CGSB-171.100-2009`  should be `CAN/CGSB-171.100-2009`
And this was causing the schema detection to detect this as a ISO19139.

I also received other records where the autodetect was failing to pick HNAP due to the metadataStandard elements not being set correctly.  As we have our system setup to restrict the schema's to HNAP only we could not load the metadata records without fixing the problem.

1 - it was difficult to identify the records from the MEF file that were causing issued.
Created pull request to give better error message.
https://github.com/geonetwork/core-geonetwork/pull/4838

2 - It was time consuming to identify and fix each error.
So I created a converter that would modify the metadataStandard tags to make it HNAP compliant so that the autodetect would not choose the wrong schema.  That is what this pull request is for.

The converter will automatically install itself as part of the schema initialization process.