### PR TITLE
Fixed bug with code list values not containing the translated values.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -895,7 +895,7 @@
 
             <gmd:type>
               <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="{@type}">
-                <xsl:value-of select="XslUtil:getCodelistTranslation('gmd:MD_KeywordTypeCode', string(@type), string($mainLanguage))"/>
+                  <xsl:value-of select="$codelistDocument/codelists/codelist[@name='gmd:MD_KeywordTypeCode']/entry[code = $currentCodeValue]/value"/>
               </gmd:MD_KeywordTypeCode>
             </gmd:type>
 


### PR DESCRIPTION
Fixed bug with code list values not containing the translated values. It should be using value instead of label.

Before change
```

  <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101"
                                          codeListValue="RI_528">Theme</gmd:MD_KeywordTypeCode>
```
After change										  
```
  <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101"
                                          codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
```
