### PR TITLE
minor updates to make org selector more configurable

### DIFF
--- a/src/main/config/translations/en-schema-iso19139.ca.HNAP.json
+++ b/src/main/config/translations/en-schema-iso19139.ca.HNAP.json
@@ -1,5 +1,8 @@
 {
   "schema": "Schema-Specific Settings",
   "schema/iso19139.ca.HNAP": "ISO19139 HNAP Settings",
-  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Use 'Government of Canada' Organization Selector"
+  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Use 'Government of Canada' Organization Selector",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en": "Default top-level Organization Name (English)",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr": "Default top-level Organization Name (French)"
+
 }

--- a/src/main/config/translations/en-schema-iso19139.ca.HNAP.json
+++ b/src/main/config/translations/en-schema-iso19139.ca.HNAP.json
@@ -1,8 +1,8 @@
 {
   "schema": "Schema-Specific Settings",
   "schema/iso19139.ca.HNAP": "ISO19139 HNAP Settings",
-  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Use 'Government of Canada' Organization Selector",
-  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en": "Default top-level Organization Name (English)",
-  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr": "Default top-level Organization Name (French)"
+  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Use Enhanced ('MultiEntryCombiner') Organization Selector",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en": "Org Select: Default top-level Organization Name (English)",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr": "Org Select: Default top-level Organization Name (French)"
 
 }

--- a/src/main/config/translations/fr-schema-iso19139.ca.HNAP.json
+++ b/src/main/config/translations/fr-schema-iso19139.ca.HNAP.json
@@ -1,5 +1,7 @@
 {
   "schema": "Paramètres spécifiques au schéma",
   "schema/iso19139.ca.HNAP": "ISO19139 HNAP Paramètres",
-  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Utilisez le sélecteur d'organisation «Gouvernement du Canada»\n"
+  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Utilisez le sélecteur d'organisation «Gouvernement du Canada»\n",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en": "Nom de l'organisation de niveau supérieur par défaut (anglais)",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr": "Nom de l'organisation de niveau supérieur par défaut (français)"
 }

--- a/src/main/config/translations/fr-schema-iso19139.ca.HNAP.json
+++ b/src/main/config/translations/fr-schema-iso19139.ca.HNAP.json
@@ -1,7 +1,7 @@
 {
   "schema": "Paramètres spécifiques au schéma",
   "schema/iso19139.ca.HNAP": "ISO19139 HNAP Paramètres",
-  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Utilisez le sélecteur d'organisation «Gouvernement du Canada»\n",
-  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en": "Nom de l'organisation de niveau supérieur par défaut (anglais)",
-  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr": "Nom de l'organisation de niveau supérieur par défaut (français)"
+  "schema/iso19139.ca.HNAP/UseGovernmentOfCanadaOrganisationName": "Utiliser le sélecteur d'organisation amélioré («combinaison d'entrées multiples»)\n",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en": "Sélection de l'organisation: Nom de l'organisation de niveau supérieur par défaut (anglais)",
+  "schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr": "Sélection de l'organisation: Nom de l'organisation de niveau supérieur par défaut (français)"
 }

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java
@@ -44,6 +44,10 @@ public class SchemaInitializerSettings implements
     private void addSettings() {
         addSetting("schema/"+ HNAP_SCHEMA_NAME+"/UseGovernmentOfCanadaOrganisationName",
             SettingDataType.BOOLEAN,"true",1);
+        addSetting("schema/"+ HNAP_SCHEMA_NAME+"/DefaultMainOrganizationName_en",
+            SettingDataType.STRING,"Government of Canada",2);
+        addSetting("schema/"+ HNAP_SCHEMA_NAME+"/DefaultMainOrganizationName_fr",
+            SettingDataType.STRING,"Gouvernement du Canada",3);
     }
 
     //when the server starts up, we are ready to

--- a/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerThesauri.java
+++ b/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerThesauri.java
@@ -9,6 +9,7 @@ import org.fao.geonet.repository.SettingRepository;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
@@ -29,7 +30,8 @@ import java.util.regex.Pattern;
  * See config-spring-geonetwork.xml in this schema
  */
 public class SchemaInitializerThesauri implements
-    ApplicationListener<GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent> {
+    ApplicationListener<GeonetworkDataDirectory.GeonetworkDataDirectoryInitializedEvent>,
+    Ordered {
 
     boolean OVERWRITE_EXISTING_THESAURI = true;
 
@@ -78,5 +80,10 @@ public class SchemaInitializerThesauri implements
         } catch (IOException e) {
             Log.error(Geonet.THESAURUS, "SchemaInitializer: preloading RDF files", e);
         }
+    }
+
+    @Override
+    public int getOrder() {
+        return 1;
     }
 }

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -149,6 +149,12 @@
       </values>
     </xsl:variable>
 
+
+    <xsl:variable name="DefaultMainOrganizationName_fr" select="/root/gui/settings/schema/iso19139.ca.HNAP/DefaultMainOrganizationName_fr"/>
+
+    <xsl:variable name="DefaultMainOrganizationName_en" select="/root/gui/settings/schema/iso19139.ca.HNAP/DefaultMainOrganizationName_en"/>
+
+
     <!--
       This creates the "values":  section
        "values": {
@@ -185,8 +191,8 @@
             },
             "thesaurus": "external.theme.GC_Org_Names",
             "defaultValues": {
-                  "eng": "Government of Canada",
-                  "fra": "Gouvernement du Canada"
+                  "eng": "<xsl:value-of select="$DefaultMainOrganizationName_en"/>",
+                  "fra": "<xsl:value-of select="$DefaultMainOrganizationName_fr"/>"
             }
           },
 


### PR DESCRIPTION
1. I added Ordered to the ThesaurusInitizer for listening to GeonetworkDataDir events.
    * this is to make it easier for downstream projects (i.e. municipalities/other orgs) to do things with the thesaurus

2. I made it so the org selector's top-level item (current Government of Canada) can be set with Settings 
     * added default setting
     * added text for the setting   
     * use the setting in the schema