### PR TITLE
Fix advanced search by resource date calendar range

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -151,7 +151,7 @@
         </xsl:for-each>
 
         <xsl:for-each
-                select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='revision']/gmd:date">
+                select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_368']/gmd:date">
           <Field name="revisionDate" string="{string(gco:Date|gco:DateTime)}" store="false" index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
             <Field name="tempExtentBegin" string="{string(gco:Date|gco:DateTime)}" store="false" index="true"/>
@@ -159,7 +159,7 @@
         </xsl:for-each>
 
         <xsl:for-each
-                select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='creation']/gmd:date">
+                select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_366']/gmd:date">
           <Field name="createDate" string="{string(gco:Date|gco:DateTime)}" store="true" index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
             <Field name="tempExtentBegin" string="{string(gco:Date|gco:DateTime)}" store="false" index="true"/>
@@ -167,7 +167,7 @@
         </xsl:for-each>
 
         <xsl:for-each
-                select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='publication']/gmd:date">
+                select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_367']/gmd:date">
           <Field name="publicationDate" string="{string(gco:Date|gco:DateTime)}" store="false" index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
             <Field name="tempExtentBegin" string="{string(gco:Date|gco:DateTime)}" store="false" index="true"/>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -91,7 +91,7 @@
               <xsl:otherwise>$isoLangId</xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
-          <Document locale="{$isoLangId_ISO639_2B}">
+          <Document locale="{$isoLangId_ISrevisionDateO639_2B}">
 
             <Field name="_locale" string="{$isoLangId}" store="true" index="true"/>
             <Field name="_docLocale" string="{$isoDocLangId}" store="true" index="true"/>
@@ -165,17 +165,17 @@
         </xsl:for-each>
 
         <xsl:for-each
-          select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='revision']/gmd:date/gco:Date">
+          select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_368']/gmd:date/gco:Date">
           <Field name="revisionDate" string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 
         <xsl:for-each
-          select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='creation']/gmd:date/gco:Date">
+          select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_366']/gmd:date/gco:Date">
           <Field name="createDate" string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 
         <xsl:for-each
-          select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='publication']/gmd:date/gco:Date">
+          select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_367']/gmd:date/gco:Date">
           <Field name="publicationDate" string="{string(.)}" store="true" index="true"/>
         </xsl:for-each>
 

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -91,7 +91,7 @@
               <xsl:otherwise>$isoLangId</xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
-          <Document locale="{$isoLangId_ISrevisionDateO639_2B}">
+          <Document locale="{$isoLangId_ISO639_2B}">
 
             <Field name="_locale" string="{$isoLangId}" store="true" index="true"/>
             <Field name="_docLocale" string="{$isoDocLangId}" store="true" index="true"/>
@@ -130,6 +130,15 @@
         <xsl:otherwise>$isoLangId</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
+
+    <xsl:for-each select="gmd:dateStamp/gco:DateTime">
+      <Field name="changeDate" string="{string(.)}" store="true" index="true"/>
+    </xsl:for-each>
+
+    <!-- Index gco:Date as is allowed also, GN uses gco:DateTime, but this case manages imported and not edited metadata -->
+    <xsl:for-each select="gmd:dateStamp/gco:Date">
+      <Field name="changeDate" string="{concat(string(.), 'T00:00:00')}" store="true" index="true"/>
+    </xsl:for-each>
 
     <!-- === Data or Service Identification === -->
 


### PR DESCRIPTION
Search resource date range using hnap codeList values for revision, creation, publication.

# testing

Testing with hnap sample data (as outlined below):

* [x] Search by resource now picks up data identification changes
* [x] Search by record reflects record record dateStamp
* [x] Temporal extent beginDate and endDate not available to search (confirmed not part of the design)

Search by resource is having trouble picking up records with an incomplete date:
```
<gmd:CI_Date>
  <gmd:date>
    <gco:Date>2001</gco:Date>
  </gmd:date>
  <gmd:dateType>
    <gmd:CI_DateTypeCode
         codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
         codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
    </gmd:dateType>
</gmd:CI_Date>
```

Search by record is picking up records using dateStamp:
```
<gmd:dateStamp>
  <gco:DateTime>2020-03-25T14:12:19</gco:DateTime>
</gmd:dateStamp>
```
# sample data

aside: sample data shows inconsistencies between xml, default display mode, and full display mode.

*Ocean Salmon Program* `b16db0fe-a4ec-4844-819e-630e33137b6d`
* dateStamp: `2018-12-17T12:41:20` (displayed full `Mon Dec 17 2018 12:41:20 GMT-0800`)
* created: `1993` (display full: `1992` default `1992-12-31` )
* published: `2018` (display full `2017`)
* revision: `2018-12` (display full: `Dec 2018`)
* begin: `1990-07-25` (display full: `25 Jul 1990`)
* end: `1993-07-27` (display full: `27 Jul 1993`)

*Harbour Porpoise Presence, Maritimes Region* `58ea48ab-f052-48ab-9c18-4353e51b8bea`

* dateStamp: `2018-09-21T12:08:41` (displayed full `Fri Sep 21 2018 12:08:41 GMT-0700`)
* created: `2016-11-18` (displayed full: `18 Nov 2016` default `2016-11-18`)
* published: `2018-06-21` (displayed full `21 Jun 2018`)
* revision
* begin: `2018-05-09` (displayed full `09 May 2018`)

*Sites d'échouerie potentiels* `3b0ccbbe-e0f7-4e6f-a6aa-8b327c69a169`

* dateStamp: `2020-03-25T14:12:19` (displayed `Wed Mar 25 2020 14:12:19 GMT-0700`)
* creation: `2001` (display default: `2000-12-31` full:`2000`)
* publication: `2018` (display full: `2017`)
* revision:
* begin: `1978` (displayed full `1978`)
* end: `2000` (displayed full `2000` )

# testing 

Collecting testing results [here](https://docs.google.com/spreadsheets/d/1AZsPSJ0c2nozm3hnSpos-ywoG1VZ6GaHlJpC5ol63-8/edit?usp=sharing).

![image](https://user-images.githubusercontent.com/629681/99856373-b5eade80-2b3d-11eb-8c77-7a2730e68ecd.png)
