### PR TITLE
Fix typo in thesausus name for open licenses

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -272,7 +272,7 @@
         |//*[@gco:isoType='gmd:MD_DataIdentification']
         |//*[@gco:isoType='srv:SV_ServiceIdentification']">
 
-      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_licenses.rdf'), '\\', '/')))"/>
+      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
 
       <sch:let name="openLicense" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
             (normalize-space(gco:CharacterString) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]) and

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -138,7 +138,7 @@
             |//*[@gco:isoType='gmd:MD_DataIdentification']
             |//*[@gco:isoType='srv:SV_ServiceIdentification']">
 
-      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_licenses.rdf'), '\\', '/')))"/>
+      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
 
       <sch:let name="openLicense" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
                (normalize-space(gco:CharacterString) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char])])" />


### PR DESCRIPTION
- Open license check it was always failing on Unix because of typo in thesaurus name

![image](https://user-images.githubusercontent.com/1868233/97352093-63394200-1871-11eb-8efd-98fc0453884c.png)

This PR fixes the typo
