### PR TITLE
Add gmd:description to the basic view editor.  

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -528,7 +528,10 @@
             </template>
           </field>
 
-          <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement"/>
+          <section name="gmd:EX_Extent">
+            <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:description"/>
+            <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement"/>
+          </section>
 
         </section>
 


### PR DESCRIPTION
This fixes issue #122 

Note: for this to work it depends on https://github.com/geonetwork/core-geonetwork/pull/5185 to be implemented as well.

After implemented description will show up as follows.

![image](https://user-images.githubusercontent.com/1868233/98942080-de326780-24c3-11eb-9b32-6f44e51b8e39.png)

