### PR TITLE
Fix bug with vertical extents not being numeric values when editing.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -241,8 +241,8 @@
     <exclude>
       <name>gmd:identifier</name>
       <name>gmd:metadataStandardVersion</name>
-      <name>gmd:parentIdentifier</name>
       <name>gmd:hierarchyLevelName</name>
+      <name>gmd:parentIdentifier</name>
       <name>gmd:dataSetURI</name>
       <name>gmd:postalCode</name>
       <name>gmd:city</name>
@@ -276,6 +276,10 @@
       <name>gmd:condition</name>
       <name>gmd:maximumOccurence</name>
       <name>gmd:domainValue</name>
+      <name>gmd:minimumValue</name>
+      <name>gmd:maximumValue</name>
+      <name>gmd:dimensionSize</name>
+      <name>gmd:numberOfDimensions</name>
       <name>gmd:densityUnits</name>
       <name>gmd:descriptor</name>
       <name>gmd:denominator</name>
@@ -284,12 +288,13 @@
       <name>gmd:transformationDimensionDescription</name>
       <name>gmd:orientationParameterDescription</name>
       <name>gmd:distance</name>
+      <name>gmd:geometricObjectCount</name>
       <name>srv:name</name>
       <name>srv:invocationName</name>
-      <name>srv:serviceType</name>
       <name>srv:serviceTypeVersion</name>
       <name>srv:operationName</name>
       <name>srv:identifier</name>
+      <name>srv:serviceType</name>
       <name>gmd:individualName</name>
       <name>gmd:code</name>
       <name>gco:aName</name>


### PR DESCRIPTION
Fix bug with vertical extents not being numeric values when editing.

![image](https://user-images.githubusercontent.com/1868233/98703622-13b74380-2352-11eb-8211-fcd9ebff5841.png)

minimumValue, maximumValue
Also added some other missing numeric values based on iso19139

After fix 

![image](https://user-images.githubusercontent.com/1868233/98703720-321d3f00-2352-11eb-944e-c5e70f0a4c82.png)
