### PR TITLE
Consider plugin folder a resource, exclude contents from maven-jar-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
 
   <build>
     <resources>
+      <!-- packaged into jar -->
       <resource>
         <directory>src/main/config/codelist/local/thesauri/theme</directory>
         <targetPath>thesarus/theme</targetPath>
@@ -82,18 +83,31 @@
       <resource>
         <directory>src/main/resources</directory>
       </resource>
+      <!-- packaged into zip -->
+      <resource>
+        <directory>src/main/plugin/iso19139.ca.HNAP</directory>
+      </resource>
     </resources>
-
     <testResources>
       <testResource>
         <directory>src/test/resources/org/fao/geonet</directory>
       </testResource>
-      <testResource>
-        <directory>src/main/plugin/iso19139.ca.HNAP</directory>
-      </testResource>
     </testResources>
 
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>ca/**</include>
+            <include>META-INF/**</include>
+            <include>thesarus/**</include>
+            <include>xsl/**</include>
+            <include>config-spring-geonetwork.xml</include>
+            <include>rebel.xml</include>
+          </includes>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Setting up a build change from this discussion https://github.com/metadata101/iso19139.ca.HNAP/issues/107 changing the plugin folder to be a resource, and making sure the contents are excluded from maven-jar-plugin (since they are being packaged as a zip).

Traditionally schema plugins consider the plugin folder as a testResource, which is not quite accurate. 