### PR TITLE
Added GC_Security_Level as selection option for security user note

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -49,7 +49,11 @@
     <for name="gmd:statement" use="textarea"/>
     <for name="gmd:supplementalInformation" use="textarea"/>
     <for name="gmd:specificUsage" use="textarea"/>
-    <for name="gmd:userNote" use="textarea"/>
+    <for name="gmd:userNote"
+         use="data-gn-keyword-picker">
+      <directiveAttributes data-thesaurus-key="external.theme.GC_Security_Level" data-focus-to-input="true"/>
+    </for>
+
     <for name="gmd:useLimitation" use="textarea"/>
 
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -2114,14 +2114,6 @@
         <label>Security User note</label>
         <description>Explanation of the application of the legal constraints or other restrictions
             and legal prerequisites for obtaining and using the resource or metadata</description>
-    <helper>
-            <option value="Protect A">Protect A</option>
-            <option value="Protect B">Protect B</option>
-            <option value="Protect C">Protect C</option>
-            <option value="Confidential">Confidential</option>
-            <option value="Secret">Secret</option>
-            <option value="Top Secret">Top Secret</option>
-      </helper>
     </element>
     <element name="gmd:value" id="137.0" context="gmd:DQ_QuantitativeResult">
         <condition>mandatory</condition>


### PR DESCRIPTION
Change security note so that the value comes from the thesaurus instead of the helper.

The Thésaurus is better as is support multilingual values.

![image](https://user-images.githubusercontent.com/1868233/97337278-dbe2d300-185e-11eb-9065-743bd6d1b428.png)

Also removed the helper option from the label as it is not required.