### PR TITLE
hnap 3.10.5-0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 The Canadian GeoNetwork community is pleased share the *ISO Harmonized North American Profile (HNAP)* schema plugin. This is a bilingual extension of the *North American Profile of ISO 19115:2003 - Geographic information - Metadata* used nationally.
 
-For details on this release see [3.5.0 Milestone](https://github.com/metadata101/iso19139.ca.HNAP/milestone/2?closed=1) release notes for details.
+For details on this release see [3.6.0 Milestone](https://github.com/metadata101/iso19139.ca.HNAP/milestone/3?closed=1) release notes for details.
 
 ## Installation
 
 ### GeoNetwork version to use with this plugin
 
-Use GeoNetwork `3.10.5-0`, not tested with prior versions!
+Use GeoNetwork `3.10.x`, not tested with prior versions!
 
 The schema plugin editor makes use of a number of controls for editing structured text fields requiring newer releases of core-geonetwork.
 
@@ -16,11 +16,15 @@ The schema plugin editor makes use of a number of controls for editing structure
 
 The plugin can be deployed manually in an existing GeoNetwork installation:
 
-1. Copy the content of the folder `schemas/iso19139.ca.HNAP/src/main/plugin` to `WEB-INF/data/config/schema_plugins/iso19139.ca.HNAP`.
+1. Download from [releases](https://github.com/metadata101/iso19139.ca.HNAP/releases) page.
+   
+   There are two files for each release, a `jar` and a `zip`.
 
-2. Copy the `schema-iso19139.ca.HNAP-3.10.5-0.jar` to geonetwork `WEB-INF/libs`
+2. Extract contents of the `schema-iso19139.ca.HNAP` zip download into `WEB-INF/data/config/schema_plugins/iso19139.ca.HNAP`.
 
-3. Restart geonetwork
+3. Copy the `schema-iso19139.ca.HNAP` jar to geonetwork `WEB-INF/libs`
+
+4. Restart geonetwork
 
 There is some custom initialization code run when GeoNetwork starts up:
 
@@ -54,3 +58,11 @@ The best approach is to add the plugin as a submodule:
    cd web
    mvn jetty:run -Penv-dev
    ```
+
+### Deploy locally built profile into existing installation
+
+1. Copy the `iso19139.ca.HNAP` folder from `schemas/iso19139.ca.HNAP/src/main/plugin` into geonetwork `WEB-INF/data/config/schema_plugins/`.
+
+2. Copy `schema-iso19139.ca.HNAP` jar from `target` into geonetwork `WEB-INF/libs`.
+
+3. Restart geonetwork

--- a/README.md
+++ b/README.md
@@ -1,42 +1,56 @@
 # ISO Harmonized North American Profile (HNAP) plugin for GeoNetwork
 
-ISO Harmonized North American Profile (HNAP)
+The Canadian GeoNetwork community is pleased share the *ISO Harmonized North American Profile (HNAP)* schema plugin. This is a bilingual extension of the *North American Profile of ISO 19115:2003 - Geographic information - Metadata* used nationally.
 
-## Installing the plugin
+For details on this release see [3.5.0 Milestone](https://github.com/metadata101/iso19139.ca.HNAP/milestone/2?closed=1) release notes for details.
+
+## Installation
 
 ### GeoNetwork version to use with this plugin
 
-Use GeoNetwork 3.10+. It's not supported in older versions so don't plug it into it!
+Use GeoNetwork `3.10.5-0`, not tested with prior versions!
 
-### Adding the plugin to the source code
-
-The best approach is to add the plugin as a submodule. Use https://github.com/geonetwork/core-geonetwork/blob/3.10.x/add-schema.sh for automatic deployment:
-
-```
-./add-schema.sh iso19139.ca.HNAP https://github.com/metadata101/iso19139.ca.HNAP 3.10.x
-```
-
-### Build the application
-
-Once the application is built, the war file contains the schema plugin:
-
-```
-$ mvn clean install -Penv-prod
-```
+The schema plugin editor makes use of a number of controls for editing structured text fields requiring newer releases of core-geonetwork.
 
 ### Deploy the profile in an existing installation
 
 The plugin can be deployed manually in an existing GeoNetwork installation:
 
-Copy the content of the folder `schemas/iso19139.ca.HNAP/src/main/plugin` to `INSTALL_DIR/geonetwork/WEB-INF/data/config/schema_plugins/iso19139.ca.HNAP`.
+1. Copy the content of the folder `schemas/iso19139.ca.HNAP/src/main/plugin` to `WEB-INF/data/config/schema_plugins/iso19139.ca.HNAP`.
 
+2. Copy the `schema-iso19139.ca.HNAP-3.10.5-0.jar` to geonetwork `WEB-INF/libs`
 
-# Changes To Standard Schema Build and Initialization
+3. Restart geonetwork
 
-There is some custom code that gets run when GeoNetwork starts up.
+There is some custom initialization code run when GeoNetwork starts up:
 
-This will look in the GeoNetwork Data Directory (ThesauriDir) and check to see if the HNAP Thesauruses are already there.  If they are not (i.e. this is the very first run of GeoNetwork with the HNAP Schema), then they are are copied from the JAR to the correct location in the Data Directory.  Otherwise it does nothing.
+1. The plugin includes will check the GeoNetwork Data Directory `ThesauriDir` to see if the HNAP Thesauruses are already installed.
 
+2. If they are not (i.e. this is the very first run of GeoNetwork with the HNAP Schema), the required thesaurus files are are copied from the `jar` into to the correct location in the Data Directory.
 
-See `SchemaInitializer.java`
+  See `SchemaInitializer.java` for details.
 
+## Building
+
+### Adding the plugin to the source code
+
+The best approach is to add the plugin as a submodule:
+
+1. Use [add-schema.sh](https://github.com/geonetwork/core-geonetwork/blob/3.10.x/add-schema.sh] for automatic deployment:
+
+   ```
+   ./add-schema.sh iso19139.ca.HNAP https://github.com/metadata101/iso19139.ca.HNAP 3.10.x
+   ```
+
+2. Build the application:
+   
+   ```
+   mvn clean install -Penv-prod -DskipTests
+   ```
+   
+3. Once the application is built, the war file contains the schema plugin:
+
+   ```
+   cd web
+   mvn jetty:run -Penv-dev
+   ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
     <version>3.7</version>
-    <!-- build core-geonetwork locally 3.7 dependency above -->
+    <!-- tested with 3.10.5-0 -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>schema-iso19139.ca.HNAP</artifactId>
   <name>Schema Plugin HNAP ISO19139/119</name>
-  <version>3.10.5-SNAPSHOT</version>
+  <version>3.10.5-0</version>
   <description>
      GeoNetwork schema plugin for HNAP ISO19139/119 standard
   </description>
@@ -29,13 +29,6 @@
      <artifactId>core</artifactId>
      <version>${gn.project.version}</version>
      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>schema-core</artifactId>
-      <version>3.7</version>
-      <type>test-jar</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
@@ -57,6 +50,14 @@
       <artifactId>common</artifactId>
       <version>${gn.project.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <!-- test scope -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>schema-core</artifactId>
+      <version>3.7</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <artifactId>schemas</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
     <version>3.7</version>
-    <!-- tested with 3.10.5-0 -->
+    <!-- tested with 3.10.6-SNAPSHOT -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>schema-iso19139.ca.HNAP</artifactId>
   <name>Schema Plugin HNAP ISO19139/119</name>
-  <version>3.10.5-0</version>
+  <version>3.10.6-SNAPSHOT</version>
   <description>
      GeoNetwork schema plugin for HNAP ISO19139/119 standard
   </description>

--- a/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
@@ -27,8 +27,8 @@
         xsi:schemaLocation="http://geonetwork-opensource.org/schemas/schema-ident http://geonetwork-opensource.org/schemas/schema-ident/schema-ident.xsd">
 	<name>iso19139.ca.HNAP</name>
 	<id>3693b080-4f89-11e4-916c-0800200c9a66</id>
-	<version>1.0</version>
-	<appMinorVersionSupported>3.6.0</appMinorVersionSupported>
+	<version>3.10.5</version>
+	<appMinorVersionSupported>3.10.5</appMinorVersionSupported>
 
 	<title xml:lang="en">ISO Harmonized North American Profile (HNAP)</title>
 	<title xml:lang="fr">ISO Profil nord-américain harmonisé (HNAP)</title>


### PR DESCRIPTION
Release compatible with core-geonetwork 3.10.5-0:

* Updated README.md to seperate out build installation instructions and manual installation instructions
* See [Milestone 3.10.5](https://github.com/metadata101/iso19139.ca.HNAP/milestone/2?closed=1) for details

This PR includes two commits to help with the release process:

* https://github.com/metadata101/iso19139.ca.HNAP/pull/121/commits/af78f28992ebc259eec3dd62b13262282525d74e to be tagged as as 3.10.5 release
* https://github.com/metadata101/iso19139.ca.HNAP/pull/121/commits/6cad32611912c1924718fad7aeb64d536a2b41a9 to restore build, tracking core-geonetwork 3.10.x branch using `3.10.6-SNAPSHOT`