### PR TITLE
napec no longer used - remove from template

### DIFF
--- a/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
+++ b/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
@@ -111,7 +111,7 @@ public class XslUtilHnap {
     }
 
     /**
-     * From df-build\XslUtil.java, declared in utils-fn.xsl, used in napec schematron .sch files
+     * From df-build\XslUtil.java, declared in utils-fn.xsl, used in schematron .sch files
      * ported from utils-fn.xsl in ec
      * @param date
      * @return

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1.xml
@@ -4,7 +4,6 @@
                  xmlns:gfc="http://www.isotc211.org/2005/gfc"
                  xmlns:gco="http://www.isotc211.org/2005/gco"
                  xmlns:xlink="http://www.w3.org/1999/xlink"
-                 xmlns:napec="http://www.ec.gc.ca/data_donnees/standards/schemas/napec"
                  xmlns:gts="http://www.isotc211.org/2005/gts"
                  xmlns:gmx="http://www.isotc211.org/2005/gmx"
                  xmlns:gml="http://www.opengis.net/gml/3.2"
@@ -161,7 +160,7 @@
       </gmd:MD_ReferenceSystem>
     </gmd:referenceSystemInfo>
   <gmd:identificationInfo>
-    <napec:MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+    <gmd:MD_DataIdentification>
       <gmd:citation>
         <gmd:CI_Citation>
           <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
@@ -388,29 +387,7 @@
       <gmd:supplementalInformation gco:nilReason="missing">
         <gco:CharacterString/>
       </gmd:supplementalInformation>
-      <napec:EC_CorporateInfo>
-        <napec:EC_Branch>
-          <napec:EC_Branch_TypeCode codeListValue="" codeList="http://www.ec.gc.ca/data_donnees/standards/schemas/napec#EC_Branch"/>
-        </napec:EC_Branch>
-        <napec:EC_Directorate>
-          <napec:EC_Directorate_TypeCode codeListValue="" codeList="http://www.ec.gc.ca/data_donnees/standards/schemas/napec#EC_Directorate"/>
-        </napec:EC_Directorate>
-        <napec:EC_Project xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
-          <gco:CharacterString/>
-          <gmd:PT_FreeText>
-            <gmd:textGroup>
-              <gmd:LocalisedCharacterString locale="#fra"/>
-            </gmd:textGroup>
-          </gmd:PT_FreeText>
-        </napec:EC_Project>
-        <napec:GC_Security_Classification>
-          <napec:GC_Security_Classification_TypeCode codeListValue="" codeList="http://www.ec.gc.ca/data_donnees/standards/schemas/napec#GC_Security_Classification"/>
-        </napec:GC_Security_Classification>
-        <napec:EC_Program>
-          <napec:EC_Program_TypeCode codeListValue="" codeList="http://www.ec.gc.ca/data_donnees/standards/schemas/napec#EC_Program"/>
-        </napec:EC_Program>
-      </napec:EC_CorporateInfo>
-    </napec:MD_DataIdentification>
+    </gmd:MD_DataIdentification>
   </gmd:identificationInfo>
   <gmd:distributionInfo>
     <gmd:MD_Distribution>


### PR DESCRIPTION
Cleanup 
napec no longer used - remove from template - the template was not working correctly with the napec elements.
Also removed from code comment.