### PR TITLE
Added security classification 

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -296,10 +296,11 @@
 
       <xsl:choose>
         <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
-          <Field name="secConstr" string="true" store="false" index="true"/>
+          <Field name="secConstr" string="true" store="true" index="true"/>
+          <Field name="secUserNote" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote/gco:CharacterString}" store="true" index="true"/>
         </xsl:when>
         <xsl:otherwise>
-          <Field name="secConstr" string="false" store="false" index="true"/>
+          <Field name="secConstr" string="false" store="true" index="true"/>
         </xsl:otherwise>
       </xsl:choose>
 

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -266,6 +266,7 @@
       <xsl:choose>
         <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
           <Field name="secConstr" string="true" store="true" index="true"/>
+          <Field name="secUserNote" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId]}" store="true" index="true"/>
         </xsl:when>
         <xsl:otherwise>
           <Field name="secConstr" string="false" store="true" index="true"/>


### PR DESCRIPTION
We need to be able to report on security classification so adding them to the index.

Added secConstr and secUserNote to the index so that we can report the security status of the document.


