### PR TITLE
Fix regression bug related to iso19139 records (caused by PR #125)

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -747,7 +747,7 @@
   </xsl:template>
 
   <!-- Readonly language in flat mode - changing the language may cause issues with the locale so disabling it on basic view. -->
-  <xsl:template mode="mode-iso19139" priority="2100" match="//gmd:MD_Metadata/gmd:language[$isFlatMode]">
+  <xsl:template mode="mode-iso19139" priority="2100" match="//gmd:MD_Metadata/gmd:language[$isFlatMode and $schema = 'iso19139.ca.HNAP']">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>


### PR DESCRIPTION
Fix regression bug from https://github.com/metadata101/iso19139.ca.HNAP/pull/125. 

It was applying the template to the iso19139 records when it should only apply the template to hnap records.