### PR TITLE
Don't add multilingual section to keywords in non-multilingual metadata

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -881,14 +881,23 @@
 
             <xsl:for-each select="keyword">
 
-              <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-                <gco:CharacterString><xsl:value-of select="@value" /></gco:CharacterString>
-                <gmd:PT_FreeText>
-                  <gmd:textGroup>
-                    <gmd:LocalisedCharacterString locale="{@locale}"><xsl:value-of select="@translation" /></gmd:LocalisedCharacterString>
-                  </gmd:textGroup>
-                </gmd:PT_FreeText>
-              </gmd:keyword>
+              <xsl:choose>
+                <xsl:when test="$isMultilingual">
+                  <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString><xsl:value-of select="@value" /></gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="{@locale}"><xsl:value-of select="@translation" /></gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:keyword>
+                </xsl:when>
+                <xsl:otherwise>
+                  <gmd:keyword>
+                    <gco:CharacterString><xsl:value-of select="@value" /></gco:CharacterString>
+                  </gmd:keyword>
+                </xsl:otherwise>
+              </xsl:choose>
 
             </xsl:for-each>
 


### PR DESCRIPTION
With non-multilingual metadata, the keywords got a multilingual section with empty value for the alternative language.

```
<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
  <gco:CharacterString>Aboriginal affairs</gco:CharacterString>
  <gmd:PT_FreeText>
    <gmd:textGroup>
      <gmd:LocalisedCharacterString xmlns="" locale=""></gmd:LocalisedCharacterString>
    </gmd:textGroup>
  </gmd:PT_FreeText>
</gmd:keyword>
```

With the change:

```
<gmd:keyword>
  <gco:CharacterString>Aboriginal affairs</gco:CharacterString>
</gmd:keyword>
```