### PR TITLE
Metadata editor - render in default view gmd:spatialRepresentationInfo and gmd:dataQualityInfo if available

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -528,6 +528,9 @@
                  or="referenceSystemInfo"/>
         </section>
 
+        <section xpath="/gmd:MD_Metadata/gmd:spatialRepresentationInfo"
+                 in="/gmd:MD_Metadata"/>
+
         <section name="gmd:MD_Distribution">
           <section name="distributionFormats">
             <field xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"
@@ -546,6 +549,10 @@
           </section>-->
 
         </section>
+
+        <section xpath="/gmd:MD_Metadata/gmd:dataQualityInfo"
+                 in="/gmd:MD_Metadata"/>
+
 
       </tab>
 


### PR DESCRIPTION
Change to render  in default view `gmd:spatialRepresentationInfo` and `gmd:dataQualityInfo` if available. For example:

```
   <gmd:dataQualityInfo>
      <gmd:DQ_DataQuality>
         <gmd:scope>
            <gmd:DQ_Scope>
               <gmd:level>
                  <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108"
                                    codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
               </gmd:level>
               <gmd:levelDescription>
                  <gmd:MD_ScopeDescription>
                     <gmd:dataset gco:nilReason="missing">
                        <gco:CharacterString/>
                     </gmd:dataset>
                  </gmd:MD_ScopeDescription>
               </gmd:levelDescription>
            </gmd:DQ_Scope>
         </gmd:scope>
         <gmd:lineage>
            <gmd:LI_Lineage>
               <gmd:statement gco:nilReason="missing">
                  <gco:CharacterString/>
               </gmd:statement>
            </gmd:LI_Lineage>
         </gmd:lineage>
      </gmd:DQ_DataQuality>
```

![data-quality-section](https://user-images.githubusercontent.com/1695003/90860349-21c87a00-e38a-11ea-8a90-0bc77b2c99e0.png)

Previously the user had to switch to the advanced view to update these fields. If the metadata doesn't contain these sections, are not displayed in the default view.