### PR TITLE
Remove help from /fre/label.xml to make it identical to eng/labels.xml

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1,2616 +1,2616 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:noNamespaceSchemaLocation="../../../labels.xsd"
- xmlns:gco="http://www.isotc211.org/2005/gco"
- xmlns:gmd="http://www.isotc211.org/2005/gmd"
- xmlns:srv="http://www.isotc211.org/2005/srv"
- xmlns:gml="http://www.opengis.net/gml/3.2"
- xmlns:gts="http://www.isotc211.org/2005/gts"
- xmlns:gmx="http://www.isotc211.org/2005/gmx">
+        xsi:noNamespaceSchemaLocation="../../../labels.xsd"
+        xmlns:gco="http://www.isotc211.org/2005/gco"
+        xmlns:gmd="http://www.isotc211.org/2005/gmd"
+        xmlns:srv="http://www.isotc211.org/2005/srv"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:gts="http://www.isotc211.org/2005/gts"
+        xmlns:gmx="http://www.isotc211.org/2005/gmx">
 
-    <element name="gmd:MD_ScopeCode">
-        <label>Scope code</label>
-        <description>Class of information to which the referencing entity applies</description>
-    </element>
-    <element name="code" id="207.0" context="gmd:MD_Identifier">
-        <label>Code</label>
-        <description>Alphanumeric value identifying an instance in the namespace</description>
-        <help>alphanumeric value identifying an instance in the namespace</help>
-    </element>
-    <element name="code">
-        <label>System code</label>
-        <description>Code. i.e. EPSG code.</description>
-    </element>
-    <element name="code" id="547.0" context="gmd:MD_CodeValue">
-        <label>Code</label>
-        <description>Value code</description>
-        <help>Value code (i.e. numeric)</help>
-    </element>
-    <element name="codeSpace" id="208.1">
-        <label>Reference Authority</label>
-        <description>Authority responsible for codification. i.e. EPSG</description>
-    </element>
-    <element name="gco:Date" id="364.0" context="gmd:CI_Citation">
-        <label>Edition Date</label>
-        <description>Date of the edition</description>
-    </element>
-    <element name="gco:Date" id="393.0">
-        <label>Date</label>
-        <description>Formatted as 2007-09-12 (YYYY-MM-DD)</description>
-        <help>reference date and event used to describe it</help>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gco:DateTime" id="64.0" context="gmd:MD_Usage">
-        <description>Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)</description>
-        <label>Usage Date / Time</label>
-        <help>date and time of the first use or range of uses of the resource and/or resource
-            series</help>
-    </element>
-    <element name="gco:DateTime" id="300.0" context="gmd:MD_StandardOrderProcess">
-        <description>Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)</description>
-        <label>Planned Available Date / Time</label>
-        <help>date and time when theresource will be available</help>
-    </element>
-    <!--<element name="gmd:dateTime">
-        <label>DateTime</label>
-        <description>Date and time or range of date and time on or over which the process step
-            occurred (YYYY-MM-DDThh:mm:ss)</description>
-    </element>-->
-    <element name="gco:Measure" id="100.0" context="gmd:DQ_Element">
-        <label>Name of Measure</label>
-        <description>Name of the test applied to the data</description>
-    </element>
-    <element name="gco:Measure" id="357.0" context="gmd:EX_VerticalExtent">
-        <label>Unit of Measure</label>
-        <description>Vertical units used for vertical extent information Examples: metres, feet,
-            millimetres, hectopascals</description>
-        <_condition>M</_condition>
-    </element>
-    <element name="gmd:CI_Address" id="380.0">
-        <label>Address</label>
-        <description>Location of the responsible individual or organization</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_Citation" id="359.0">
-        <label>Citation</label>
-        <description>Standardised resource reference</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_Contact" id="387.0">
-        <label>Contact</label>
-        <description>Information required to enable contact with the responsible person and/or
-            organization</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_Date" id="393.0">
-        <label>Date</label>
-        <description>Reference date and event used to describe it (YYYY-MM-DD)</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_OnlineResource" id="396.0">
-        <label>Online Resource</label>
-        <description>Information about on-line sources from which the dataset, specification, or
-            community profile name and extended metadata elements can be obtained</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_ResponsibleParty" id="374.0">
-        <label>Responsible party</label>
-        <description>Identification of, and means of communication with, person(s) and organizations
-            associated with the dataset</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_Series" id="403.0">
-        <label>Series</label>
-        <description>Information about the series, or aggregate dataset, to which a dataset
-            belongs</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:CI_Telephone" id="407.0">
-        <label>Telephone</label>
-        <description>Telephone numbers for contacting the responsible individual or
-            organization</description>
-        <_condition>Use obligation/condition from referencing object</_condition>
-    </element>
-    <element name="gmd:DQ_AbsoluteExternalPositionalAccuracy" id="117.0">
-        <label>Absolute external positional accuracy</label>
-        <description>Closeness of reported coordinate values to values accepted as or being
-            true</description>
-    </element>
-    <element name="gmd:DQ_AccuracyOfATimeMeasurement" id="121.0">
-        <label>Accuracy of time measurement</label>
-        <description>Correctness of the temporal references of an item (reporting of error in time
-            measurement)</description>
-    </element>
-    <element name="gmd:DQ_CompletenessCommission" id="109.0">
-        <label>Completeness commission</label>
-        <description>Excess data present in the dataset, as described by the scope</description>
-    </element>
-    <element name="gmd:DQ_CompletenessOmission" id="110.0">
-        <label>Completeness omission</label>
-        <description>Data absent from the dataset, as described by the scope</description>
-    </element>
-    <element name="gmd:DQ_ConceptualConsistency" id="112.0">
-        <label>Conceptual consistency</label>
-        <description>Adherence to rules of the conceptual schema</description>
-    </element>
-    <element name="gmd:DQ_ConformanceResult" id="129.0">
-        <label>Conformance result</label>
-        <description>Information about the outcome of evaluating the obtained value (or set of
-            values) against a specified acceptable conformance quality level</description>
-    </element>
-    <element name="gmd:DQ_DataQuality" id="78.0">
-        <label>Data quality</label>
-        <description>Quality information for the data specified by a data quality
-            scope</description>
-    </element>
-    <element name="gmd:DQ_DomainConsistency" id="113.0">
-        <label>Domain consistency</label>
-        <description>Adherence of values to the value domains</description>
-    </element>
-    <element name="gmd:DQ_FormatConsistency" id="114.0">
-        <label>Format consistency</label>
-        <description>Degree to which data is stored in accordance with the physical structure of the
-            dataset, as described by the scope</description>
-    </element>
-    <element name="gmd:DQ_GriddedDataPositionalAccuracy" id="118.0">
-        <label>Gridded data positional accuracy</label>
-        <description>Closeness of gridded data position values to values accepted as or being
-            true</description>
-    </element>
-    <element name="gmd:DQ_NonQuantitativeAttributeAccuracy" id="126.0">
-        <label>Non quantitative attribute accuracy</label>
-        <description>Correctness of non-quantitative attributes</description>
-    </element>
-    <element name="gmd:DQ_QuantitativeAttributeAccuracy" id="127.0">
-        <label>Quantitative attribute accuracy</label>
-        <description>Accuracy of quantitative attributes</description>
-    </element>
-    <element name="gmd:DQ_QuantitativeResult" id="133.0">
-        <label>Quantitative result</label>
-        <description>The values or information about the value(s) (or set of values) obtained from
-            applying a data quality measure</description>
-    </element>
-    <element name="gmd:DQ_RelativeInternalPositionalAccuracy" id="119.0">
-        <label>Relative internal positional accuracy</label>
-        <description>Closeness of the relative positions of features in the scope to their
-            respective relative positions accepted as or being true</description>
-    </element>
-    <element name="gmd:DQ_Scope" id="138.0">
-        <label>Scope</label>
-        <description>Description of the data specified by the scope</description>
-        <help>extent of characteristic(s) of the data for which quality information is
-            reported</help>
-    </element>
-    <element name="gmd:DQ_TemporalConsistency" id="122.0">
-        <label>Temporal consistency</label>
-        <description>Correctness of ordered events or sequences, if reported</description>
-    </element>
-    <element name="gmd:DQ_TemporalValidity" id="123.0">
-        <label>Temporal validity</label>
-        <description>Validity of data specified by the scope with respect to time</description>
-    </element>
-    <element name="gmd:DQ_ThematicClassificationCorrectness" id="125.0">
-        <label>Thematic classification correctness</label>
-        <description>Comparison of the classes assigned to features or their attributes to a
-            universe of discourse</description>
-    </element>
-    <element name="gmd:DQ_TopologicalConsistency" id="115.0">
-        <label>Topological consistency</label>
-        <description>Correctness of the explicitly encoded topological characteristics of the
-            dataset as described by the scope</description>
-    </element>
-    <element name="gmd:EX_BoundingPolygon" id="341.0">
-        <label>Bounding Polygon</label>
-        <description>Boundary enclosing the dataset, expressed as the closed set of (x,y)
-            coordinates of the polygon (last point replicates first point)</description>
-    </element>
-    <element name="gmd:EX_Extent" id="334.0">
-        <label>Extent</label>
-        <description>Information about spatial, vertical, and temporal extent</description>
-    </element>
-    <element name="gmd:EX_GeographicBoundingBox" id="343.0">
-        <label>Geographic Bounding Box</label>
-        <description>A rectangle representing the geographic area covered by the resource</description>
-    </element>
-    <element name="gmd:EX_GeographicDescription" id="348.0">
-        <label>Geographic description</label>
-        <description>Description of the geographic area using identifiers</description>
-    </element>
-    <element name="gmd:EX_SpatialTemporalExtent" id="352.0">
-        <label>Spatial Temporal Extent</label>
-        <description>Extent with respect to date/time and spatial boundaries</description>
-    </element>
-    <element name="gmd:EX_TemporalExtent" id="350.0">
-        <label>Temporal Extent</label>
-        <description>Time period covered by the content of the dataset</description>
-    </element>
-    <element name="gmd:EX_VerticalExtent" id="354.0">
-        <label>Vertical extent</label>
-        <description>Vertical domain of dataset</description>
-    </element>
-    <element name="gmd:ISBN" id="372.0">
-        <label>ISBN</label>
-        <description>International Standard Book Number</description>
-    </element>
-    <element name="gmd:ISSN" id="373.0">
-        <label>ISSN</label>
-        <description>International Standard Serial Number</description>
-    </element>
-    <element name="gmd:LI_Lineage" id="82.0">
-        <label>Lineage</label>
-        <description>Information about the events or source data used in constructing the data
-            specified by the scope or lack of knowledge about lineage</description>
-    </element>
-    <element name="gmd:LI_ProcessStep" id="86.0">
-        <label>Process step</label>
-        <description>Information about an event in the creation process for the data specified by
-            the scope</description>
-        <help>information about an event or transformation in the life of a dataset including the
-            process used to maintain the dataset</help>
-    </element>
-    <element name="gmd:LI_Source" id="92.0">
-        <label>Source</label>
-        <description>Information about the source data used in creating the data specified by the
-            scope</description>
-    </element>
-    <element name="gmd:MD_AggregateInformation" id="66.1">
-        <label>Aggregate Information</label>
-        <description>Aggregate dataset information</description>
-    </element>
-    <element name="gmd:MD_ApplicationSchemaInformation" id="320.0">
-        <description>Information about the application schema used to build the
-            dataset</description>
-        <label>Application Schema Information</label>
-    </element>
-    <element name="gmd:MD_Band" id="259.0">
-        <label>Band</label>
-        <description>Range of wavelengths in the electromagnetic spectrum</description>
-        <help>range of wavelengths in the electromagnetic spectrum</help>
-    </element>
-    <element name="gmd:MD_BrowseGraphic" id="48.0">
-        <description>Graphic that provides an illustration of the dataset (should include a legend
-            for the graphic)</description>
-        <label>Browse Graphic</label>
-    </element>
-    <element name="gmd:MD_Constraints" id="67.0">
-        <label>Constraints</label>
-        <description>Restrictions on the access and use of a resource or metadata</description>
-    </element>
-    <element name="gmd:MD_CoverageDescription" id="239.0">
-        <label>Coverage description</label>
-        <description>Information about the content of a grid data cell</description>
-    </element>
-    <element name="gmd:MD_DataIdentification" id="36.0">
-        <label>Data identification</label>
-        <description>Information required to identify a dataset</description>
-    </element>
-    <element name="gmd:MD_DigitalTransferOptions" id="274.0">
-        <label>Digital transfer options</label>
-        <description>Technical means and media by which a resource is obtained from the
-            distributor</description>
-    </element>
-    <element name="gmd:MD_Dimension" id="179.0">
-        <label>Dimension</label>
-        <description>Axis properties</description>
-    </element>
-    <element name="gmd:MD_Distribution" id="270.0">
-        <label>Distribution</label>
-        <description>Information about the distributor of and options for obtaining the
-            resource</description>
-    </element>
-    <element name="gmd:MD_Distributor" id="279.0">
-        <label>Distributor</label>
-        <description>Information about the distributor</description>
-    </element>
-    <element name="gmd:MD_ExtendedElementInformation" id="306.0">
-        <description>New metadata element, not found in ISO 19115, which is required to describe
-            geographic data</description>
-        <label>Extended Element Information</label>
-    </element>
-    <element name="gmd:MD_FeatureCatalogueDescription" id="233.0">
-        <label>Feature catalogue description</label>
-        <description>Information identifying the feature catalogue or the conceptual
-            schema</description>
-    </element>
-    <element name="gmd:MD_Format" id="284.0">
-        <label>Format</label>
-        <description>Description of the computer language construct that specifies the
-            representation of data objects in a record, file, message, storage device or
-            transmission channel</description>
-    </element>
-    <element name="gmd:MD_GeometricObjects" id="183.0">
-        <label>Geometric objects</label>
-        <description>Number of objects, listed by geometric object type, used in the
-            dataset</description>
-    </element>
-    <element name="gmd:MD_Georectified" id="162.0">
-        <label>Georectified</label>
-        <description>Grid whose cells are regularly spaced in a geographic (i.e., lat / long) or map
-            coordinate system defined in the Spatial Referencing System (SRS) so that any cell in
-            the grid can be geolocated given its grid coordinate and the grid origin, cell spacing,
-            and orientation</description>
-    </element>
-    <element name="gmd:MD_Georeferenceable" id="170.0">
-        <label>Georeferenceable</label>
-        <description>Grid with cells irregularly spaced in any given geographic/map projection
-            coordinate system, whose individual cells can be geolocated using geolocation
-            information supplied with the data but cannot be geolocated from the grid properties
-            alone</description>
-    </element>
-    <element name="gmd:MD_GridSpatialRepresentation" id="157.0">
-        <label>Grid spatial representation</label>
-        <description>Information about grid spatial objects in the dataset</description>
-    </element>
-    <element name="gmd:MD_Identifier" id="205.0">
-        <label>Identifier</label>
-        <description>Value uniquely identifying an object within a namespace</description>
-    </element>
-    <element name="gmd:MD_ImageDescription" id="243.0">
-        <label>Image description</label>
-        <description>Information about an image's suitability for use</description>
-    </element>
-    <element name="gmd:MD_Keywords" id="52.0">
-        <label>Keywords</label>
-        <description>Keywords, their type and reference source</description>
-    </element>
-    <element name="gmd:MD_LegalConstraints" id="69.0">
-        <label>Legal constraints</label>
-        <description>Restrictions and legal prerequisites for accessing and using the resource or
-            metadata</description>
-    </element>
-    <element name="gmd:MD_MaintenanceInformation" id="142.0">
-        <label>Maintenance information</label>
-        <description>Information about the scope and frequency of updating</description>
-    </element>
-    <element name="gmd:MD_Medium" id="291.0">
-        <label>Medium</label>
-        <description>Information about the media on which the resource can be
-            distributed</description>
-    </element>
-    <element name="gmd:MD_Metadata" id="1.0">
-        <label>Metadata Record Information</label>
-        <description>Root entity which defines metadata about a resource or resources</description>
-    </element>
-    <element name="gmd:MD_MetadataExtensionInformation" id="303.0">
-        <description>Information describing metadata extensions</description>
-        <label>Metadata Extension Information</label>
-    </element>
-    <element name="gmd:MD_PortrayalCatalogueReference" id="268.0">
-        <label>Portrayal catalogue reference</label>
-        <description>Information identifying the portrayal catalogue used</description>
-    </element>
-    <element name="gmd:MD_RangeDimension" id="256.0">
-        <label>Range dimension</label>
-        <description>Information on the range of each dimension of a cell measurement
-            value</description>
-    </element>
-    <element name="gmd:MD_ReferenceSystem" id="186.0">
-        <label>Reference system</label>
-        <description>Information about the reference system.</description>
-        <help>information about the reference system</help>
-    </element>
-    <element name="gmd:MD_RepresentativeFraction" id="56.0">
-        <label>Representative fraction</label>
-        <description>Derived from Scale where MD_RepresentativeFraction.denominator = 1 /
-            Scale.measure And Scale.targetUnits = Scale.sourceUnits</description>
-    </element>
-    <element name="gmd:MD_Resolution" id="59.0">
-        <label>Resolution</label>
-        <description>Level of detail expressed as a scale factor or a ground distance</description>
-    </element>
-    <element name="gmd:MD_ScopeDescription" id="149.0">
-        <label>Scope description</label>
-        <description>Description of the class of information covered by the
-            information</description>
-        <condition>Either attributes, features, featureInstances, attributeInstnaces, dataset or other must be provided</condition>
-    </element>
-    <element name="gmd:MD_SecurityConstraints" id="73.0">
-        <label>Security constraints</label>
-        <description>Handling restrictions imposed on the resource or metadata for national security
-            or similar security concerns</description>
-    </element>
-    <element name="gmd:MD_ServiceIdentification" id="47.0">
-        <label>Service Identification</label>
-        <description>Identification of capabilities which a service provider makes available to a
-            service user through a set of interfaces that define a behaviour - See ISO 19119 -
-            Services for further information</description>
-    </element>
-    <element name="gmd:MD_StandardOrderProcess" id="298.0">
-        <label>Standard order process</label>
-        <description>Common ways in which the resource may be obtained or received, and related
-            instructions and fee information</description>
-    </element>
-    <element name="gmd:MD_Usage" id="62.0">
-        <label>Usage</label>
-        <description>Brief description of ways in which the resource(s) is/are currently
-            used</description>
-    </element>
-    <element name="gmd:MD_VectorSpatialRepresentation" id="176.0">
-        <label>Vector spatial representation</label>
-        <description>Information about the vector spatial objects in the dataset</description>
-    </element>
-    <element name="gmd:PT_FreeText" id="601.0">
-        <label>Free text</label>
-        <description>Description of a multi-language free text metadata element</description>
-    </element>
-    <element name="gmd:RS_Identifier" id="208.0">
-        <description>Identifier used for reference systems</description>
-        <label>Identifier</label>
-    </element>
-    <element name="gmd:URL" context="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
-        <label>Online resource</label>
-        <description>On-line information that can be used to contact the responsible individual or organization</description>
-    </element>
-    <element name="gmd:URL" context="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
-      <label>Online resource</label>
-      <description>On-line information that can be used to contact the responsible individual or organization</description>
-    </element>
-    <element name="gmd:URL" id="608.0">
-        <label>URL</label>
-        <description>Electronic location where the resource can be found. If your dataset is available online on either the Internet or Intranet, enter the web address here. If you wish to upload your dataset to the catalogue, this field will be pre-populated with a provided URL.</description>
-    </element>
-    <element name="gmd:abstract" id="25.0">
-        <label>Abstract</label>
-        <description>Provide a brief overview of the content, methodology and findings of the dataset in free text format</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:accessConstraints" id="70.0">
-        <label>Access Constraints</label>
-        <description>This element allows you to indicate any additional or special restrictions or limitations that may exist on accessing the resource, outside of those which are covered by existing departmental restrictions.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:address" id="525.0" context="gmd:CI_ResponsibleParty">
-        <label>Address</label>
-        <description>Address of the responsible party</description>
-    </element>
-    <element name="gmd:address" id="389.0">
-        <label>Address</label>
-        <description>Physical and email address at which the organization or individual may be
-            contacted</description>
-    </element>
-    <element name="gmd:administrativeArea" id="383.0">
-        <label>Province/State</label>
-        <description>State, province of the location</description>
-    </element>
-    <element name="gmd:aggregateDataSetIdentifier" id="66.3">
-        <label>Aggregate Datasetindentifier</label>
-        <description>Identification information about aggregate dataset</description>
-    </element>
-    <element name="gmd:aggregateDataSetName" id="66.2">
-        <label>Aggregate Datasetname</label>
-        <description>Citation information about the aggregate dataset</description>
-        <_condition>C / if aggregateDataSetIdentifier not documented?</_condition>
-    </element>
-    <element name="gmd:aggregationInfo" id="35.1">
-        <label>Aggregation Information</label>
-        <description>Provides aggregate dataset information</description>
-    </element>
-    <element name="gmd:alternateTitle" id="361.0">
-        <label>Alternate title</label>
-        <description>Short name or other language name by which the cited information is known.
-            Example: "DCW" as an alternative title for "Digital Chart of the World</description>
-    </element>
-    <element name="gmd:amendmentNumber" id="287.0">
-        <label>Amendment number</label>
-        <description>Amendment number of the format version</description>
-    </element>
-    <element name="gmd:applicationProfile" id="399.0">
-        <label>Application profile</label>
-        <description>Name of an application profile that can be used with the online
-            resource</description>
-    </element>
-    <element name="gmd:applicationSchemaInfo" id="21.0">
-        <label>Application schema info</label>
-        <description>Provides information about the conceptual schema of a dataset</description>
-    </element>
-    <element name="gmd:associationType" id="66.4">
-        <label>Association Type</label>
-        <description>Association type of the aggregate dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:attributeDescription" id="240.0">
-        <label>Attribute description</label>
-        <description>Description of the attribute described by the measurement value</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:attributeInstances" id="153.0">
-        <label>Attribute instances</label>
-        <description>Attribute instances to which the information applies</description>
-        <condition/>
-    </element>
-    <element name="gmd:attributes" id="150.0">
-        <label>Attributes</label>
-        <description>Attributes to which the information applies</description>
-        <condition/>
-    </element>
-    <element name="gmd:authority" id="206.0">
-        <label>Authority</label>
-        <description>Person or party responsible for maintenance of the namespace</description>
-    </element>
-    <element name="gmd:axisDimensionProperties" id="159.0">
-        <label>Axis Dimensions Properties</label>
-        <description>Information about spatial-temporal axis properties</description>
-        <_condition>M</_condition>
-    </element>
-    <element name="gmd:bitsPerValue" id="264.0">
-        <label>Bits per value</label>
-        <description>Maximum number of significant bits in the uncompressed representation for the
-            value in each band of each pixel</description>
-    </element>
-    <element name="gmd:cameraCalibrationInformationAvailability" id="253.0">
-        <label>Camera calibration information availability</label>
-        <description>Indication of whether or not constants are available which allow for camera
-            calibration corrections</description>
-    </element>
-    <element name="gmd:cellGeometry" id="160.0">
-        <label>Cell geometry</label>
-        <description>Identification of grid data as point or cell</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:centerPoint" id="166.0">
-        <label>Center point</label>
-        <description>Earth location in the coordinate system defined by the Spatial Reference System
-            and the grid coordinate of the cell halfway between opposite ends of the grid in the
-            spatial dimensions</description>
-    </element>
-    <element name="gmd:characterSet" id="4.0" context="gmd:MD_Metadata">
-        <label>Character set</label>
-        <description>Full name of the character coding standard used for the metadata
-            set</description>
-        <condition>conditional</condition>
-        <_condition>conditional / ISO/IEC 10646-1 not used and not defined by encoding?</_condition>
-    </element>
-    <element name="gmd:characterSet" id="40.0" context="gmd:MD_DataIdentification">
-        <label>Character Set</label>
-        <description>Full name of the character coding standard used for the dataset</description>
-        <_condition>Conditional / ISO 10646-1 not used?</_condition>
-    </element>
-    <element name="gmd:characterSet" id="4.0">
-        <label>Character set</label>
-        <description>Full name of the character coding standard used for the metadata
-            set</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:checkPointAvailability" id="163.0">
-        <description>Indication of whether or not geographic position points are available to test
-            the accuracy of the georeferenced grid data</description>
-        <condition>mandatory</condition>
-        <label>Checkpoint Availability</label>
-    </element>
-    <element name="gmd:checkPointDescription" id="164.0">
-        <description>Description of geographic position points used to test the accuracy of the
-            georeferenced grid data</description>
-        <condition>conditional</condition>
-        <label>Checkpoint Description</label>
-    </element>
-    <element name="gmd:citation" id="24.0" context="gmd:MD_Identification">
-        <label>Citation</label>
-        <description>Citation data for the resource(s)</description>
-    </element>
-    <element name="gmd:citation" id="576.0" context="gmd:MD_Authority">
-        <label>Citation</label>
-        <description>Citation which belongs to the authority</description>
-    </element>
-    <element name="gmd:citation" id="581.0" context="gmd:MD_Thesaurus">
-        <label>Citation</label>
-        <description>Citation of the thesaurus</description>
-    </element>
-    <element name="gmd:citation" id="581.0">
-        <label>Citation</label>
-        <description>Citation data for the resource(s)</description>
-    </element>
-    <element name="gmd:citedResponsibleParty" id="367.0">
-        <label>Cited responsible party</label>
-        <description>Name and position information for an individual or organization that is
-            responsible for the resource</description>
-    </element>
-    <element name="gmd:city" id="382.0">
-        <label>City</label>
-        <description>City of the location</description>
-    </element>
-    <element name="gmd:classification" id="74.0">
-        <condition>mandatory</condition>
-        <label>Security Classification</label>
-        <description>Name of the handling restrictions on the resource or metadata</description>
-    </element>
-    <element name="gmd:classificationSystem" id="76.0">
-        <label>Classification system</label>
-        <description>Name of the classification system</description>
-    </element>
-    <element name="gmd:cloudCoverPercentage" id="248.0">
-        <label>Cloud cover percentage</label>
-        <description>Area of the dataset obscured by clouds, expressed as a percentage of the
-            spatial extent</description>
-    </element>
-    <element name="gmd:code" id="207.0" context="gmd:RS_Identifier">
-        <label>Code</label>
-        <description>Alphanumeric value identifying an instance in the namespace</description>
-        <condition>mandatory</condition>
-      <helper rel="gmd:codeSpace">
-        <option title="http://www.epsg-registry.org" value="EPSG:3857">EPSG:3857 WGS 84 / Pseudo-Mercator</option>
-        <option title="http://www.epsg-registry.org" value="EPSG:3978">EPSG:3978 Lambert Conic Conformal (Nad83)</option>
-        <option title="http://www.epsg-registry.org" value="EPSG:3979">EPSG:3979 Lambert Conic Conformal (CSRS)</option>
-        <option title="http://www.epsg-registry.org" value="EPSG:4269">EPSG:4269 LL (Nad83)</option>
-        <option title="http://www.epsg-registry.org" value="EPSG:4326">EPSG:4326 WGS 84</option>
-        <option title="http://www.epsg-registry.org" value="EPSG:26917">EPSG:26917 NAD83 / UTM zone 17N</option>
-        <option title="http://www.spatialreference.org" value="SRG-ORG:16">SRG-ORG:16</option>
-        <option title="http://www.spatialreference.org" value="SRG-ORG:29">SRG-ORG:29</option>
-      </helper>
-    </element>
-    <element name="gmd:code" id="207.0" context="gmd:MD_Identifier">
-        <label>Code</label>
-        <description>Alphanumeric value identifying an instance in the namespace</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:code" id="547.0" context="gmd:MD_CodeValue">
-        <label>Code</label>
-        <description>Value code</description>
-        <help>Value code (i.e. numeric)</help>
-    </element>
-    <element name="gmd:codeSpace" id="208.1">
-        <label>Codespace</label>
-        <description>Name or identifier of the person or organization responsible for
-        namespace</description>
-    </element>
-    <element name="gmd:collectiveTitle" id="371.0">
-        <label>Collective title</label>
-        <description>Common title with holdings note. NOTE title identifies elements of a series
-            collectively, combined with information about what volumes are available at the source
-            cited</description>
-        <help>This field is used to name the Basic Geodata as defined in the GeoIV Annex I, as it is possible that there are more than 1 "physical" datasets assigned to 1 legal entry. E.g.: Entry no. 47 "Geophysikalisches Kartenwerk" consists of 3 datasets "Geophysikalische Karten 1:500000", "Geophysikalische Spezialkarten" and "Gravimetrischer Atlas 1:100000"</help>
-    </element>
-    <element name="gmd:complianceCode" id="234.0">
-        <label>Compliance code</label>
-        <description>Indication of whether or not the cited feature catalogue complies with ISO
-            19110</description>
-    </element>
-    <element name="gmd:compressionGenerationQuantity" id="250.0">
-        <label>Compression generation quantity</label>
-        <description>Count of the number the number of lossy compression cycles performed on the
-            image</description>
-    </element>
-    <element name="gmd:condition" id="312.0">
-        <label>Condition</label>
-        <description>Condition under which the extended element is mandatory</description>
-    </element>
-    <element name="gmd:constraintLanguage" id="323.0">
-        <label>Constraint language</label>
-        <description>Formal language used in Application Schema</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:contact" id="8.0" context="gmd:MD_Metadata">
-        <condition>mandatory</condition>
-        <label>Contact</label>
-        <description>Party responsible for the metadata information</description>
-    </element>
-    <element name="gmd:contact" id="148.1" context="gmd:MD_MaintenanceInformation">
-        <label>Contact</label>
-        <description>Identification of, and means of communication with, person(s) and
-            organization(s) with responsability for maintaining the metadata</description>
-    </element>
-    <element name="gmd:contact" id="8.0">
-        <label>Metadata author</label>
-        <description>Party responsible for the metadata information</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:contactInfo" id="378.0">
-        <description>Address of the responsible party</description>
-        <label>Contact Information</label>
-    </element>
-    <element name="gmd:contactInstructions" id="392.0">
-        <label>Contact instructions</label>
-        <description>Supplemental instructions on how or when to contact the individual or
-            organization</description>
-    </element>
-    <element name="gmd:contentInfo" id="16.0">
-        <description>Provides information about the feature catalogue and describes the coverage and
-            image data characteristics</description>
-        <label>Content Information</label>
-    </element>
-    <element name="gmd:contentType" id="241.0">
-        <label>Content type</label>
-        <description>Type of information represented by the cell value</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:controlPointAvailability" id="171.0">
-        <description>Indication of whether or not control point(s) exists</description>
-        <condition>mandatory</condition>
-        <label>Controlpoint Availability</label>
-    </element>
-    <element name="gmd:cornerPoints" id="165.0">
-        <label>Corner points</label>
-        <description>Earth location in the coordinate system defined by the Spatial Reference System
-            and the grid coordinate of the cells at opposite ends of grid coverage along two
-            diagonals in the grid spatial dimensions. There are four corner points in a georectified
-            grid; at least two corner points along one diagonal are required</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:country" id="612.0">
-        <label>Country</label>
-        <description>Country of the physical address</description>
-    </element>
-    <element name="gmd:country" id="508.0" context="gmd:MD_Legislation">
-        <label>Country</label>
-        <description>Country in which the law was issued</description>
-    </element>
-    <element name="gmd:country" id="605.0" context="PT_Group">
-        <label>Country</label>
-        <description>Country of language used for documenting a plain text</description>
-    </element>
-    <element name="gmd:credit" id="27.0">
-        <label>Credit</label>
-        <description>Recognition of those who contributed to the resource(s)</description>
-    </element>
-    <element name="gmd:dataQualityInfo" id="18.0">
-        <label>Data quality info</label>
-        <description>Provides overall assessment of quality of a resource(s)</description>
-    </element>
-    <element name="gmd:dataSetURI" id="11.1">
-        <label>Dataset Uniform Resource Identifier (URI)</label>
-        <description>Use this field to designate either a URL link to the dataset if available or a unique identifier (such as a DOI) for the resource if one exists</description>
-        <help>Uniformed Resource Identifier (URI) of the dataset to which the metadata applies. This
-            link refers direct to the machine-readable dataset.</help>
-    </element>
-    <element name="gmd:dataType" id="313.0">
-        <label>Data type</label>
-        <description>Code which identifies the kind of valueprovidedeprovided in the extended
-            element</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:dataset" id="154.0">
-        <description>Dataset to which the information applies</description>
-        <condition/>
-        <label>Dataset</label>
-    </element>
-    <element name="gmd:date" id="570.0">
-        <label>Date</label>
-        <description>Insert date in yyyy-mm-dd format or use the calendar icon to select the date</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:date" id="570.0" context="gmd:MD_Revision">
-        <label>Date of last update</label>
-        <description>Date of last update</description>
-    </element>
-    <element name="gmd:date" id="144.0" context="gmd:MD_MaintenanceInformation">
-        <label>Date of next update</label>
-        <description>Scheduled revision date for resource</description>
-    </element>
-    <element name="gmd:date" id="362.0" context="gmd:CI_Citation">
-        <condition>mandatory</condition>
-        <label>Date</label>
-        <description>Reference date for the cited resource</description>
-        <_condition>M</_condition>
-    </element>
-    <element name="gmd:date" id="394.0" context="gmd:CI_Date">
-        <condition>mandatory</condition>
-        <label>Date</label>
-        <description>Reference date for the cited resource</description>
-        <_condition>M</_condition>
-    </element>
-    <element name="gmd:dateOfNextUpdate" id="144.0">
-        <label>Date of next update</label>
-        <description>Scheduled revision date for resource (YYYY-MM-DD)</description>
-    </element>
-    <element name="gmd:dateStamp" id="9.0">
-        <label>Date Stamp</label>
-        <description>Date the metadata record was created / last updated (YYYY-MM-DDTHH:MM:SS)</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:dateTime" id="89.0">
-        <label>Date / Time</label>
-        <description>Date and time or range of date and time on or over which the process step
-            occurred (YYYY-MM-DDThh:mm:ss)</description>
-    </element>
-    <element name="gmd:dateTime" id="89.0" context="LI_ProcessStep">
-        <description>Date and time or range of date and time on or over which the process step
-            occurred (YYYY-MM-DDThh:mm:ss)</description>
-        <label>Date / Time</label>
-    </element>
-    <element name="gmd:dateTime" id="106.0" context="gmd:DQ_Element">
-        <label>Date / Time</label>
-        <description>Date or range of dates on which a data quality measure was
-            applied</description>
-    </element>
-    <element name="gmd:dateType" id="395.0">
-        <label>Date Type</label>
-        <description>Select the appropriate date type from the list. If the date you entered is the date the dataset was created, select 'creation', if it is the date of publication, select 'publication', and if the date reflects when changes were made to the dataset, select 'revision'</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:definition" id="310.0">
-        <label>Definition</label>
-        <description>Definition of the extended element</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:deliveryPoint" id="381.0">
-        <label>Delivery Point (Civic Address)</label>
-        <description>Enter the street address for the responsible organization or individual. E.g. 123 Main St.</description>
-    </element>
-    <element name="gmd:denominator" id="57.0">
-        <label>Denominator</label>
-      <description>The number below the line in a vulgar fraction</description>
-      <condition>add either a denominator or a distance</condition>
+  <element name="gmd:MD_ScopeCode">
+    <label>Scope code</label>
+    <description>Class of information to which the referencing entity applies</description>
+  </element>
+  <element name="code" id="207.0" context="gmd:MD_Identifier">
+    <label>Code</label>
+    <description>Alphanumeric value identifying an instance in the namespace</description>
+    <help>alphanumeric value identifying an instance in the namespace</help>
+  </element>
+  <element name="code">
+    <label>System code</label>
+    <description>Code. i.e. EPSG code.</description>
+  </element>
+  <element name="code" id="547.0" context="gmd:MD_CodeValue">
+    <label>Code</label>
+    <description>Value code</description>
+    <help>Value code (i.e. numeric)</help>
+  </element>
+  <element name="codeSpace" id="208.1">
+    <label>Reference Authority</label>
+    <description>Authority responsible for codification. i.e. EPSG</description>
+  </element>
+  <element name="gco:Date" id="364.0" context="gmd:CI_Citation">
+    <label>Edition Date</label>
+    <description>Date of the edition</description>
+  </element>
+  <element name="gco:Date" id="393.0">
+    <label>Date</label>
+    <description>Formatted as 2007-09-12 (YYYY-MM-DD)</description>
+    <help>reference date and event used to describe it</help>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gco:DateTime" id="64.0" context="gmd:MD_Usage">
+    <description>Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)</description>
+    <label>Usage Date / Time</label>
+    <help>date and time of the first use or range of uses of the resource and/or resource
+      series</help>
+  </element>
+  <element name="gco:DateTime" id="300.0" context="gmd:MD_StandardOrderProcess">
+    <description>Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)</description>
+    <label>Planned Available Date / Time</label>
+    <help>date and time when theresource will be available</help>
+  </element>
+  <!--<element name="gmd:dateTime">
+      <label>DateTime</label>
+      <description>Date and time or range of date and time on or over which the process step
+          occurred (YYYY-MM-DDThh:mm:ss)</description>
+  </element>-->
+  <element name="gco:Measure" id="100.0" context="gmd:DQ_Element">
+    <label>Name of Measure</label>
+    <description>Name of the test applied to the data</description>
+  </element>
+  <element name="gco:Measure" id="357.0" context="gmd:EX_VerticalExtent">
+    <label>Unit of Measure</label>
+    <description>Vertical units used for vertical extent information Examples: metres, feet,
+      millimetres, hectopascals</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="gmd:CI_Address" id="380.0">
+    <label>Address</label>
+    <description>Location of the responsible individual or organization</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_Citation" id="359.0">
+    <label>Citation</label>
+    <description>Standardised resource reference</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_Contact" id="387.0">
+    <label>Contact</label>
+    <description>Information required to enable contact with the responsible person and/or
+      organization</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_Date" id="393.0">
+    <label>Date</label>
+    <description>Reference date and event used to describe it (YYYY-MM-DD)</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_OnlineResource" id="396.0">
+    <label>Online Resource</label>
+    <description>Information about on-line sources from which the dataset, specification, or
+      community profile name and extended metadata elements can be obtained</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_ResponsibleParty" id="374.0">
+    <label>Responsible party</label>
+    <description>Identification of, and means of communication with, person(s) and organizations
+      associated with the dataset</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_Series" id="403.0">
+    <label>Series</label>
+    <description>Information about the series, or aggregate dataset, to which a dataset
+      belongs</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:CI_Telephone" id="407.0">
+    <label>Telephone</label>
+    <description>Telephone numbers for contacting the responsible individual or
+      organization</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gmd:DQ_AbsoluteExternalPositionalAccuracy" id="117.0">
+    <label>Absolute external positional accuracy</label>
+    <description>Closeness of reported coordinate values to values accepted as or being
+      true</description>
+  </element>
+  <element name="gmd:DQ_AccuracyOfATimeMeasurement" id="121.0">
+    <label>Accuracy of time measurement</label>
+    <description>Correctness of the temporal references of an item (reporting of error in time
+      measurement)</description>
+  </element>
+  <element name="gmd:DQ_CompletenessCommission" id="109.0">
+    <label>Completeness commission</label>
+    <description>Excess data present in the dataset, as described by the scope</description>
+  </element>
+  <element name="gmd:DQ_CompletenessOmission" id="110.0">
+    <label>Completeness omission</label>
+    <description>Data absent from the dataset, as described by the scope</description>
+  </element>
+  <element name="gmd:DQ_ConceptualConsistency" id="112.0">
+    <label>Conceptual consistency</label>
+    <description>Adherence to rules of the conceptual schema</description>
+  </element>
+  <element name="gmd:DQ_ConformanceResult" id="129.0">
+    <label>Conformance result</label>
+    <description>Information about the outcome of evaluating the obtained value (or set of
+      values) against a specified acceptable conformance quality level</description>
+  </element>
+  <element name="gmd:DQ_DataQuality" id="78.0">
+    <label>Data quality</label>
+    <description>Quality information for the data specified by a data quality
+      scope</description>
+  </element>
+  <element name="gmd:DQ_DomainConsistency" id="113.0">
+    <label>Domain consistency</label>
+    <description>Adherence of values to the value domains</description>
+  </element>
+  <element name="gmd:DQ_FormatConsistency" id="114.0">
+    <label>Format consistency</label>
+    <description>Degree to which data is stored in accordance with the physical structure of the
+      dataset, as described by the scope</description>
+  </element>
+  <element name="gmd:DQ_GriddedDataPositionalAccuracy" id="118.0">
+    <label>Gridded data positional accuracy</label>
+    <description>Closeness of gridded data position values to values accepted as or being
+      true</description>
+  </element>
+  <element name="gmd:DQ_NonQuantitativeAttributeAccuracy" id="126.0">
+    <label>Non quantitative attribute accuracy</label>
+    <description>Correctness of non-quantitative attributes</description>
+  </element>
+  <element name="gmd:DQ_QuantitativeAttributeAccuracy" id="127.0">
+    <label>Quantitative attribute accuracy</label>
+    <description>Accuracy of quantitative attributes</description>
+  </element>
+  <element name="gmd:DQ_QuantitativeResult" id="133.0">
+    <label>Quantitative result</label>
+    <description>The values or information about the value(s) (or set of values) obtained from
+      applying a data quality measure</description>
+  </element>
+  <element name="gmd:DQ_RelativeInternalPositionalAccuracy" id="119.0">
+    <label>Relative internal positional accuracy</label>
+    <description>Closeness of the relative positions of features in the scope to their
+      respective relative positions accepted as or being true</description>
+  </element>
+  <element name="gmd:DQ_Scope" id="138.0">
+    <label>Scope</label>
+    <description>Description of the data specified by the scope</description>
+    <help>extent of characteristic(s) of the data for which quality information is
+      reported</help>
+  </element>
+  <element name="gmd:DQ_TemporalConsistency" id="122.0">
+    <label>Temporal consistency</label>
+    <description>Correctness of ordered events or sequences, if reported</description>
+  </element>
+  <element name="gmd:DQ_TemporalValidity" id="123.0">
+    <label>Temporal validity</label>
+    <description>Validity of data specified by the scope with respect to time</description>
+  </element>
+  <element name="gmd:DQ_ThematicClassificationCorrectness" id="125.0">
+    <label>Thematic classification correctness</label>
+    <description>Comparison of the classes assigned to features or their attributes to a
+      universe of discourse</description>
+  </element>
+  <element name="gmd:DQ_TopologicalConsistency" id="115.0">
+    <label>Topological consistency</label>
+    <description>Correctness of the explicitly encoded topological characteristics of the
+      dataset as described by the scope</description>
+  </element>
+  <element name="gmd:EX_BoundingPolygon" id="341.0">
+    <label>Bounding Polygon</label>
+    <description>Boundary enclosing the dataset, expressed as the closed set of (x,y)
+      coordinates of the polygon (last point replicates first point)</description>
+  </element>
+  <element name="gmd:EX_Extent" id="334.0">
+    <label>Extent</label>
+    <description>Information about spatial, vertical, and temporal extent</description>
+  </element>
+  <element name="gmd:EX_GeographicBoundingBox" id="343.0">
+    <label>Geographic Bounding Box</label>
+    <description>A rectangle representing the geographic area covered by the resource</description>
+  </element>
+  <element name="gmd:EX_GeographicDescription" id="348.0">
+    <label>Geographic description</label>
+    <description>Description of the geographic area using identifiers</description>
+  </element>
+  <element name="gmd:EX_SpatialTemporalExtent" id="352.0">
+    <label>Spatial Temporal Extent</label>
+    <description>Extent with respect to date/time and spatial boundaries</description>
+  </element>
+  <element name="gmd:EX_TemporalExtent" id="350.0">
+    <label>Temporal Extent</label>
+    <description>Time period covered by the content of the dataset</description>
+  </element>
+  <element name="gmd:EX_VerticalExtent" id="354.0">
+    <label>Vertical extent</label>
+    <description>Vertical domain of dataset</description>
+  </element>
+  <element name="gmd:ISBN" id="372.0">
+    <label>ISBN</label>
+    <description>International Standard Book Number</description>
+  </element>
+  <element name="gmd:ISSN" id="373.0">
+    <label>ISSN</label>
+    <description>International Standard Serial Number</description>
+  </element>
+  <element name="gmd:LI_Lineage" id="82.0">
+    <label>Lineage</label>
+    <description>Information about the events or source data used in constructing the data
+      specified by the scope or lack of knowledge about lineage</description>
+  </element>
+  <element name="gmd:LI_ProcessStep" id="86.0">
+    <label>Process step</label>
+    <description>Information about an event in the creation process for the data specified by
+      the scope</description>
+    <help>information about an event or transformation in the life of a dataset including the
+      process used to maintain the dataset</help>
+  </element>
+  <element name="gmd:LI_Source" id="92.0">
+    <label>Source</label>
+    <description>Information about the source data used in creating the data specified by the
+      scope</description>
+  </element>
+  <element name="gmd:MD_AggregateInformation" id="66.1">
+    <label>Aggregate Information</label>
+    <description>Aggregate dataset information</description>
+  </element>
+  <element name="gmd:MD_ApplicationSchemaInformation" id="320.0">
+    <description>Information about the application schema used to build the
+      dataset</description>
+    <label>Application Schema Information</label>
+  </element>
+  <element name="gmd:MD_Band" id="259.0">
+    <label>Band</label>
+    <description>Range of wavelengths in the electromagnetic spectrum</description>
+    <help>range of wavelengths in the electromagnetic spectrum</help>
+  </element>
+  <element name="gmd:MD_BrowseGraphic" id="48.0">
+    <description>Graphic that provides an illustration of the dataset (should include a legend
+      for the graphic)</description>
+    <label>Browse Graphic</label>
+  </element>
+  <element name="gmd:MD_Constraints" id="67.0">
+    <label>Constraints</label>
+    <description>Restrictions on the access and use of a resource or metadata</description>
+  </element>
+  <element name="gmd:MD_CoverageDescription" id="239.0">
+    <label>Coverage description</label>
+    <description>Information about the content of a grid data cell</description>
+  </element>
+  <element name="gmd:MD_DataIdentification" id="36.0">
+    <label>Data identification</label>
+    <description>Information required to identify a dataset</description>
+  </element>
+  <element name="gmd:MD_DigitalTransferOptions" id="274.0">
+    <label>Digital transfer options</label>
+    <description>Technical means and media by which a resource is obtained from the
+      distributor</description>
+  </element>
+  <element name="gmd:MD_Dimension" id="179.0">
+    <label>Dimension</label>
+    <description>Axis properties</description>
+  </element>
+  <element name="gmd:MD_Distribution" id="270.0">
+    <label>Distribution</label>
+    <description>Information about the distributor of and options for obtaining the
+      resource</description>
+  </element>
+  <element name="gmd:MD_Distributor" id="279.0">
+    <label>Distributor</label>
+    <description>Information about the distributor</description>
+  </element>
+  <element name="gmd:MD_ExtendedElementInformation" id="306.0">
+    <description>New metadata element, not found in ISO 19115, which is required to describe
+      geographic data</description>
+    <label>Extended Element Information</label>
+  </element>
+  <element name="gmd:MD_FeatureCatalogueDescription" id="233.0">
+    <label>Feature catalogue description</label>
+    <description>Information identifying the feature catalogue or the conceptual
+      schema</description>
+  </element>
+  <element name="gmd:MD_Format" id="284.0">
+    <label>Format</label>
+    <description>Description of the computer language construct that specifies the
+      representation of data objects in a record, file, message, storage device or
+      transmission channel</description>
+  </element>
+  <element name="gmd:MD_GeometricObjects" id="183.0">
+    <label>Geometric objects</label>
+    <description>Number of objects, listed by geometric object type, used in the
+      dataset</description>
+  </element>
+  <element name="gmd:MD_Georectified" id="162.0">
+    <label>Georectified</label>
+    <description>Grid whose cells are regularly spaced in a geographic (i.e., lat / long) or map
+      coordinate system defined in the Spatial Referencing System (SRS) so that any cell in
+      the grid can be geolocated given its grid coordinate and the grid origin, cell spacing,
+      and orientation</description>
+  </element>
+  <element name="gmd:MD_Georeferenceable" id="170.0">
+    <label>Georeferenceable</label>
+    <description>Grid with cells irregularly spaced in any given geographic/map projection
+      coordinate system, whose individual cells can be geolocated using geolocation
+      information supplied with the data but cannot be geolocated from the grid properties
+      alone</description>
+  </element>
+  <element name="gmd:MD_GridSpatialRepresentation" id="157.0">
+    <label>Grid spatial representation</label>
+    <description>Information about grid spatial objects in the dataset</description>
+  </element>
+  <element name="gmd:MD_Identifier" id="205.0">
+    <label>Identifier</label>
+    <description>Value uniquely identifying an object within a namespace</description>
+  </element>
+  <element name="gmd:MD_ImageDescription" id="243.0">
+    <label>Image description</label>
+    <description>Information about an image's suitability for use</description>
+  </element>
+  <element name="gmd:MD_Keywords" id="52.0">
+    <label>Keywords</label>
+    <description>Keywords, their type and reference source</description>
+  </element>
+  <element name="gmd:MD_LegalConstraints" id="69.0">
+    <label>Legal constraints</label>
+    <description>Restrictions and legal prerequisites for accessing and using the resource or
+      metadata</description>
+  </element>
+  <element name="gmd:MD_MaintenanceInformation" id="142.0">
+    <label>Maintenance information</label>
+    <description>Information about the scope and frequency of updating</description>
+  </element>
+  <element name="gmd:MD_Medium" id="291.0">
+    <label>Medium</label>
+    <description>Information about the media on which the resource can be
+      distributed</description>
+  </element>
+  <element name="gmd:MD_Metadata" id="1.0">
+    <label>Metadata Record Information</label>
+    <description>Root entity which defines metadata about a resource or resources</description>
+  </element>
+  <element name="gmd:MD_MetadataExtensionInformation" id="303.0">
+    <description>Information describing metadata extensions</description>
+    <label>Metadata Extension Information</label>
+  </element>
+  <element name="gmd:MD_PortrayalCatalogueReference" id="268.0">
+    <label>Portrayal catalogue reference</label>
+    <description>Information identifying the portrayal catalogue used</description>
+  </element>
+  <element name="gmd:MD_RangeDimension" id="256.0">
+    <label>Range dimension</label>
+    <description>Information on the range of each dimension of a cell measurement
+      value</description>
+  </element>
+  <element name="gmd:MD_ReferenceSystem" id="186.0">
+    <label>Reference system</label>
+    <description>Information about the reference system.</description>
+    <!--<help>information about the reference system</help>-->
+  </element>
+  <element name="gmd:MD_RepresentativeFraction" id="56.0">
+    <label>Representative fraction</label>
+    <description>Derived from Scale where MD_RepresentativeFraction.denominator = 1 /
+      Scale.measure And Scale.targetUnits = Scale.sourceUnits</description>
+  </element>
+  <element name="gmd:MD_Resolution" id="59.0">
+    <label>Resolution</label>
+    <description>Level of detail expressed as a scale factor or a ground distance</description>
+  </element>
+  <element name="gmd:MD_ScopeDescription" id="149.0">
+    <label>Scope description</label>
+    <description>Description of the class of information covered by the
+      information</description>
+    <condition>Either attributes, features, featureInstances, attributeInstnaces, dataset or other must be provided</condition>
+  </element>
+  <element name="gmd:MD_SecurityConstraints" id="73.0">
+    <label>Security constraints</label>
+    <description>Handling restrictions imposed on the resource or metadata for national security
+      or similar security concerns</description>
+  </element>
+  <element name="gmd:MD_ServiceIdentification" id="47.0">
+    <label>Service Identification</label>
+    <description>Identification of capabilities which a service provider makes available to a
+      service user through a set of interfaces that define a behaviour - See ISO 19119 -
+      Services for further information</description>
+  </element>
+  <element name="gmd:MD_StandardOrderProcess" id="298.0">
+    <label>Standard order process</label>
+    <description>Common ways in which the resource may be obtained or received, and related
+      instructions and fee information</description>
+  </element>
+  <element name="gmd:MD_Usage" id="62.0">
+    <label>Usage</label>
+    <description>Brief description of ways in which the resource(s) is/are currently
+      used</description>
+  </element>
+  <element name="gmd:MD_VectorSpatialRepresentation" id="176.0">
+    <label>Vector spatial representation</label>
+    <description>Information about the vector spatial objects in the dataset</description>
+  </element>
+  <element name="gmd:PT_FreeText" id="601.0">
+    <label>Free text</label>
+    <description>Description of a multi-language free text metadata element</description>
+  </element>
+  <element name="gmd:RS_Identifier" id="208.0">
+    <description>Identifier used for reference systems</description>
+    <label>Identifier</label>
+  </element>
+  <element name="gmd:URL" context="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    <label>Online resource</label>
+    <description>On-line information that can be used to contact the responsible individual or organization</description>
+  </element>
+  <element name="gmd:URL" context="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    <label>Online resource</label>
+    <description>On-line information that can be used to contact the responsible individual or organization</description>
+  </element>
+  <element name="gmd:URL" id="608.0">
+    <label>URL</label>
+    <description>Electronic location where the resource can be found. If your dataset is available online on either the Internet or Intranet, enter the web address here. If you wish to upload your dataset to the catalogue, this field will be pre-populated with a provided URL.</description>
+  </element>
+  <element name="gmd:abstract" id="25.0">
+    <label>Abstract</label>
+    <description>Provide a brief overview of the content, methodology and findings of the dataset in free text format</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:accessConstraints" id="70.0">
+    <label>Access Constraints</label>
+    <description>This element allows you to indicate any additional or special restrictions or limitations that may exist on accessing the resource, outside of those which are covered by existing departmental restrictions.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:address" id="525.0" context="gmd:CI_ResponsibleParty">
+    <label>Address</label>
+    <description>Address of the responsible party</description>
+  </element>
+  <element name="gmd:address" id="389.0">
+    <label>Address</label>
+    <description>Physical and email address at which the organization or individual may be
+      contacted</description>
+  </element>
+  <element name="gmd:administrativeArea" id="383.0">
+    <label>Province/State</label>
+    <description>State, province of the location</description>
+  </element>
+  <element name="gmd:aggregateDataSetIdentifier" id="66.3">
+    <label>Aggregate Datasetindentifier</label>
+    <description>Identification information about aggregate dataset</description>
+  </element>
+  <element name="gmd:aggregateDataSetName" id="66.2">
+    <label>Aggregate Datasetname</label>
+    <description>Citation information about the aggregate dataset</description>
+    <_condition>C / if aggregateDataSetIdentifier not documented?</_condition>
+  </element>
+  <element name="gmd:aggregationInfo" id="35.1">
+    <label>Aggregation Information</label>
+    <description>Provides aggregate dataset information</description>
+  </element>
+  <element name="gmd:alternateTitle" id="361.0">
+    <label>Alternate title</label>
+    <description>Short name or other language name by which the cited information is known.
+      Example: "DCW" as an alternative title for "Digital Chart of the World</description>
+  </element>
+  <element name="gmd:amendmentNumber" id="287.0">
+    <label>Amendment number</label>
+    <description>Amendment number of the format version</description>
+  </element>
+  <element name="gmd:applicationProfile" id="399.0">
+    <label>Application profile</label>
+    <description>Name of an application profile that can be used with the online
+      resource</description>
+  </element>
+  <element name="gmd:applicationSchemaInfo" id="21.0">
+    <label>Application schema info</label>
+    <description>Provides information about the conceptual schema of a dataset</description>
+  </element>
+  <element name="gmd:associationType" id="66.4">
+    <label>Association Type</label>
+    <description>Association type of the aggregate dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:attributeDescription" id="240.0">
+    <label>Attribute description</label>
+    <description>Description of the attribute described by the measurement value</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:attributeInstances" id="153.0">
+    <label>Attribute instances</label>
+    <description>Attribute instances to which the information applies</description>
+    <condition/>
+  </element>
+  <element name="gmd:attributes" id="150.0">
+    <label>Attributes</label>
+    <description>Attributes to which the information applies</description>
+    <condition/>
+  </element>
+  <element name="gmd:authority" id="206.0">
+    <label>Authority</label>
+    <description>Person or party responsible for maintenance of the namespace</description>
+  </element>
+  <element name="gmd:axisDimensionProperties" id="159.0">
+    <label>Axis Dimensions Properties</label>
+    <description>Information about spatial-temporal axis properties</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="gmd:bitsPerValue" id="264.0">
+    <label>Bits per value</label>
+    <description>Maximum number of significant bits in the uncompressed representation for the
+      value in each band of each pixel</description>
+  </element>
+  <element name="gmd:cameraCalibrationInformationAvailability" id="253.0">
+    <label>Camera calibration information availability</label>
+    <description>Indication of whether or not constants are available which allow for camera
+      calibration corrections</description>
+  </element>
+  <element name="gmd:cellGeometry" id="160.0">
+    <label>Cell geometry</label>
+    <description>Identification of grid data as point or cell</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:centerPoint" id="166.0">
+    <label>Center point</label>
+    <description>Earth location in the coordinate system defined by the Spatial Reference System
+      and the grid coordinate of the cell halfway between opposite ends of the grid in the
+      spatial dimensions</description>
+  </element>
+  <element name="gmd:characterSet" id="4.0" context="gmd:MD_Metadata">
+    <label>Character set</label>
+    <description>Full name of the character coding standard used for the metadata
+      set</description>
+    <condition>conditional</condition>
+    <_condition>conditional / ISO/IEC 10646-1 not used and not defined by encoding?</_condition>
+  </element>
+  <element name="gmd:characterSet" id="40.0" context="gmd:MD_DataIdentification">
+    <label>Character Set</label>
+    <description>Full name of the character coding standard used for the dataset</description>
+    <_condition>Conditional / ISO 10646-1 not used?</_condition>
+  </element>
+  <element name="gmd:characterSet" id="4.0">
+    <label>Character set</label>
+    <description>Full name of the character coding standard used for the metadata
+      set</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:checkPointAvailability" id="163.0">
+    <description>Indication of whether or not geographic position points are available to test
+      the accuracy of the georeferenced grid data</description>
+    <condition>mandatory</condition>
+    <label>Checkpoint Availability</label>
+  </element>
+  <element name="gmd:checkPointDescription" id="164.0">
+    <description>Description of geographic position points used to test the accuracy of the
+      georeferenced grid data</description>
+    <condition>conditional</condition>
+    <label>Checkpoint Description</label>
+  </element>
+  <element name="gmd:citation" id="24.0" context="gmd:MD_Identification">
+    <label>Citation</label>
+    <description>Citation data for the resource(s)</description>
+  </element>
+  <element name="gmd:citation" id="576.0" context="gmd:MD_Authority">
+    <label>Citation</label>
+    <description>Citation which belongs to the authority</description>
+  </element>
+  <element name="gmd:citation" id="581.0" context="gmd:MD_Thesaurus">
+    <label>Citation</label>
+    <description>Citation of the thesaurus</description>
+  </element>
+  <element name="gmd:citation" id="581.0">
+    <label>Citation</label>
+    <description>Citation data for the resource(s)</description>
+  </element>
+  <element name="gmd:citedResponsibleParty" id="367.0">
+    <label>Cited responsible party</label>
+    <description>Name and position information for an individual or organization that is
+      responsible for the resource</description>
+  </element>
+  <element name="gmd:city" id="382.0">
+    <label>City</label>
+    <description>City of the location</description>
+  </element>
+  <element name="gmd:classification" id="74.0">
+    <condition>mandatory</condition>
+    <label>Security Classification</label>
+    <description>Name of the handling restrictions on the resource or metadata</description>
+  </element>
+  <element name="gmd:classificationSystem" id="76.0">
+    <label>Classification system</label>
+    <description>Name of the classification system</description>
+  </element>
+  <element name="gmd:cloudCoverPercentage" id="248.0">
+    <label>Cloud cover percentage</label>
+    <description>Area of the dataset obscured by clouds, expressed as a percentage of the
+      spatial extent</description>
+  </element>
+  <element name="gmd:code" id="207.0" context="gmd:RS_Identifier">
+    <label>Code</label>
+    <description>Alphanumeric value identifying an instance in the namespace</description>
+    <condition>mandatory</condition>
+    <helper rel="gmd:codeSpace">
+      <option title="http://www.epsg-registry.org" value="EPSG:3857">EPSG:3857 WGS 84 / Pseudo-Mercator</option>
+      <option title="http://www.epsg-registry.org" value="EPSG:3978">EPSG:3978 Lambert Conic Conformal (Nad83)</option>
+      <option title="http://www.epsg-registry.org" value="EPSG:3979">EPSG:3979 Lambert Conic Conformal (CSRS)</option>
+      <option title="http://www.epsg-registry.org" value="EPSG:4269">EPSG:4269 LL (Nad83)</option>
+      <option title="http://www.epsg-registry.org" value="EPSG:4326">EPSG:4326 WGS 84</option>
+      <option title="http://www.epsg-registry.org" value="EPSG:26917">EPSG:26917 NAD83 / UTM zone 17N</option>
+      <option title="http://www.spatialreference.org" value="SRG-ORG:16">SRG-ORG:16</option>
+      <option title="http://www.spatialreference.org" value="SRG-ORG:29">SRG-ORG:29</option>
+    </helper>
+  </element>
+  <element name="gmd:code" id="207.0" context="gmd:MD_Identifier">
+    <label>Code</label>
+    <description>Alphanumeric value identifying an instance in the namespace</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:code" id="547.0" context="gmd:MD_CodeValue">
+    <label>Code</label>
+    <description>Value code</description>
+    <help>Value code (i.e. numeric)</help>
+  </element>
+  <element name="gmd:codeSpace" id="208.1">
+    <label>Codespace</label>
+    <description>Name or identifier of the person or organization responsible for
+      namespace</description>
+  </element>
+  <element name="gmd:collectiveTitle" id="371.0">
+    <label>Collective title</label>
+    <description>Common title with holdings note. NOTE title identifies elements of a series
+      collectively, combined with information about what volumes are available at the source
+      cited</description>
+    <!--<help>This field is used to name the Basic Geodata as defined in the GeoIV Annex I, as it is possible that there are more than 1 "physical" datasets assigned to 1 legal entry. E.g.: Entry no. 47 "Geophysikalisches Kartenwerk" consists of 3 datasets "Geophysikalische Karten 1:500000", "Geophysikalische Spezialkarten" and "Gravimetrischer Atlas 1:100000"</help>-->
+  </element>
+  <element name="gmd:complianceCode" id="234.0">
+    <label>Compliance code</label>
+    <description>Indication of whether or not the cited feature catalogue complies with ISO
+      19110</description>
+  </element>
+  <element name="gmd:compressionGenerationQuantity" id="250.0">
+    <label>Compression generation quantity</label>
+    <description>Count of the number the number of lossy compression cycles performed on the
+      image</description>
+  </element>
+  <element name="gmd:condition" id="312.0">
+    <label>Condition</label>
+    <description>Condition under which the extended element is mandatory</description>
+  </element>
+  <element name="gmd:constraintLanguage" id="323.0">
+    <label>Constraint language</label>
+    <description>Formal language used in Application Schema</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:contact" id="8.0" context="gmd:MD_Metadata">
+    <condition>mandatory</condition>
+    <label>Contact</label>
+    <description>Party responsible for the metadata information</description>
+  </element>
+  <element name="gmd:contact" id="148.1" context="gmd:MD_MaintenanceInformation">
+    <label>Contact</label>
+    <description>Identification of, and means of communication with, person(s) and
+      organization(s) with responsability for maintaining the metadata</description>
+  </element>
+  <element name="gmd:contact" id="8.0">
+    <label>Metadata author</label>
+    <description>Party responsible for the metadata information</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:contactInfo" id="378.0">
+    <description>Address of the responsible party</description>
+    <label>Contact Information</label>
+  </element>
+  <element name="gmd:contactInstructions" id="392.0">
+    <label>Contact instructions</label>
+    <description>Supplemental instructions on how or when to contact the individual or
+      organization</description>
+  </element>
+  <element name="gmd:contentInfo" id="16.0">
+    <description>Provides information about the feature catalogue and describes the coverage and
+      image data characteristics</description>
+    <label>Content Information</label>
+  </element>
+  <element name="gmd:contentType" id="241.0">
+    <label>Content type</label>
+    <description>Type of information represented by the cell value</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:controlPointAvailability" id="171.0">
+    <description>Indication of whether or not control point(s) exists</description>
+    <condition>mandatory</condition>
+    <label>Controlpoint Availability</label>
+  </element>
+  <element name="gmd:cornerPoints" id="165.0">
+    <label>Corner points</label>
+    <description>Earth location in the coordinate system defined by the Spatial Reference System
+      and the grid coordinate of the cells at opposite ends of grid coverage along two
+      diagonals in the grid spatial dimensions. There are four corner points in a georectified
+      grid; at least two corner points along one diagonal are required</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:country" id="612.0">
+    <label>Country</label>
+    <description>Country of the physical address</description>
+  </element>
+  <element name="gmd:country" id="508.0" context="gmd:MD_Legislation">
+    <label>Country</label>
+    <description>Country in which the law was issued</description>
+  </element>
+  <element name="gmd:country" id="605.0" context="PT_Group">
+    <label>Country</label>
+    <description>Country of language used for documenting a plain text</description>
+  </element>
+  <element name="gmd:credit" id="27.0">
+    <label>Credit</label>
+    <description>Recognition of those who contributed to the resource(s)</description>
+  </element>
+  <element name="gmd:dataQualityInfo" id="18.0">
+    <label>Data quality info</label>
+    <description>Provides overall assessment of quality of a resource(s)</description>
+  </element>
+  <element name="gmd:dataSetURI" id="11.1">
+    <label>Dataset Uniform Resource Identifier (URI)</label>
+    <description>Use this field to designate either a URL link to the dataset if available or a unique identifier (such as a DOI) for the resource if one exists</description>
+    <!--<help>Uniformed Resource Identifier (URI) of the dataset to which the metadata applies. This
+        link refers direct to the machine-readable dataset.</help>-->
+  </element>
+  <element name="gmd:dataType" id="313.0">
+    <label>Data type</label>
+    <description>Code which identifies the kind of valueprovidedeprovided in the extended
+      element</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:dataset" id="154.0">
+    <description>Dataset to which the information applies</description>
+    <condition/>
+    <label>Dataset</label>
+  </element>
+  <element name="gmd:date" id="570.0">
+    <label>Date</label>
+    <description>Insert date in yyyy-mm-dd format or use the calendar icon to select the date</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:date" id="570.0" context="gmd:MD_Revision">
+    <label>Date of last update</label>
+    <description>Date of last update</description>
+  </element>
+  <element name="gmd:date" id="144.0" context="gmd:MD_MaintenanceInformation">
+    <label>Date of next update</label>
+    <description>Scheduled revision date for resource</description>
+  </element>
+  <element name="gmd:date" id="362.0" context="gmd:CI_Citation">
+    <condition>mandatory</condition>
+    <label>Date</label>
+    <description>Reference date for the cited resource</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="gmd:date" id="394.0" context="gmd:CI_Date">
+    <condition>mandatory</condition>
+    <label>Date</label>
+    <description>Reference date for the cited resource</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="gmd:dateOfNextUpdate" id="144.0">
+    <label>Date of next update</label>
+    <description>Scheduled revision date for resource (YYYY-MM-DD)</description>
+  </element>
+  <element name="gmd:dateStamp" id="9.0">
+    <label>Date Stamp</label>
+    <description>Date the metadata record was created / last updated (YYYY-MM-DDTHH:MM:SS)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:dateTime" id="89.0">
+    <label>Date / Time</label>
+    <description>Date and time or range of date and time on or over which the process step
+      occurred (YYYY-MM-DDThh:mm:ss)</description>
+  </element>
+  <element name="gmd:dateTime" id="89.0" context="LI_ProcessStep">
+    <description>Date and time or range of date and time on or over which the process step
+      occurred (YYYY-MM-DDThh:mm:ss)</description>
+    <label>Date / Time</label>
+  </element>
+  <element name="gmd:dateTime" id="106.0" context="gmd:DQ_Element">
+    <label>Date / Time</label>
+    <description>Date or range of dates on which a data quality measure was
+      applied</description>
+  </element>
+  <element name="gmd:dateType" id="395.0">
+    <label>Date Type</label>
+    <description>Select the appropriate date type from the list. If the date you entered is the date the dataset was created, select 'creation', if it is the date of publication, select 'publication', and if the date reflects when changes were made to the dataset, select 'revision'</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:definition" id="310.0">
+    <label>Definition</label>
+    <description>Definition of the extended element</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:deliveryPoint" id="381.0">
+    <label>Delivery Point (Civic Address)</label>
+    <description>Enter the street address for the responsible organization or individual. E.g. 123 Main St.</description>
+  </element>
+  <element name="gmd:denominator" id="57.0">
+    <label>Denominator</label>
+    <description>The number below the line in a vulgar fraction</description>
+    <condition>add either a denominator or a distance</condition>
     <helper>
-		<option value="5000">1:5´000</option>
-		<option value="10000">1:10´000</option>
-		<option value="25000">1:25´000</option>
-		<option value="50000">1:50´000</option>
-		<option value="100000">1:100´000</option>
-		<option value="200000">1:200´000</option>
-		<option value="300000">1:300´000</option>
-		<option value="500000">1:500´000</option>
-		<option value="1000000">1:1´000´000</option>
+      <option value="5000">1:5´000</option>
+      <option value="10000">1:10´000</option>
+      <option value="25000">1:25´000</option>
+      <option value="50000">1:50´000</option>
+      <option value="100000">1:100´000</option>
+      <option value="200000">1:200´000</option>
+      <option value="300000">1:300´000</option>
+      <option value="500000">1:500´000</option>
+      <option value="1000000">1:1´000´000</option>
     </helper>
 
-    </element>
-    <element name="gmd:density" id="293.0">
-        <label>Density</label>
-        <description>Density at which the data is recorded</description>
-    </element>
-    <element name="gmd:densityUnits" id="294.0">
-        <label>Density units</label>
-        <description>Units of measure for the recording density</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:description" id="561.0">
-        <label>Description</label>
-        <description>Description of the event, including related parameters or
-            tolerances</description>
-    </element>
-    <element name="gmd:description" id="561.0" context="gmd:MD_AbstractClass">
-        <label>Description</label>
-        <description>Description</description>
-    </element>
-    <element name="gmd:description" id="87.0" context="LI_ProcessStep">
-        <condition>mandatory</condition>
-        <label>Description</label>
-        <description>Description of the event, including related parameters or
-            tolerances</description>
-    </element>
-    <element name="gmd:description" id="93.0" context="LI_Source">
-        <label>Description</label>
-        <description>Detailed description of the level of the source data</description>
-        <_condition>Conditional / sourceExtent not provided?</_condition>
-    </element>
-    <element name="gmd:description" id="335.0" context="gmd:EX_Extent">
-        <label>Description</label>
-        <description>Spatial and temporal extent for the referring object</description>
-        <_condition>Conditional / geographicElement and temporalElement and verticalElement not
-            documented?</_condition>
-    </element>
-    <element name="gmd:description" id="401.0" context="gmd:CI_OnlineResource">
-        <label>Description</label>
-        <description>Detailed text description of what the online resource is/does</description>
-    </element>
-    <element name="gmd:description" id="541.0" context="gmd:MD_CodeDomain">
-        <label>Description</label>
-        <description>Description of the code domain</description>
-    </element>
-    <element name="gmd:description" id="549.0" context="gmd:MD_CodeValue">
-        <label>Value description</label>
-        <description>Description of the value</description>
-    </element>
-    <element name="gmd:description" id="552.0" context="gmd:MD_Attribute">
-        <label>Description</label>
-        <description>Attribute description</description>
-    </element>
-    <element name="gmd:description" id="557.0" context="gmd:MD_Role">
-        <label>Description</label>
-        <description>Role description</description>
-    </element>
-    <element name="gmd:descriptiveKeywords" id="33.0">
-        <label>Descriptive keywords</label>
-        <description>Provides category keywords, their type, and reference source</description>
-    </element>
-    <element name="gmd:descriptor" id="258.0">
-        <label>Descriptor</label>
-        <description>Description of the range of a cell measurement value</description>
-    </element>
-    <element name="gmd:dimension" id="242.0">
-        <label>Dimension</label>
-        <description>Information on the dimensions of the cell measurement value</description>
-    </element>
-    <element name="gmd:dimensionName" id="180.0">
-        <label>Dimension name</label>
-        <description>Name of the axis</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:dimensionSize" id="181.0">
-        <label>Dimension size</label>
-        <description>Number of elements along the axis</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:distance" id="61.0">
-        <label>Distance</label>
-        <description>Ground sample distance</description>
-        <condition>Provide a distance if no equivalent Scale is documented</condition>
-        <helper relAtt="uom">
-            <option value="0.10" title="cm">10 cm</option>
-            <option value="0.25" title="cm">25 cm</option>
-            <option value="0.50" title="cm">50 cm</option>
-            <option value="1" title="m">1 m</option>
-            <option value="30" title="m">30 m</option>
-            <option value="100" title="m">100 m</option>
-        </helper>
-    </element>
-    <element name="gmd:distributionFormat" id="271.0">
-        <label>Distribution format</label>
-        <btnLabel>Add Distribution format</btnLabel>
-        <condition>mandatory</condition>
-        <description>Provides a description of the format of the data to be
-            distributed</description>
-    </element>
-    <element name="gmd:distributionInfo" id="17.0">
-        <description>Provides information about the distributor of and options for obtaining the
-            resource(s)</description>
-        <label>Distribution Information</label>
-    </element>
-    <element name="gmd:distributionOrderProcess" id="281.0">
-        <label>Distribution / Order Process</label>
-        <description>Provides information about how the resource may be obtained, and related
-            instructions and fee information</description>
-    </element>
-    <element name="gmd:distributor" id="272.0">
-        <label>Distributor</label>
-        <description>Provides information about the distributor</description>
-    </element>
-    <element name="gmd:distributorContact" id="280.0">
-        <label>Distributor contact</label>
-        <description>Party from whom the resource may be obtained. This list need not be
-            exhaustive</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:distributorFormat" id="282.0">
-        <label>Distributor format</label>
-        <description>Provides information about the format used by the distributor</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:distributorTransferOptions" id="283.0">
-        <label>Distributor transfer options</label>
-        <description>Provides information about the technical means and media used by the
-            distributor</description>
-    </element>
-    <element name="gmd:domainCode" id="309.0">
-        <label>Domain code</label>
-        <description>Three digit code assigned to the extended element</description>
-        <_condition>Conditional / is dataType ?codelistElement??</_condition>
-    </element>
-    <element name="gmd:domainOfValidity" id="197.0">
-        <label>Domain of validity</label>
-        <description>Range which is valid for the referencesystem</description>
-    </element>
-    <element name="gmd:domainValue" id="315.0">
-        <label>Domain value</label>
-        <description>Valid values that can be assigned to the extended element</description>
-        <_condition>Conditonal / dataType not 'codelist', 'enumeration' or
-            'codelistElement'</_condition>
-    </element>
-    <element name="gmd:eastBoundLongitude" id="345.0">
-        <label>East bound</label>
-        <description>Eastern-most coordinate of the limit of the dataset extent, expressed in
-            longitude in decimal degrees (positive east)</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:edition" id="363.0">
-        <label>Edition</label>
-        <description>Version of the cited resource</description>
-    </element>
-    <element name="gmd:editionDate" id="364.0">
-        <label>Edition date</label>
-        <description>Date of the edition (YYYY-MM-DD)</description>
-    </element>
-    <element name="gmd:electronicMailAddress" id="386.0">
-        <label>Electronic Mail Address</label>
-        <description>Address of the electronic mailbox of the responsible organization or individual</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:environmentDescription" id="44.0">
-        <label>Environment description</label>
-        <description>Description of the dataset in the producer_s processing environment, including
-            items such as the software, the computer operating system, file name, and the dataset
-            size</description>
-    </element>
-    <element name="gmd:equivalentScale" id="60.0">
-        <label>Equivalent scale</label>
-        <description>Level of detail expressed as the scale of a comparable hardcopy map or
-            chart</description>
-        <_condition>Conditional / distance not documented?</_condition>
-    </element>
-    <element name="gmd:errorStatistic" id="136.0">
-        <label>Error statistic</label>
-        <description>Statistical method used to determine the value</description>
-    </element>
-    <element name="gmd:evaluationMethodDescription" id="104.0">
-        <label>Evaluation method description</label>
-        <description>Description of the evaluation method</description>
-    </element>
-    <element name="gmd:evaluationMethodType" id="103.0">
-        <label>Evaluation Method</label>
-        <description>Type of method used to evaluate quality of the dataset</description>
-    </element>
-    <element name="gmd:evaluationProcedure" id="105.0">
-        <label>Evaluation procedure</label>
-        <description>Reference to the procedure information</description>
-    </element>
-    <element name="gmd:explanation" id="131.0">
-        <label>Explanation</label>
-        <description>Explanation of the meaning of conformance for this result</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:extendedElementInformation" id="305.0">
-        <label>Extended element information</label>
-        <description>Provides information about a new metadata element, not found in ISO 19115,
-            which is required to describe geographic data</description>
-    </element>
-    <element name="gmd:extensionOnLineResource" id="304.0">
-        <label>Extension Online resource</label>
-        <description>Information about on-line sources containing the community profile name and the
-            extended metadata elements. Information for all new metadata elements</description>
-    </element>
-    <element name="gmd:extent" id="45.0" context="gmd:MD_DataIdentification">
-        <label>Extent</label>
-        <description>Extent information including the bounding polygon, vertical, and temporal
-            extent of the dataset</description>
-        <_condition>Conditional / if hierarchyLevel equals "dataset"? Either
-            extent.geographicElement.EX_GeographicBoundingBox or
-            extent.geographicElement.EX_GeographicDescription is required</_condition>
-    </element>
-    <element name="gmd:extent" id="140.0" context="gmd:DQ_Scope">
-        <label>Extent</label>
-        <description>Information about the horizontal, vertical and temporal extent of the data
-            specified by the scope</description>
-    </element>
-    <element name="gmd:extent" id="351.0" context="gmd:EX_TemporalExtent">
-        <label>Extent</label>
-        <description>Date and time for the content of the dataset</description>
-        <_condition>mandatory</_condition>
-    </element>
-    <element name="gmd:extentTypeCode" id="340.0">
-        <label>Extent type code</label>
-        <description>Indication of whether the bounding polygon encompasses an area covered by the
-            data or an area where data is not present. Possible values: '1' for inclusion or '0' for
-            exclusion</description>
-    </element>
-    <element name="gmd:facsimile" id="409.0">
-        <label>Fax Number</label>
-        <description>Telephone number of a fax machine for the responsible organization or individual</description>
-    </element>
-    <element name="gmd:featureCatalogueCitation" id="238.0">
-        <label>Feature catalogue citation</label>
-        <description>Complete bibliographic reference to one or more external feature
-            catalogues</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:featureInstances" id="152.0">
-        <label>Feature instances</label>
-        <description>Feature instances to which the information applies</description>
-        <condition/>
-    </element>
-    <element name="gmd:featureTypes" id="237.0">
-        <label>Feature types</label>
-        <description>Subset of feature types from cited feature catalogue occurring in
-            data</description>
-    </element>
-    <element name="gmd:features" id="151.0">
-        <label>Features</label>
-        <description>Features to which the information applies</description>
-        <condition/>
-    </element>
-    <element name="gmd:fees" id="299.0">
-        <label>File Usage Fees</label>
-        <description>In the event that there are fees associated with the use of the dataset, they are indicated here. Include the appropriate monetary units. Eg."300.00 CAD" If there are no fees, leave the default set to 'none'</description>
-    </element>
-    <element name="gmd:fileDecompressionTechnique" id="289.0">
-        <label>File decompression technique</label>
-        <description>Recommendations of algorithms or processes that can be applied to read or
-            expand resources to which compression techniques have been applied</description>
-    </element>
-    <element name="gmd:fileDescription" id="50.0">
-        <label>File description</label>
-        <description>Text description of the illustration</description>
-    </element>
-    <element name="gmd:fileIdentifier" id="2.0">
-        <label>File Identifier</label>
-        <description>System generated unique identifier for this metadata record</description>
-    </element>
-    <element name="gmd:fileName" id="49.0">
-        <label>File name</label>
-        <description>Name of the file that contains a graphic that provides an illustration of the
-            dataset. It could be a public image document URL.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:fileType" id="51.0">
-        <label>File type</label>
-        <description>Format in which the illustration is encoded</description>
-        <help>format in which the illustration is encoded Examples: CGM, EPS, GIF, JPEG, PBM, PS,
-            TIFF, XWD</help>
-    </element>
-    <element name="gmd:filmDistortionInformationAvailability" id="254.0">
-        <label>Film distortion information availability</label>
-        <description>Indication of whether or not Calibration Reseau information is
-            available</description>
-    </element>
-    <element name="gmd:formatDistributor" id="290.0">
-        <label>Format distributor</label>
-        <description>Provides information about the distributor’s format</description>
-    </element>
-    <element name="gmd:function" id="402.0">
-        <label>Function</label>
-        <description>Code for function performed by the online resource</description>
-    </element>
-    <element name="gmd:geographicElement" id="336.0">
-        <label>Geographic element</label>
-        <description>Provides geographic component of the extent of the referring
-            object</description>
-        <_condition>Conditional / description and temporalElement and verticalElement not
-            documented?</_condition>
-    </element>
-    <element name="gmd:geographicIdentifier" id="349.0">
-        <label>Geographic identifier</label>
-        <description>Identifier used to represent a geographic area</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:geometricObjectCount" id="185.0">
-        <label>Geometric object count</label>
-        <description>Total number of the point or vector object type occurring in the
-            dataset</description>
-    </element>
-    <element name="gmd:geometricObjectType" id="184.0">
-        <label>Geometric object type</label>
-        <description>Name of point and vector spatial objects used to locate zero-, one-, and
-            two-dimensional spatial locations in the dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:geometricObjects" id="178.0">
-        <label>Geometric objects</label>
-        <description>Information about the geometric objects used in the dataset</description>
-    </element>
-    <element name="gmd:georeferencedParameters" id="174.0">
-        <label>GeoreferencedParameters</label>
-        <description>GeoreferencedParameters</description>
-    </element>
-    <element name="gmd:graphicOverview" id="31.0">
-        <label>Graphic overview</label>
-        <description>Provides a graphic that illustrates the resource(s) (should include a legend
-            for the graphic)</description>
-    </element>
-    <element name="gmd:graphicsFile" id="325.0">
-        <label>Graphics file</label>
-        <description>Full application schema given as a graphics file</description>
-    </element>
-    <element name="gmd:handlingDescription" id="77.0">
-        <label>Handling description</label>
-        <description>Additional information about the restrictions on handling the
-            resource</description>
-    </element>
-    <element name="gmd:hierarchyLevel" id="6.0">
-        <label>Hierarchy Level</label>
-        <description>Select the level to which the metadata applies. The default for this fields is 'Dataset'. If you are creating metadata to describe a series of datasets with a parent/child relationship, 'Series' is the most appropriate level.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:hierarchyLevelName" id="7.0">
-        <label>Hierarchy level name</label>
-        <description>Name of the hierarchy levels for which the metadata is provided</description>
-        <_condition>Conditional / hierarchyLevel is not equal to "dataset"?</_condition>
-    </element>
-    <element name="gmd:hoursOfService" id="391.0">
-        <label>Hours of Service</label>
-        <description>Provide a time period (including time zone) when an organization or individual can be contacted</description>
-    </element>
-    <element name="gmd:identificationInfo" id="15.0">
-        <label>Identification info</label>
-        <description>Basic information about the resource(s) to which the metadata
-            applies</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:identifier" id="573.0">
-        <label>Identifier</label>
-        <description>Unique identifier for the resource. EXAMPLE: Universal Product Code (UPC),
-            National Stock Number (NSN)</description>
-    </element>
-    <element name="gmd:identifier" id="573.0" context="gmd:CI_Citation">
-        <label>Citation identifier</label>
-        <description>Identifier of the citation</description>
-    </element>
-    <element name="gmd:identifier" id="575.0" context="gmd:MD_Authority">
-        <label>Identifier</label>
-        <description>Identifier which belongs to the authority</description>
-    </element>
-    <element name="gmd:illuminationAzimuthAngle" id="245.0">
-        <label>Illumination azimuth angle</label>
-        <description>Illumination azimuth measured in degrees clockwise from true north at the time
-            the image is taken. For images from a scanning device, refer to the centre pixel of the
-            image</description>
-    </element>
-    <element name="gmd:illuminationElevationAngle" id="244.0">
-        <label>Illumination elevation angle</label>
-        <description>Illumination elevation measured in degrees clockwise from the target plane at
-            intersection of the optical line of sight with the Earth_s surface. For images from a
-            scanning device, refer to the centre pixel of the image</description>
-    </element>
-    <element name="gmd:imageQualityCode" id="247.0">
-        <label>Image quality code</label>
-        <description>Specifies the image quality</description>
-        <help>specifies the image quality</help>
-    </element>
-    <element name="gmd:imagingCondition" id="246.0">
-        <label>Imaging condition</label>
-        <description>Conditions affected the image</description>
-    </element>
-    <element name="gmd:includedWithDataset" id="236.0">
-        <label>Included with dataset</label>
-        <description>Indication of whether or not the feature catalogue is included with the
-            dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:individualName" id="375.0">
-        <label>Individual Name</label>
-        <description>Name of the responsible person – surname, given name, title, separated by a delimiter</description>
-        <_condition>Conditional / organisationName and positionName not documented?</_condition>
-    </element>
-    <element name="gmd:initiativeType" id="66.5">
-        <label>Initiative Type</label>
-        <description>Type of initiative under which the aggregate dataset was produced</description>
-    </element>
-    <element name="gmd:issueIdentification" id="405.0">
-        <label>Issue identification</label>
-        <description>Information identifying the issue of the series</description>
-    </element>
-    <element name="gmd:keyword" id="53.0">
-        <label>Keyword</label>
-        <description>Commonly used word(s), or formalized word(s) or phrase(s) used to describe the subject of the resource.  Keywords are a repeatable element; enter as many keywords as possible to describe the data, as this will help the data be discovered.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:language" context="gmd:MD_Metadata" id="3.0">
-        <label>Metadata language</label>
-        <btnLabel>Add language</btnLabel>
-        <description>Select the language used to create the metadata</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:language" context="gmd:MD_DataIdentification" id="39.0">
-        <label>Language</label>
-        <btnLabel>Add language</btnLabel>
-        <description>Language(s) used within the dataset</description>
-        <help>language(s) used within the dataset</help>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:language" context="gmd:MD_FeatureCatalogueDescription" id="235.0">
-        <label>Language</label>
-        <description>Language(s) used within the catalogue</description>
-    </element>
-    <element name="gmd:lensDistortionInformationAvailability" id="255.0">
-        <label>Lens distortion information availability</label>
-        <description>Indication of whether or not lens aberration correction information is
-            available</description>
-    </element>
-    <element name="gmd:level" id="139.0">
-        <label>Hierarchy level</label>
-        <description>Hierarchical level of the data specified by the scope</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:levelDescription" id="141.0">
-        <label>Level description</label>
-        <description>Detailed description about the level of the data specified by the
-            scope</description>
-        <_condition>Conditional / level not equal 'dataset' or 'series'?</_condition>
-    </element>
-    <element name="gmd:lineage" id="81.0">
-        <label>Lineage</label>
-        <description>Non-quantitative quality information about the lineage of the data specified by
-            the scope</description>
-        <_condition>Conditional / report not provided?</_condition>
-    </element>
-    <element name="gmd:linkage" id="397.0">
-        <label>Linkage</label>
-        <description>Location (address) for on-line access using a Uniform Resource Locator address
-            or similar addressing scheme such as http://www.statkart.no/isotc211</description>
-        <!--<condition>mandatory</condition>-->
-    </element>
-    <element name="gmd:maintenanceAndUpdateFrequency" id="143.0">
-        <label>Maintenance and Update Frequency</label>
-        <description>Frequency with which changes and additions are made to the resource after the initial resource is completed. For continuous monitoring data, select the appropriate value which best describes how often data is collected.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:maintenanceNote" id="148.0">
-        <label>Maintenance note</label>
-        <description>Information regarding specific requirements for maintaining the
-            resource</description>
-    </element>
-    <element name="gmd:maxValue" id="260.0">
-        <label>Maximum value</label>
-        <description>Longest wavelength that the sensor is capable of collecting within a designated
-            band</description>
-    </element>
-    <element name="gmd:maximumValue" id="356.0">
-        <label>Maximum value</label>
-        <description>Highest vertical extent contained in the dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:measureDescription" id="102.0">
-        <label>Measure description</label>
-        <description>Description of the measure being determined</description>
-    </element>
-    <element name="gmd:measureIdentification" id="101.0">
-        <label>Measure identification</label>
-        <description>Code identifying a registered standard procedure</description>
-    </element>
-    <element name="gmd:mediumFormat" id="296.0">
-        <label>Medium format</label>
-        <description>Method used to write to the medium</description>
-    </element>
-    <element name="gmd:mediumNote" id="297.0">
-        <label>Medium note</label>
-        <description>Description of other limitations or requirements for using the
-            medium</description>
-    </element>
-    <element name="gmd:metadataConstraints" id="20.0" context="gmd:MD_Metadata">
-        <label>Metadata constraints</label>
-        <description>Provides restrictions on the access and use of metadata</description>
-    </element>
-    <element name="gmd:metadataConstraints">
-        <label>Metadata constraints</label>
-        <description>Provides restrictions on the access and use of data</description>
-    </element>
-    <element name="gmd:metadataExtensionInfo" id="14.0">
-        <description>Information describing metadata extensions</description>
-        <label>Metadata Extension Information</label>
-    </element>
-    <element name="gmd:metadataMaintenance" id="22.0">
-        <label>Metadata maintenance</label>
-        <description>Provides information about the frequency of metadata updates, and the scope of
-            those updates</description>
-    </element>
-    <element name="gmd:metadataStandardName" id="10.0">
-        <label>Metadata standard name</label>
-        <description>Name of the metadata standard (including profile name) used</description>
-    </element>
-    <element name="gmd:metadataStandardVersion" id="11.0">
-        <label>Metadata standard version</label>
-        <description>Version (profile) of the metadata standard used</description>
-    </element>
-    <element name="gmd:minValue" id="261.0">
-        <label>Minimum value</label>
-        <description>Shortest wavelength that the sensor is capable of collecting within a
-            designated band</description>
-    </element>
-    <element name="gmd:minimumValue" id="355.0">
-        <label>Minimum value</label>
-        <description>Lowest vertical extent contained in the dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:name" context="gmd:MD_AbstractClass" id="560.0">
-        <label>Name</label>
-        <description>Name</description>
-    </element>
-    <element name="gmd:name" context="gmd:MD_Medium" id="292.0">
-        <label>Name</label>
-        <description>Name of the medium on which the resource can be received</description>
-    </element>
-    <element name="gmd:name" context="gmd:RS_ReferenceSystem" id="196.0">
-        <label>Name</label>
-        <description>Name of reference system used</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:name" context="gmd:MD_Format" id="285.0">
-        <label>File Format Name</label>
-        <description>Enter the name of the data transfer format(s). For a list of possible formats, see the 'suggestions' menu</description>
-        <help>name of the data transfer format(s)</help>
-        <condition>mandatory</condition>
-      <!--<helper rel="gmd:version">
-          <option value="Text">Text</option>
-          <option value="ESRI Shapefile" title="1.0">ESRI Shapefile</option>
-          <option value="Mapinfo MIF/MID" title="4.5">Mapinfo MIF/MID</option>
-          <option value="Mapinfo TAB">Mapinfo TAB</option>
-          <option value="KML">KML</option>
-          <option value="GeoTIFF" title="1.0">GeoTIFF</option>
-          <option value="TIFF">TIFF</option>
-          <option value="ECW">ECW</option>
-          <option value="ZIP">ZIP</option
-           <option value="bil">bil</option>
-           <option value="bmp">bmp</option>
-           <option value="bsq">bsq</option>
-           <option value="bzip2">bzip2</option>
-           <option value="cdr">cdr</option>
-           <option value="cgm">cgm</option>
-           <option value="cover">cover</option>
-           <option value="csv">csv</option>
-           <option value="dbf">dbf</option>
-           <option value="dgn">dgn</option>
-           <option value="doc">doc</option>
-           <option value="dwg">dwg</option>
-           <option value="dxf">dxf</option>
-           <option value="e00">e00</option>
-           <option value="ecw">ecw</option>
-           <option value="eps">eps</option>
-           <option value="ers">ers</option>
-           <option value="gdb">gdb</option>
-           <option value="geotiff">GeoTIFF</option>
-           <option value="gif">GIF</option>
-           <option value="gml">gml</option>
-           <option value="grid">grid</option>
-           <option value="gzip">gzip</option>
-           <option value="html">html</option>
-           <option value="jpg">JPG</option>
-           <option value="mdb">mdb</option>
-           <option value="mif">mif</option>
-           <option value="pbm">pbm</option>
-           <option value="pdf" title="1.7">PDF Version 1.7</option>
-           <option value="png">png</option>
-           <option value="ps">ps</option>
-           <option value="rtf">rtf</option>
-           <option value="sdc">sdc</option>
-           <option value="shp">shp</option>
-           <option value="sid">sid</option>
-           <option value="svg">svg</option>
-           <option value="tab">tab</option>
-           <option value="tar">tar</option>
-          <option value="tiff">tiff</option>
-          <option value="txt">txt</option>
-          <option value="xhtml">xhtml</option>
-          <option value="xls">xls</option>
-          <option value="xml" title="1.0">XML Version 1.0</option>
-          <option value="xwd">xwd</option>
-          <option value="zip">zip</option>
-          <option value="wpd">wpd</option>
-      </helper> >-->
-    </element>
-    <element name="gmd:name" context="gmd:MD_ExtendedElementInformation" id="307.0">
-        <label>Name</label>
-        <description>Name of the extended metadata element</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:name" context="gmd:MD_ApplicationSchemaInformation" id="321.0">
-        <label>Name</label>
-        <description>Name of the application schema used</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:name" context="gmd:CI_OnlineResource" id="400.0">
-        <label>Name</label>
-        <description>The name of the data resource</description>
-    </element>
-    <element name="gmd:name" context="gmd:CI_Series" id="404.0">
-        <label>Name</label>
-        <description>Name of the series, or aggregate dataset, of which the dataset is a
-            part</description>
-    </element>
-    <element name="gmd:name" context="gmd:MD_CodeDomain" id="537.0">
-        <label>Name</label>
-        <description>Name of the code domain</description>
-    </element>
-    <element name="gmd:name" context="gmd:MD_CodeValue" id="546.0">
-        <label>Name</label>
-        <description>Value name</description>
-    </element>
-    <element name="gmd:name" context="gmd:MD_Attribute" id="551.0">
-        <label>Name</label>
-        <description>Attribute name</description>
-    </element>
-    <element name="gmd:name" context="gmd:MD_Role" id="556.0">
-        <label>Name</label>
-        <description>Role name</description>
-    </element>
-    <element name="gmd:name">
-        <label>Name</label>
-        <description/>
-    </element>
-    <element name="gmd:nameOfMeasure" id="100.0">
-        <label>Name of measure</label>
-        <description>Name of the test applied to the data</description>
-      <!-- ISO19138 Data quality basic measures Annex C - under revision ISO 19157 http://www.iso.org/iso/fr/catalogue_detail.htm?csnumber=32575 -->
-      <helper rel="gmd:measureDescription">
-        <option value="">-- Completeness --</option>
-        <option value="Excess item" title="Indication that an item is incorrectly present in the data" id="ISO19138:2006:measure:1">Excess item</option>
-        <option value="Number of excess items" title="Number of items within the dataset, that should not have been in the dataset" id="ISO19138:2006:measure:2">Number of excess items</option>
-        <option value="Rate of excess items" title="Number of excess items in the dataset in relation to the number of items that should have been present" id="ISO19138:2006:measure:3">Rate of excess items</option>
-        <option value="Number of duplicate feature instances" title="Total number of exact duplications of feature instances within the data. Count of all items in the data that are incorrectly extracted with duplicate geometrie" id="ISO19138:2006:measure:4">Number of duplicate feature instances</option>
-        <option value="Missing item" title="Indicator that shows that a specific item is missing in the data" id="ISO19138:2006:measure:5">Missing item</option>
-        <option value="Number of missing items" title="Count of all items that should have been in the dataset and are missing" id="ISO19138:2006:measure:6">Number of missing items</option>
-        <option value="Rate of missing items" title="Number of missing items in the dataset in relation to the number of items that should have been present" id="ISO19138:2006:measure:7">Rate of missing items</option>
-        <option value="">-- Logical consistency / Conceptual consistency --</option>
-        <option value="Conceptual schema noncompliance" title="Indication that an item is not compliant to the rules of the relevant conceptual schema" id="ISO19138:2006:measure:8">Conceptual schema noncompliance</option>
-        <option value="Conceptual schema compliance" title="Indication that an item complies with the rules of the relevant conceptual schema" id="ISO19138:2006:measure:9">Conceptual schema compliance</option>
-        <option value="Number of items noncompliant to the rules of the conceptual schema" title="Count of all items in the dataset that are noncompliant to the rules of the conceptual schema. If the conceptual schema explicitly or implicitly describes rules, these rules have to be followed. Violations against such rules can e.g. be invalid placement of features within a defined tolerance, duplication of features and invalid overlap of features." id="ISO19138:2006:measure:10">Number of items noncompliant to the rules of the conceptual schema</option>
-        <option value="Number of invalid overlaps of surfaces" title="Total number of erroneous overlaps within the data Which surfaces may overlap and which must not is application dependent. Not all overlapping surfaces are necessarily erroneous. When reporting this data quality measure the types of feature classes corresponding to the illegal overlapping surfaces have to be reported as well." id="ISO19138:2006:measure:11">Number of invalid overlaps of surfaces</option>
-        <option value="Non-compliance rate with respect to the rules of the conceptual schema" title="Number of items in the dataset that are noncompliant to the rules of the conceptual schema in relation to the total number of these items supposed to be in the dataset" id="ISO19138:2006:measure:12">Non-compliance rate with respect to the rules of the conceptual schema</option>
-        <option value=" Compliance rate with the rules of the conceptual schema" title="number of items in the dataset in compliance with the rules of the conceptual schema in relation to the total number of items" id="ISO19138:2006:measure:13"> Compliance rate with the rules of the conceptual schema</option>
-        <option value="">-- Logical consistency / Domain consistency --</option>
-        <option value="Value domain non-conformance" title="Indication of if an item is not in conformance with its value domain" id="ISO19138:2006:measure:14">Value domain non-conformance</option>
-        <option value="Value domain conformance" title="Indication of if an item is conforming to its value domain" id="ISO19138:2006:measure:15">Value domain conformance</option>
-        <option value="Number of items not in conformance with their value domain" title="Count of all items in the dataset that are not in conformance with their value domain." id="ISO19138:2006:measure:16">Number of items not in conformance with their value domain</option>
-        <option value="Value domain conformance rate" title="Number of items in the dataset that are in conformance with their value domain in relation to the total number of items in the dataset" id="ISO19138:2006:measure:17">Value domain conformance rate</option>
-        <option value="Value domain non-conformance rate" title="the number of items in the dataset that are not in conformance with their value domain in relation to the total number of items" id="ISO19138:2006:measure:18">Value domain non-conformance rate</option>
-        <option value="Physical structure conflicts" title="Count of all items in the dataset that are stored in conflict with the physical structure of the dataset" id="ISO19138:2006:measure:19">Physical structure conflicts</option>
-        <option value="Physical structure conflict rate" title="Number of items in the dataset that are stored in conflict with the physical structure of the dataset divided by the total number of items" id="ISO19138:2006:measure:20">Physical structure conflict rate</option>
-        <option value="">-- Logical consistency / Topological consistency --</option>
-        <option value="Number of faulty point-curve connections" title="Number of faulty point-curve connections in the dataset. A point-curve connection exists where different curves touch. These curves have an intrinsic topological relationship that has to reflect the true constellation. If the point-curve connection contradicts the universe of discourse, the point-curve connection is faulty with respect to this data quality measure. The data quality measure counts the number of errors of this kind." id="ISO19138:2006:measure:21">Number of faulty point-curve connections</option>
-        <option value="Rate of faulty point-curve connections" title="Number of faulty link node connections in relation to the number of supposed link node connections" id="ISO19138:2006:measure:22">Rate of faulty point-curve connections</option>
-        <option value="Number of missing connection due to undershoots" title="Count of items in the dataset, within the parameter tolerance, that are mismatched due to undershoots" id="ISO19138:2006:measure:23">Number of missing connection due to undershoots</option>
-        <option value="Number of missing connections due to overshoots" title="Count of items in the dataset, within the parameter tolerance, that are mismatched due to overshoots" id="ISO19138:2006:measure:24">Number of missing connections due to overshoots</option>
-        <option value="Number of invalid slivers" title="Count of all items in the dataset that are invalid sliver surfaces. A sliver is an unintended area that occurs when adjacent surfaces are not digitized properly. The borders of the adjacent surfaces may unintentionally gap or overlap by small amounts to cause a topological error." id="ISO19138:2006:measure:25">Number of invalid slivers</option>
-        <option value="Number of invalid self intersect errors" title="Count of all items in the data that illegally intersect with themselves" id="ISO19138:2006:measure:26">Number of invalid self intersect errors</option>
-        <option value="Number of invalid self overlap errors" title="Count of all items in the data that illegally self overlap" id="ISO19138:2006:measure:27">Number of invalid self overlap errors</option>
-        <option value="">-- Positional accuracy / Absolute or external accuracy / General measures --</option>
-        <option value="Mean value of positional uncertainties" title="Mean value of the positional uncertainties for a set of positions where the positional uncertainties are defined as the distance between a measured position and what is considered as the corresponding true position" id="ISO19138:2006:measure:28">Mean value of positional uncertainties</option>
-        <option value="Mean value of positional uncertainties excluding outliers" title="For a set of points where the distance does not exceed a defined threshold the arithmetical average of distances between their measured positions and what is considered as the corresponding true positions" id="ISO19138:2006:measure:29">Mean value of positional uncertainties excluding outliers</option>
-        <option value="Number of positional uncertainties above a given threshold" title="Number of positional uncertainties above a given threshold for a set of positions. The errors are defined as the distance between a measured position and what is considered as the corresponding true position" id="ISO19138:2006:measure:30">Number of positional uncertainties above a given threshold</option>
-        <option value="Rate of positional errors above a given threshold" title="Number of positional uncertainties above a given threshold for a set of positions in relation to the total number of measured positions. The errors are defined as the distance between a measured position and what is considered as the corresponding true position." id="ISO19138:2006:measure:31">Rate of positional errors above a given threshold</option>
-        <option value="Covariance matrix" title="A symmetrical square matrix with variances of point coordinates on the main diagonal and covariances between these coordinates as off-diagonal elements." id="ISO19138:2006:measure:32">Covariance matrix</option>
-        <option value="">-- Positional accuracy / Absolute or external accuracy / Vertical --</option>
-        <option value="Linear error probable" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 50%." id="ISO19138:2006:measure:33">Linear error probable</option>
-        <option value="Standard linear error" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 68.3%." id="ISO19138:2006:measure:34">Standard linear error</option>
-        <option value="Linear map accuracy at 90% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 90%." id="ISO19138:2006:measure:35">Linear map accuracy at 90% significance level</option>
-        <option value="Linear map accuracy at 95% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 95%." id="ISO19138:2006:measure:36">Linear map accuracy at 95% significance level</option>
-        <option value="Linear map accuracy at 99% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 99%." id="ISO19138:2006:measure:37">Linear map accuracy at 99% significance level</option>
-        <option value="Near certainty linear error" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 99.8%." id="ISO19138:2006:measure:38">Near certainty linear error</option>
-        <option value="Root mean square error" title="Standard deviation, where the true value is not estimated from the observations but known a priori." id="ISO19138:2006:measure:39">Root mean square error</option>
-        <option value="Absolute linear error at 90% significance level of biased vertical data (Alternative 1)" title="The absolute vertical accuracy of the data’s coordinates, expressed in terms of linear error at 90% probability given that a bias is present." id="ISO19138:2006:measure:40">Absolute linear error at 90% significance level of biased vertical data (Alternative 1)</option>
-        <option value="Absolute linear error at 90% significance level of biased vertical data" title="The absolute vertical accuracy of the data’s coordinates, expressed in terms of linear error at 90% probability given that a bias is present." id="ISO19138:2006:measure:41">Absolute linear error at 90% significance level of biased vertical data</option>
-        <option value="">-- Positional accuracy / Absolute or external accuracy / Horizontal --</option>
-        <option value="Circular standard deviation" title="Radius describing a circle, in which the true point location lies with the probability of 39.4%." id="ISO19138:2006:measure:42">Circular standard deviation</option>
-        <option value="Circular error probable" title="Radius describing a circle, in which the true point location lies with the probability of 50%." id="ISO19138:2006:measure:43">Circular error probable</option>
-        <option value=" Circular map accuracy standard" title="Radius describing a circle, in which the true point location lies with the probability of 90%." id="ISO19138:2006:measure:44"> Circular map accuracy standard</option>
-        <option value="Circular error at 95% significance level" title="Radius describing a circle, in which the true point location lies with the probability of 95%." id="ISO19138:2006:measure:45">Circular error at 95% significance level</option>
-        <option value="Circular near certainty error" title="Radius describing a circle, in which the true point location lies with the probability of 99.8%." id="ISO19138:2006:measure:46">Circular near certainty error</option>
-        <option value="Root mean square error of planimetry" title="Radius of a circle around the given point, in which the true value lies with probability P." id="ISO19138:2006:measure:47">Root mean square error of planimetry</option>
-        <option value="Absolute circular error at 90% significance level of biased data (Alternative 2)" title="The absolute horizontal accuracy of the data’s coordinates, expressed in terms of circular error at 90% probability given that a bias is present." id="ISO19138:2006:measure:48">Absolute circular error at 90% significance level of biased data (Alternative 2)</option>
-        <option value="Absolute circular error at 90% significance level of biased data" title="The absolute horizontal accuracy of the data’s coordinates, expressed in terms of circular error at 90% probability given that a bias is present." id="ISO19138:2006:measure:49">Absolute circular error at 90% significance level of biased data</option>
-        <option value="Uncertainty ellipse" title="2D ellipse with the two main axes indicating the direction and magnitude of the highest and the lowest uncertainty of a 2D point" id="ISO19138:2006:measure:50">Uncertainty ellipse</option>
-        <option value="Confidence ellipse" title="2D ellipse with the two main axes indicating the direction and magnitude of the highest and the lowest uncertainty of a 2D point" id="ISO19138:2006:measure:51">Confidence ellipse</option>
-        <option value="">-- Positional accuracy / Relative or internal accuracy --</option>
-        <option value="Relative vertical error" title="Evaluation of the random errors of one relief feature to another in the same dataset or on the same map/chart. It is a function of the random errors in the two elevations with respect to a common vertical datum." id="ISO19138:2006:measure:52">Relative vertical error</option>
-        <option value="Relative horizontal error" title="Evaluation of the random errors in the horizontal position of one feature to another in the same dataset or on the same map/chart." id="ISO19138:2006:measure:53">Relative horizontal error</option>
-        <option value="">-- Temporal accuracy / Accuracy of a time measurement --</option>
-        <option value="Time accuracy at 68.3% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 68.3%." id="ISO19138:2006:measure:54">Time accuracy at 68.3% significance level</option>
-        <option value="Time accuracy at 50% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 50%." id="ISO19138:2006:measure:55">Time accuracy at 50% significance level</option>
-        <option value="Time accuracy at 90% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 90%." id="ISO19138:2006:measure:56">Time accuracy at 90% significance level</option>
-        <option value="Time accuracy at 95% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 95%." id="ISO19138:2006:measure:57">Time accuracy at 95% significance level</option>
-        <option value="Time accuracy at 99% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 99%." id="ISO19138:2006:measure:58">Time accuracy at 99% significance level</option>
-        <option value="Time accuracy at 99.8% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 99.8%." id="ISO19138:2006:measure:59">Time accuracy at 99.8% significance level</option>
-        <option value="">-- Thematic accuracy / Classification correctness --</option>
-        <option value="Number of incorrectly classified features" title="Number of incorrectly classified features" id="ISO19138:2006:measure:60">Number of incorrectly classified features</option>
-        <option value="Misclassification rate" title="number of incorrectly classified features in relation to the number of features that are supposed to be there" id="ISO19138:2006:measure:61">Misclassification rate</option>
-        <option value="Misclassification matrix" title="matrix that indicates the number of items of class (i) classified as class (j)." id="ISO19138:2006:measure:62">Misclassification matrix</option>
-        <option value="Relative misclassification matrix" title="matrix that indicates the number of items of class (i) classified as class (i) divided by the number of items of class (i)" id="ISO19138:2006:measure:63">Relative misclassification matrix</option>
-        <option value="Kappa coefficient" title="Coefficient to quantify the proportion of agreement of assignments to classes by removing misclassifications" id="ISO19138:2006:measure:64">Kappa coefficient</option>
-        <option value="">-- Thematic accuracy / Non-quantitative attribute correctness --</option>
-        <option value="Number of incorrect attribute values" title="Total number of erroneous attribute values within the relevant part of the dataset" id="ISO19138:2006:measure:65">Number of incorrect attribute values</option>
-        <option value="Rate of correct attribute values" title="Number of correct attribute values in relation to the total number of attribute values" id="ISO19138:2006:measure:66">Rate of correct attribute values</option>
-        <option value="Rate of incorrect attribute values" title="Number of attribute values where incorrect values are assigned in relation to the total number of attribute values" id="ISO19138:2006:measure:67">Rate of incorrect attribute values</option>
-        <option value="">-- Thematic accuracy / Quantitative attribute accuracy --</option>
-        <option value="Attribute value uncertainty at 68.3% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 68.3%." id="ISO19138:2006:measure:68">Attribute value uncertainty at 68.3% significance level</option>
-        <option value="Attribute value uncertainty at 50% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 50%." id="ISO19138:2006:measure:69">Attribute value uncertainty at 50% significance level</option>
-        <option value="Attribute value uncertainty at 90% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 90%." id="ISO19138:2006:measure:70">Attribute value uncertainty at 90% significance level</option>
-        <option value="Attribute value uncertainty at 95% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 95%." id="ISO19138:2006:measure:71">Attribute value uncertainty at 95% significance level</option>
-        <option value="Attribute value uncertainty at 99% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 99%." id="ISO19138:2006:measure:72">Attribute value uncertainty at 99% significance level</option>
-        <option value="Attribute value uncertainty at 99.8% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 99.8%." id="ISO19138:2006:measure:73">Attribute value uncertainty at 99.8% significance level</option>
-      </helper>
-    </element>
-    <element name="gmd:northBoundLatitude" id="347.0">
-        <label>North bound</label>
-        <description>Northern-most, coordinate of the limit of the dataset extent expressed in
-            latitude in decimal degrees (positive north)</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:numberOfDimensions" id="158.0">
-        <label>Number of dimensions</label>
-        <description>Number of independent spatial-temporal axes</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:obligation" id="311.0">
-        <label>Obligation</label>
-        <description>Obligation of the extended element</description>
-    </element>
-    <element name="gmd:offLine" id="278.0">
-        <label>Offline</label>
-        <description>Information about offline media on which the resource can be
-            obtained</description>
-    </element>
-    <element name="gmd:offset" id="267.0">
-        <label>Offset</label>
-        <description>The physical value corresponding to a cell value of zero</description>
-    </element>
-    <element name="gmd:onLine" id="277.0">
-        <label>Online Resource</label>
-        <description>Information about online sources from which the resource can be
-            obtained</description>
-    </element>
-    <element name="gmd:onlineResource" id="390.0">
-        <help>Define URL to access the website</help>
-        <label>Website</label>
-        <description>On-line information that can be used to contact the individual or
-            organisation</description>
-    </element>
-    <element name="gmd:orderingInstructions" id="301.0">
-        <label>Ordering instructions</label>
-        <description>General instructions, terms and services provided by the
-            distributor</description>
-    </element>
-    <element name="gmd:organisationName" id="376.0">
-        <label>Organization Name</label>
-        <description>Name of the responsible organization</description>
-        <!--<condition>conditional</condition>-->
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:orientationParameterAvailability" id="172.0">
-        <label>Orientation parameter availability</label>
-        <description>Indication of whether or not orientation parameters are available</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:orientationParameterDescription" id="173.0">
-        <label>Orientation parameter description</label>
-        <description>Description of parameters used to describe sensor orientation</description>
-    </element>
-    <element name="gmd:other" id="155.0">
-        <label>Other</label>
-        <description>Class of information that does not fall into the other categories to which the
-            information applies</description>
-        <condition/>
-    </element>
-    <element name="gmd:otherCitationDetails" id="370.0">
-        <label>Other citation details</label>
-        <description>Other information required to complete the citation that is not recorded
-            elsewhere</description>
-    </element>
-    <element name="gmd:otherConstraints" id="72.0">
-        <label>Other constraints</label>
-        <description>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:page" id="406.0">
-        <label>Page</label>
-        <description>Details on which pages of the publication the article was
-            published</description>
-    </element>
-    <element name="gmd:parameterCitation" id="175.0">
-        <label>Parameter citation</label>
-        <description>Reference providing description of the parameters</description>
-    </element>
-    <element name="gmd:parentEntity" id="316.0">
-        <label>Parent entity</label>
-        <description>Name of the metadata entity(s) under which this extended metadata element may
-            appear. The name(s) may be standard metadata element(s) or other extended metadata
-            element(s).</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:parentIdentifier" id="5.0">
-        <label>Parent identifier</label>
-        <description>File identifier of the metadata to which this metadata is a subset
-            (child)</description>
-    </element>
-    <element name="gmd:pass" id="132.0">
-        <label>Pass</label>
-        <description>Indication of the conformance result where 0 = fail and 1 = pass</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:peakResponse" id="263.0">
-        <label>Peak response</label>
-        <description>Wavelength at which the response is the highest</description>
-    </element>
-    <element name="gmd:phone" id="526.0">
-        <label>Phone</label>
-        <description>Telephone numbers at which the organization or individual may be
-            contacted</description>
-    </element>
-    <element name="gmd:plannedAvailableDateTime" id="300.0">
-        <label>Planned available datetime</label>
-        <description>Date and time when the dataset will be available
-            (CCYY-MM-DDThh:mm:ss)</description>
-    </element>
-    <element name="gmd:pointInPixel" id="167.0">
-        <label>Point in Pixel</label>
-        <description>Point in a pixel corresponding to the Earth location of the pixel</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:pointOfContact" id="29.0">
-        <label>Point of Contact</label>
-        <description>Identification of, and means of communication with, person(s) and
-        organizations(s) associated with the resource(s)</description>
-    </element>
-    <element name="gmd:polygon" id="342.0">
-        <label>Polygon</label>
-        <description>Sets of points defining the bounding polygon</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:portrayalCatalogueCitation" id="269.0">
-        <label>Portrayal catalogue citation</label>
-        <description>Bibliographic reference to the portrayal catalogue cited</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:portrayalCatalogueInfo" id="19.0">
-        <label>Portrayal catalogue info</label>
-        <description>Provides information about the catalogue of rules defined for the portrayal of
-            a resource(s)</description>
-    </element>
-    <element name="gmd:positionName" id="377.0">
-        <label>Position Name</label>
-        <description>Role or position of the responsible person</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:postalCode" id="384.0">
-        <label>Postal Code / ZIP Code</label>
-        <description>Postal Code or other ZIP code</description>
-    </element>
-    <element name="gmd:presentationForm" id="368.0">
-        <label>Presentation form</label>
-        <description>Mode in which the resource is represented</description>
-    </element>
-    <element name="gmd:processStep" id="84.0">
-        <label>Process step</label>
-        <description>Information about an event in the creation process for the data specified by
-            the scope</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:processingLevelCode" id="249.0">
-        <label>Processing level code</label>
-        <description>Image distributor_s code that identifies the level of radiometric and geometric
-            processing that has been applied</description>
-    </element>
-    <element name="gmd:processor" id="90.0">
-        <label>Processor</label>
-        <description>Identification of, and means of communication with, person(s) and
-            organization(s) associated with the process step</description>
-    </element>
-    <element name="gmd:protocol" id="398.0" alias="protocol">
-        <label>Protocol</label>
-        <description>Select the appropriate protocol from the drop down list. If your dataset is available online, select 'web address (URL)'</description>
-      <helper sort="true">
-        <option value="HTTP">HTTP</option>
-        <option value="HTTPS">HTTPS</option>
-        <option value="FTP">FTP</option>
-        <option value="ESRI REST: Map Service">ESRI REST: Map Service</option>
-      </helper>
-    </element>
-    <element name="gmd:purpose" id="26.0">
-        <label>Purpose</label>
-        <description>Summary of the intentions with which the resource(s) was
-            developed</description>
-    </element>
-    <element name="gmd:radiometricCalibrationDataAvailability" id="252.0">
-        <label>Radiometric calibration data availability</label>
-        <description>Indication of whether or not the radiometric calibration information for
-            generating the radiometrically calibrated standard data product is
-            available</description>
-    </element>
-    <element name="gmd:rationale" id="88.0">
-        <label>Rationale</label>
-        <description>Requirement or purpose for the process step</description>
-    </element>
-    <element name="gmd:rationale" id="318.0" context="gmd:MD_ExtendedElementInformation">
-        <label>Rationale</label>
-        <description>Reason for creating the extended element</description>
-    </element>
-    <element name="gmd:referenceSystemIdentifier" id="187.0">
-        <label>Reference system identifier</label>
-        <description>Name of reference system</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:referenceSystemInfo" id="13.0">
-        <label>Reference System Information</label>
-        <btnLabel>Add Reference System Information</btnLabel>
-        <description>Description of the spatial and temporal reference systems used in the
-            dataset</description>
-    </element>
-    <element name="gmd:report" id="80.0">
-        <label>Report</label>
-        <description>Quantitative quality information for the data specified by the
-            scope</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:resolution" id="182.0">
-        <label>Resolution</label>
-        <description>Degree of detail in the grid dataset</description>
-    </element>
-    <element name="gmd:resourceConstraints" id="35.0">
-        <label>Resource constraints</label>
-        <description>Provides information about constraints which apply to the
-            resource(s)</description>
-    </element>
-    <element name="gmd:resourceFormat" id="32.0">
-        <label>Resource format</label>
-        <description>Provides a description of the format of the resource(s)</description>
-    </element>
-    <element name="gmd:resourceMaintenance" id="30.0">
-        <label>Resource maintenance</label>
-        <description>Provides information about the frequency of resource updates, and the scope of
-            those updates</description>
-    </element>
-    <element name="gmd:resourceSpecificUsage" id="34.0">
-        <label>Resource specific usage</label>
-        <description>Provides basic information about specific application(s) for which the
-            resource(s) has/have been or is being used by different users</description>
-    </element>
-    <element name="gmd:result" id="107.0">
-        <label>Result</label>
-        <description>Value (or set of values) obtained from applying a data quality measure or the
-            out come of evaluating the obtained value (or set of values) against a specified
-            acceptable conformance quality level</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:role" id="566.0" context="gmd:MD_Association">
-        <label>Role</label>
-        <description>Reference to the ends (roles) of a concrete association</description>
-    </element>
-    <element name="gmd:role" id="379.0">
-        <label>Role</label>
-        <description>Select the appropriate role from the list provided. The role of Data Steward identifies the individual who is accountable for the dataset.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:rule" id="317.0">
-        <label>Rule</label>
-        <description>Specifies how the extended element relates to other existing elements and
-            entities</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:scaleDenominator" id="94.0">
-        <label>Scale Denominator</label>
-        <description>Denominator of the representative fraction on a source map</description>
-    </element>
-    <element name="gmd:scaleFactor" id="266.0">
-        <label>Scale factor</label>
-        <description>Scale factor which has been applied to the cell value</description>
-    </element>
-    <element name="gmd:schemaAscii" id="324.0">
-        <description>Full application schema given as an ASCII file</description>
-        <label>Schema ASCII</label>
-    </element>
-    <element name="gmd:schemaLanguage" id="322.0">
-        <label>Schema language</label>
-        <description>Identification of the schema language used</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:scope" id="79.0">
-        <label>Scope</label>
-        <description>The specific data to which the data quality information applies</description>
-    </element>
-    <element name="gmd:sequenceIdentifier" id="257.0">
-        <label>Sequence identifier</label>
-        <description>Number that uniquely identifies instances of bands of wavelengths on which a
-            sensor operates</description>
-    </element>
-    <element name="gmd:series" id="369.0">
-        <label>Series</label>
-        <description>Information about the series, or aggregate dataset, of which the dataset is a
-            part</description>
-    </element>
-    <element name="gmd:shortName" id="308.0">
-        <label>Short name</label>
-        <description>Short form suitable for use in an implementation method such as XML or SGML.
-            NOTE other methods may be used</description>
-    </element>
-    <element name="gmd:softwareDevelopmentFile" id="326.0">
-        <label>Software development file</label>
-        <description>Full application schema given as a software development file</description>
-    </element>
-    <element name="gmd:softwareDevelopmentFileFormat" id="327.0">
-        <label>Software development file format</label>
-        <description>Software dependent format used for the application schema software dependent
-            file</description>
-    </element>
-    <element name="gmd:source" id="85.0">
-        <label>Source</label>
-        <description>Information about the source data used in creating the data specified by the
-            scope</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:source" id="319.0" context="gmd:MD_ExtendedElementInformation">
-        <condition>mandatory</condition>
-        <label>Source</label>
-        <description>Name of the person or organization creating the extended element</description>
-    </element>
-    <element name="gmd:sourceCitation" id="96.0">
-        <label>Source citation</label>
-        <description>Recommended reference to be used for the source data</description>
-    </element>
-    <element name="gmd:sourceExtent" id="97.0">
-        <label>Source extent</label>
-        <description>Information about the spatial, vertical and temporal extent of the source
-            data</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:sourceReferenceSystem" id="95.0">
-        <label>Source reference system</label>
-        <description>Spatial reference system used by the source data</description>
-    </element>
-    <element name="gmd:sourceStep" id="98.0">
-        <label>Source step</label>
-        <description>Information about an event in the creation process for the source
-            data</description>
-    </element>
-    <element name="gmd:southBoundLatitude" id="346.0">
-        <label>South bound</label>
-        <description>Southern-most coordinate of the limit of the dataset extent, expressed in
-            latitude in decimal degrees (positive north)</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:spatialExtent" id="353.0">
-        <label>Spatial extent</label>
-        <description>Spatial extent component of composite spatial and temporal extent</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:spatialRepresentationInfo" id="12.0">
-        <label>Spatial representation info</label>
-        <description>Digital representation of spatial information in the dataset</description>
-    </element>
-    <element name="gmd:spatialRepresentationType" id="37.0">
-        <label>Spatial representation type</label>
-        <description>Method used to spatially represent geographic information</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:spatialResolution" id="38.0">
-        <label>Spatial resolution</label>
-        <description>Factor which provides a general understanding of the density of spatial data in
-            the dataset</description>
-    </element>
-    <element name="gmd:specificUsage" id="63.0">
-        <label>Specific usage</label>
-        <description>Brief description of the resource and/or resource series usage</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:specification" id="130.0" context="gmd:DQ_ConformanceResult">
-        <condition>mandatory</condition>
-        <label>Specification</label>
-        <description>Citation of product specification or user requirement against which data is
-            being evaluated</description>
-    </element>
-    <element name="gmd:specification" id="288.0" context="gmd:MD_Format">
-        <label>Specification</label>
-        <description>Name of a subset, profile, or product specification of the format</description>
-    </element>
-    <element name="gmd:specification">
-        <label>Specification</label>
-    </element>
-    <element name="gmd:statement" id="83.0">
-        <label>Statement</label>
-        <description>General explanation of the data producer_s knowledge about the lineage of a
-            dataset</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:status" id="28.0">
-        <label>Status</label>
-        <btnLabel>Add status</btnLabel>
-        <description>Select the status of the dataset from the list. i.e.. If your dataset is not yet complete, select 'Planned'.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:supplementalInformation" id="46.0">
-        <label>Supplemental Information</label>
-        <description>This field can be used to provide any additional information about the dataset not captured in the form. Use it to link to program information, data quality reports, data dictionaries, etc.</description>
-    </element>
-    <element name="gmd:temporalElement" id="337.0">
-        <label>Temporal element</label>
-        <description>Provides temporal component of the extent of the referring object</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:textGroup" id="602.0">
-        <label>TextGroup</label>
-        <description>TextGroup</description>
-    </element>
-    <element name="gmd:thesaurusName" id="55.0">
-        <label>Thesaurus name</label>
-        <description>You can add a keyword from a list by first selecting your thesaurus here. Once you select a thesaurus the keyword field will provide you with a drop-down menu to choose from. </description>
-    </element>
-    <element name="gmd:title" id="360.0">
-        <label>Title</label>
-        <description>Identifies the title of the resource being described. Enter the full, official name by which the cited resource is known</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:title" id="507.0" context="gmd:MD_Legislation">
-        <label>Title</label>
-        <description>Reference to legal title</description>
-    </element>
-    <element name="gmd:toneGradation" id="265.0">
-        <label>Tone gradation</label>
-        <description>Number of discrete numerical values in the grid data</description>
-    </element>
-    <element name="gmd:topicCategory" id="41.0">
-        <label>Topic category</label>
-        <btnLabel>Add topic category</btnLabel>
-        <description>Please select the most appropriate category from the list provided. These categories help to group datasets for easier discovery. This element is repeatable; select all category codes that apply to the dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:MD_TopicCategoryCode">
-        <label>Topic category</label>
-        <description>Please select the most appropriate category from the list provided. These categories help to group datasets for easier discovery. This element is repeatable; select all category codes that apply to the dataset</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:topologyLevel" id="177.0">
-        <label>Topology level</label>
-        <description>Code which identifies the degree of complexity of the spatial
-            relationships</description>
-    </element>
-    <element name="gmd:transferOptions" id="273.0">
-        <label>Transfer options</label>
-        <description>Provides information about technical means and media by which a resource is
-            obtained from the distributor</description>
-    </element>
-    <element name="gmd:transferSize" id="276.0">
-        <label>Transfer size</label>
-        <description>Estimated size of a unit in the specified transfer format, expressed in
-            megabytes. The transfer size is &gt; 0.0</description>
-    </element>
-    <element name="gmd:transformationDimensionDescription" id="168.0">
-        <label>Transformation dimension description</label>
-        <description>Description of the information about which grid dimensions are the spatial
-            dimensions</description>
-    </element>
-    <element name="gmd:transformationDimensionMapping" id="169.0">
-        <label>Transformation dimension mapping</label>
-        <description>Information about which grid dimensions are the spatial
-            dimensions</description>
-    </element>
-    <element name="gmd:transformationParameterAvailability" id="161.0">
-        <label>Transformation parameter availability</label>
-        <condition>mandatory</condition>
-        <description>Indication of whether or not parameters for transformation between image
-            coordinates and geographic or map coordinates exist (are available)</description>
-    </element>
-    <element name="gmd:triangulationIndicator" id="251.0">
-        <label>Triangulation indicator</label>
-        <description>Indication of whether or not triangulation has been performed upon the
-            image</description>
-    </element>
-    <element name="gmd:turnaround" id="302.0">
-        <label>Turnaround</label>
-        <description>Typical turnaround time for the filling of an order</description>
-    </element>
-    <element name="gmd:type" id="54.0">
-        <label>Type</label>
-        <description>Subject matter used to group similar keywords. Select the most appropriate from the list.</description>
-    </element>
-    <element name="gmd:type" id="540.0" context="gmd:MD_CodeDomain">
-        <label>Type</label>
-        <description>Datatype of the code domain</description>
-    </element>
-    <element name="gmd:type" id="543.0" context="gmd:MD_Type">
-        <label>Type definition</label>
-        <description>Data type definition</description>
-        <help>Data type definition, formal of informal (i.e. Text12, Line)</help>
-    </element>
-    <element name="gmd:units" id="262.0">
-        <label>Value unit</label>
-        <description>Units in which sensor wavelengths are expressed</description>
-    </element>
-    <element name="gmd:unitsOfDistribution" id="275.0">
-        <label>Units of distribution</label>
-        <description>Tiles, layers, geographic areas, etc., in which data is available</description>
-    </element>
-    <element name="gmd:updateScope" id="146.0">
-        <label>Update scope</label>
-        <description>Scope of data to which maintenance is applied</description>
-    </element>
-    <element name="gmd:updateScopeDescription" id="147.0">
-        <label>Update scope description</label>
-        <description>Additional information about the range or extent of the resource</description>
-    </element>
-    <element name="gmd:usageDateTime" id="64.0">
-        <label>Usage datetime</label>
-        <description>Date and time of the first use or range of uses of the resource and/or resource
-            series (YYYY-MM-DDThh:mm:ss)</description>
-    </element>
-    <element name="gmd:useConstraints" id="71.0">
-        <label>Use Constraints</label>
-        <description>This element allows you to indicate any additional or special restrictions or limitations that may exist on use of the resource, outside of those which are covered by existing departmental restrictions.</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:useLimitation" id="68.0">
-        <label>Use Limitation</label>
-        <description>Limitation affecting the fitness for use of the resource. Example, _not to be
-            used for navigation_</description>
-      <condition>mandatory</condition>
-    </element>
-    <element name="gmd:userContactInfo" id="66.0">
-        <label>User contact info</label>
-        <description>Identification of and means of communicating with person(s) and organization(s)
-            using the resource(s)</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:userDefinedMaintenanceFrequency" id="145.0">
-        <label>User defined maintenance frequency</label>
-        <description>Maintenance period other than those defined</description>
-    </element>
-    <element name="gmd:userDeterminedLimitations" id="65.0">
-        <label>User determined limitations</label>
-        <description>Applications, determined by the user for which the resource and/or resource
-            series is not suitable</description>
-    </element>
-    <element name="gmd:userNote" id="75.0">
-        <label>Security User note</label>
-        <description>Explanation of the application of the legal constraints or other restrictions
-            and legal prerequisites for obtaining and using the resource or metadata</description>
-    </element>
-    <element name="gmd:value" id="137.0" context="gmd:DQ_QuantitativeResult">
-        <condition>mandatory</condition>
-        <label>Value</label>
-        <description>Quantitative value or values, content determined by the evaluation procedure
-            used</description>
-    </element>
-    <element name="gmd:value">
-        <label>Value</label>
-        <description/>
-    </element>
-    <element name="gmd:value" id="544.0" context="gmd:MD_Type">
-        <label>Value</label>
-        <description>Data type value</description>
-    </element>
-    <element name="gmd:valueType" id="134.0">
-        <label>Value type</label>
-        <description>Quantitative conformance quality level value or range of values</description>
-      <helper>
-        <option value="Boolean">Boolean</option>
-        <option value="Real">Real</option>
-        <option value="Integer">Integer</option>
-        <option value="Ratio">Ratio</option>
-        <option value="Percentage">Percentage</option>
-        <option value="Measure(s) (value(s) + unit(s))">Measure(s) (value(s) + unit(s))</option>
-      </helper>
-    </element>
-    <element name="gmd:valueUnit" id="135.0">
-        <label>Value unit</label>
-        <description>Value unit for reporting a data quality result</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gmd:version" id="208.2" context="gmd:RS_Identifier">
-        <label>Version</label>
-        <description>Version identifier for the namespace</description>
-    </element>
-    <element name="gmd:version" context="gmd:MD_Format" id="286.0">
-        <label>File Format Version</label>
-        <description>Enter the version of the data transfer format(s). For a list of possible versions, see the 'suggestions' menu. If the version is unknown, enter "unknown"</description>
-    </element>
-    <element name="gmd:verticalElement" id="338.0">
-        <label>Vertical element</label>
-        <description>Provides vertical component of the extent of the referring object</description>
-        <condition>conditional</condition>
-    </element>
-    <element name="gmd:voice" id="408.0">
-        <label>Telephone Number (Voice)</label>
-        <description>Telephone number by which individuals can speak to the responsible organization or individual</description>
-    </element>
-    <element name="gmd:volumes" id="295.0">
-        <label>Volumes</label>
-        <description>Number of items in the media identified</description>
-    </element>
-    <element name="gmd:westBoundLongitude" id="344.0">
-        <label>West bound</label>
-        <description>Western-most coordinate of the limit of the dataset extent, expressed in
-            longitude in decimal degrees (positive east)</description>
-        <condition>mandatory</condition>
-    </element>
-    <element name="gml:beginPosition">
-        <label>Begin Date</label>
-        <description>Enter the date on which data collection began or is scheduled to begin. You may use the calendar to select the date or enter it in YYYY-MM-DD format for full date, YYYY-MM format for month/year or YYYY format for year.</description>
-    </element>
+  </element>
+  <element name="gmd:density" id="293.0">
+    <label>Density</label>
+    <description>Density at which the data is recorded</description>
+  </element>
+  <element name="gmd:densityUnits" id="294.0">
+    <label>Density units</label>
+    <description>Units of measure for the recording density</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:description" id="561.0">
+    <label>Description</label>
+    <description>Description of the event, including related parameters or
+      tolerances</description>
+  </element>
+  <element name="gmd:description" id="561.0" context="gmd:MD_AbstractClass">
+    <label>Description</label>
+    <description>Description</description>
+  </element>
+  <element name="gmd:description" id="87.0" context="LI_ProcessStep">
+    <condition>mandatory</condition>
+    <label>Description</label>
+    <description>Description of the event, including related parameters or
+      tolerances</description>
+  </element>
+  <element name="gmd:description" id="93.0" context="LI_Source">
+    <label>Description</label>
+    <description>Detailed description of the level of the source data</description>
+    <_condition>Conditional / sourceExtent not provided?</_condition>
+  </element>
+  <element name="gmd:description" id="335.0" context="gmd:EX_Extent">
+    <label>Description</label>
+    <description>Spatial and temporal extent for the referring object</description>
+    <_condition>Conditional / geographicElement and temporalElement and verticalElement not
+      documented?</_condition>
+  </element>
+  <element name="gmd:description" id="401.0" context="gmd:CI_OnlineResource">
+    <label>Description</label>
+    <description>Detailed text description of what the online resource is/does</description>
+  </element>
+  <element name="gmd:description" id="541.0" context="gmd:MD_CodeDomain">
+    <label>Description</label>
+    <description>Description of the code domain</description>
+  </element>
+  <element name="gmd:description" id="549.0" context="gmd:MD_CodeValue">
+    <label>Value description</label>
+    <description>Description of the value</description>
+  </element>
+  <element name="gmd:description" id="552.0" context="gmd:MD_Attribute">
+    <label>Description</label>
+    <description>Attribute description</description>
+  </element>
+  <element name="gmd:description" id="557.0" context="gmd:MD_Role">
+    <label>Description</label>
+    <description>Role description</description>
+  </element>
+  <element name="gmd:descriptiveKeywords" id="33.0">
+    <label>Descriptive keywords</label>
+    <description>Provides category keywords, their type, and reference source</description>
+  </element>
+  <element name="gmd:descriptor" id="258.0">
+    <label>Descriptor</label>
+    <description>Description of the range of a cell measurement value</description>
+  </element>
+  <element name="gmd:dimension" id="242.0">
+    <label>Dimension</label>
+    <description>Information on the dimensions of the cell measurement value</description>
+  </element>
+  <element name="gmd:dimensionName" id="180.0">
+    <label>Dimension name</label>
+    <description>Name of the axis</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:dimensionSize" id="181.0">
+    <label>Dimension size</label>
+    <description>Number of elements along the axis</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:distance" id="61.0">
+    <label>Distance</label>
+    <description>Ground sample distance</description>
+    <condition>Provide a distance if no equivalent Scale is documented</condition>
+    <helper relAtt="uom">
+      <option value="0.10" title="cm">10 cm</option>
+      <option value="0.25" title="cm">25 cm</option>
+      <option value="0.50" title="cm">50 cm</option>
+      <option value="1" title="m">1 m</option>
+      <option value="30" title="m">30 m</option>
+      <option value="100" title="m">100 m</option>
+    </helper>
+  </element>
+  <element name="gmd:distributionFormat" id="271.0">
+    <label>Distribution format</label>
+    <btnLabel>Add Distribution format</btnLabel>
+    <condition>mandatory</condition>
+    <description>Provides a description of the format of the data to be
+      distributed</description>
+  </element>
+  <element name="gmd:distributionInfo" id="17.0">
+    <description>Provides information about the distributor of and options for obtaining the
+      resource(s)</description>
+    <label>Distribution Information</label>
+  </element>
+  <element name="gmd:distributionOrderProcess" id="281.0">
+    <label>Distribution / Order Process</label>
+    <description>Provides information about how the resource may be obtained, and related
+      instructions and fee information</description>
+  </element>
+  <element name="gmd:distributor" id="272.0">
+    <label>Distributor</label>
+    <description>Provides information about the distributor</description>
+  </element>
+  <element name="gmd:distributorContact" id="280.0">
+    <label>Distributor contact</label>
+    <description>Party from whom the resource may be obtained. This list need not be
+      exhaustive</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:distributorFormat" id="282.0">
+    <label>Distributor format</label>
+    <description>Provides information about the format used by the distributor</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:distributorTransferOptions" id="283.0">
+    <label>Distributor transfer options</label>
+    <description>Provides information about the technical means and media used by the
+      distributor</description>
+  </element>
+  <element name="gmd:domainCode" id="309.0">
+    <label>Domain code</label>
+    <description>Three digit code assigned to the extended element</description>
+    <_condition>Conditional / is dataType ?codelistElement??</_condition>
+  </element>
+  <element name="gmd:domainOfValidity" id="197.0">
+    <label>Domain of validity</label>
+    <description>Range which is valid for the referencesystem</description>
+  </element>
+  <element name="gmd:domainValue" id="315.0">
+    <label>Domain value</label>
+    <description>Valid values that can be assigned to the extended element</description>
+    <_condition>Conditonal / dataType not 'codelist', 'enumeration' or
+      'codelistElement'</_condition>
+  </element>
+  <element name="gmd:eastBoundLongitude" id="345.0">
+    <label>East bound</label>
+    <description>Eastern-most coordinate of the limit of the dataset extent, expressed in
+      longitude in decimal degrees (positive east)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:edition" id="363.0">
+    <label>Edition</label>
+    <description>Version of the cited resource</description>
+  </element>
+  <element name="gmd:editionDate" id="364.0">
+    <label>Edition date</label>
+    <description>Date of the edition (YYYY-MM-DD)</description>
+  </element>
+  <element name="gmd:electronicMailAddress" id="386.0">
+    <label>Electronic Mail Address</label>
+    <description>Address of the electronic mailbox of the responsible organization or individual</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:environmentDescription" id="44.0">
+    <label>Environment description</label>
+    <description>Description of the dataset in the producer_s processing environment, including
+      items such as the software, the computer operating system, file name, and the dataset
+      size</description>
+  </element>
+  <element name="gmd:equivalentScale" id="60.0">
+    <label>Equivalent scale</label>
+    <description>Level of detail expressed as the scale of a comparable hardcopy map or
+      chart</description>
+    <_condition>Conditional / distance not documented?</_condition>
+  </element>
+  <element name="gmd:errorStatistic" id="136.0">
+    <label>Error statistic</label>
+    <description>Statistical method used to determine the value</description>
+  </element>
+  <element name="gmd:evaluationMethodDescription" id="104.0">
+    <label>Evaluation method description</label>
+    <description>Description of the evaluation method</description>
+  </element>
+  <element name="gmd:evaluationMethodType" id="103.0">
+    <label>Evaluation Method</label>
+    <description>Type of method used to evaluate quality of the dataset</description>
+  </element>
+  <element name="gmd:evaluationProcedure" id="105.0">
+    <label>Evaluation procedure</label>
+    <description>Reference to the procedure information</description>
+  </element>
+  <element name="gmd:explanation" id="131.0">
+    <label>Explanation</label>
+    <description>Explanation of the meaning of conformance for this result</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:extendedElementInformation" id="305.0">
+    <label>Extended element information</label>
+    <description>Provides information about a new metadata element, not found in ISO 19115,
+      which is required to describe geographic data</description>
+  </element>
+  <element name="gmd:extensionOnLineResource" id="304.0">
+    <label>Extension Online resource</label>
+    <description>Information about on-line sources containing the community profile name and the
+      extended metadata elements. Information for all new metadata elements</description>
+  </element>
+  <element name="gmd:extent" id="45.0" context="gmd:MD_DataIdentification">
+    <label>Extent</label>
+    <description>Extent information including the bounding polygon, vertical, and temporal
+      extent of the dataset</description>
+    <_condition>Conditional / if hierarchyLevel equals "dataset"? Either
+      extent.geographicElement.EX_GeographicBoundingBox or
+      extent.geographicElement.EX_GeographicDescription is required</_condition>
+  </element>
+  <element name="gmd:extent" id="140.0" context="gmd:DQ_Scope">
+    <label>Extent</label>
+    <description>Information about the horizontal, vertical and temporal extent of the data
+      specified by the scope</description>
+  </element>
+  <element name="gmd:extent" id="351.0" context="gmd:EX_TemporalExtent">
+    <label>Extent</label>
+    <description>Date and time for the content of the dataset</description>
+    <_condition>mandatory</_condition>
+  </element>
+  <element name="gmd:extentTypeCode" id="340.0">
+    <label>Extent type code</label>
+    <description>Indication of whether the bounding polygon encompasses an area covered by the
+      data or an area where data is not present. Possible values: '1' for inclusion or '0' for
+      exclusion</description>
+  </element>
+  <element name="gmd:facsimile" id="409.0">
+    <label>Fax Number</label>
+    <description>Telephone number of a fax machine for the responsible organization or individual</description>
+  </element>
+  <element name="gmd:featureCatalogueCitation" id="238.0">
+    <label>Feature catalogue citation</label>
+    <description>Complete bibliographic reference to one or more external feature
+      catalogues</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:featureInstances" id="152.0">
+    <label>Feature instances</label>
+    <description>Feature instances to which the information applies</description>
+    <condition/>
+  </element>
+  <element name="gmd:featureTypes" id="237.0">
+    <label>Feature types</label>
+    <description>Subset of feature types from cited feature catalogue occurring in
+      data</description>
+  </element>
+  <element name="gmd:features" id="151.0">
+    <label>Features</label>
+    <description>Features to which the information applies</description>
+    <condition/>
+  </element>
+  <element name="gmd:fees" id="299.0">
+    <label>File Usage Fees</label>
+    <description>In the event that there are fees associated with the use of the dataset, they are indicated here. Include the appropriate monetary units. Eg."300.00 CAD" If there are no fees, leave the default set to 'none'</description>
+  </element>
+  <element name="gmd:fileDecompressionTechnique" id="289.0">
+    <label>File decompression technique</label>
+    <description>Recommendations of algorithms or processes that can be applied to read or
+      expand resources to which compression techniques have been applied</description>
+  </element>
+  <element name="gmd:fileDescription" id="50.0">
+    <label>File description</label>
+    <description>Text description of the illustration</description>
+  </element>
+  <element name="gmd:fileIdentifier" id="2.0">
+    <label>File Identifier</label>
+    <description>System generated unique identifier for this metadata record</description>
+  </element>
+  <element name="gmd:fileName" id="49.0">
+    <label>File name</label>
+    <description>Name of the file that contains a graphic that provides an illustration of the
+      dataset. It could be a public image document URL.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:fileType" id="51.0">
+    <label>File type</label>
+    <description>Format in which the illustration is encoded</description>
+    <help>format in which the illustration is encoded Examples: CGM, EPS, GIF, JPEG, PBM, PS,
+      TIFF, XWD</help>
+  </element>
+  <element name="gmd:filmDistortionInformationAvailability" id="254.0">
+    <label>Film distortion information availability</label>
+    <description>Indication of whether or not Calibration Reseau information is
+      available</description>
+  </element>
+  <element name="gmd:formatDistributor" id="290.0">
+    <label>Format distributor</label>
+    <description>Provides information about the distributor’s format</description>
+  </element>
+  <element name="gmd:function" id="402.0">
+    <label>Function</label>
+    <description>Code for function performed by the online resource</description>
+  </element>
+  <element name="gmd:geographicElement" id="336.0">
+    <label>Geographic element</label>
+    <description>Provides geographic component of the extent of the referring
+      object</description>
+    <_condition>Conditional / description and temporalElement and verticalElement not
+      documented?</_condition>
+  </element>
+  <element name="gmd:geographicIdentifier" id="349.0">
+    <label>Geographic identifier</label>
+    <description>Identifier used to represent a geographic area</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:geometricObjectCount" id="185.0">
+    <label>Geometric object count</label>
+    <description>Total number of the point or vector object type occurring in the
+      dataset</description>
+  </element>
+  <element name="gmd:geometricObjectType" id="184.0">
+    <label>Geometric object type</label>
+    <description>Name of point and vector spatial objects used to locate zero-, one-, and
+      two-dimensional spatial locations in the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:geometricObjects" id="178.0">
+    <label>Geometric objects</label>
+    <description>Information about the geometric objects used in the dataset</description>
+  </element>
+  <element name="gmd:georeferencedParameters" id="174.0">
+    <label>GeoreferencedParameters</label>
+    <description>GeoreferencedParameters</description>
+  </element>
+  <element name="gmd:graphicOverview" id="31.0">
+    <label>Graphic overview</label>
+    <description>Provides a graphic that illustrates the resource(s) (should include a legend
+      for the graphic)</description>
+  </element>
+  <element name="gmd:graphicsFile" id="325.0">
+    <label>Graphics file</label>
+    <description>Full application schema given as a graphics file</description>
+  </element>
+  <element name="gmd:handlingDescription" id="77.0">
+    <label>Handling description</label>
+    <description>Additional information about the restrictions on handling the
+      resource</description>
+  </element>
+  <element name="gmd:hierarchyLevel" id="6.0">
+    <label>Hierarchy Level</label>
+    <description>Select the level to which the metadata applies. The default for this fields is 'Dataset'. If you are creating metadata to describe a series of datasets with a parent/child relationship, 'Series' is the most appropriate level.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:hierarchyLevelName" id="7.0">
+    <label>Hierarchy level name</label>
+    <description>Name of the hierarchy levels for which the metadata is provided</description>
+    <_condition>Conditional / hierarchyLevel is not equal to "dataset"?</_condition>
+  </element>
+  <element name="gmd:hoursOfService" id="391.0">
+    <label>Hours of Service</label>
+    <description>Provide a time period (including time zone) when an organization or individual can be contacted</description>
+  </element>
+  <element name="gmd:identificationInfo" id="15.0">
+    <label>Identification info</label>
+    <description>Basic information about the resource(s) to which the metadata
+      applies</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:identifier" id="573.0">
+    <label>Identifier</label>
+    <description>Unique identifier for the resource. EXAMPLE: Universal Product Code (UPC),
+      National Stock Number (NSN)</description>
+  </element>
+  <element name="gmd:identifier" id="573.0" context="gmd:CI_Citation">
+    <label>Citation identifier</label>
+    <description>Identifier of the citation</description>
+  </element>
+  <element name="gmd:identifier" id="575.0" context="gmd:MD_Authority">
+    <label>Identifier</label>
+    <description>Identifier which belongs to the authority</description>
+  </element>
+  <element name="gmd:illuminationAzimuthAngle" id="245.0">
+    <label>Illumination azimuth angle</label>
+    <description>Illumination azimuth measured in degrees clockwise from true north at the time
+      the image is taken. For images from a scanning device, refer to the centre pixel of the
+      image</description>
+  </element>
+  <element name="gmd:illuminationElevationAngle" id="244.0">
+    <label>Illumination elevation angle</label>
+    <description>Illumination elevation measured in degrees clockwise from the target plane at
+      intersection of the optical line of sight with the Earth_s surface. For images from a
+      scanning device, refer to the centre pixel of the image</description>
+  </element>
+  <element name="gmd:imageQualityCode" id="247.0">
+    <label>Image quality code</label>
+    <description>Specifies the image quality</description>
+    <help>specifies the image quality</help>
+  </element>
+  <element name="gmd:imagingCondition" id="246.0">
+    <label>Imaging condition</label>
+    <description>Conditions affected the image</description>
+  </element>
+  <element name="gmd:includedWithDataset" id="236.0">
+    <label>Included with dataset</label>
+    <description>Indication of whether or not the feature catalogue is included with the
+      dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:individualName" id="375.0">
+    <label>Individual Name</label>
+    <description>Name of the responsible person – surname, given name, title, separated by a delimiter</description>
+    <_condition>Conditional / organisationName and positionName not documented?</_condition>
+  </element>
+  <element name="gmd:initiativeType" id="66.5">
+    <label>Initiative Type</label>
+    <description>Type of initiative under which the aggregate dataset was produced</description>
+  </element>
+  <element name="gmd:issueIdentification" id="405.0">
+    <label>Issue identification</label>
+    <description>Information identifying the issue of the series</description>
+  </element>
+  <element name="gmd:keyword" id="53.0">
+    <label>Keyword</label>
+    <description>Commonly used word(s), or formalized word(s) or phrase(s) used to describe the subject of the resource.  Keywords are a repeatable element; enter as many keywords as possible to describe the data, as this will help the data be discovered.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:language" context="gmd:MD_Metadata" id="3.0">
+    <label>Metadata language</label>
+    <btnLabel>Add language</btnLabel>
+    <description>Select the language used to create the metadata</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:language" context="gmd:MD_DataIdentification" id="39.0">
+    <label>Language</label>
+    <btnLabel>Add language</btnLabel>
+    <description>Language(s) used within the dataset</description>
+    <!--<help>language(s) used within the dataset</help>-->
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:language" context="gmd:MD_FeatureCatalogueDescription" id="235.0">
+    <label>Language</label>
+    <description>Language(s) used within the catalogue</description>
+  </element>
+  <element name="gmd:lensDistortionInformationAvailability" id="255.0">
+    <label>Lens distortion information availability</label>
+    <description>Indication of whether or not lens aberration correction information is
+      available</description>
+  </element>
+  <element name="gmd:level" id="139.0">
+    <label>Hierarchy level</label>
+    <description>Hierarchical level of the data specified by the scope</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:levelDescription" id="141.0">
+    <label>Level description</label>
+    <description>Detailed description about the level of the data specified by the
+      scope</description>
+    <_condition>Conditional / level not equal 'dataset' or 'series'?</_condition>
+  </element>
+  <element name="gmd:lineage" id="81.0">
+    <label>Lineage</label>
+    <description>Non-quantitative quality information about the lineage of the data specified by
+      the scope</description>
+    <_condition>Conditional / report not provided?</_condition>
+  </element>
+  <element name="gmd:linkage" id="397.0">
+    <label>Linkage</label>
+    <description>Location (address) for on-line access using a Uniform Resource Locator address
+      or similar addressing scheme such as http://www.statkart.no/isotc211</description>
+    <!--<condition>mandatory</condition>-->
+  </element>
+  <element name="gmd:maintenanceAndUpdateFrequency" id="143.0">
+    <label>Maintenance and Update Frequency</label>
+    <description>Frequency with which changes and additions are made to the resource after the initial resource is completed. For continuous monitoring data, select the appropriate value which best describes how often data is collected.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:maintenanceNote" id="148.0">
+    <label>Maintenance note</label>
+    <description>Information regarding specific requirements for maintaining the
+      resource</description>
+  </element>
+  <element name="gmd:maxValue" id="260.0">
+    <label>Maximum value</label>
+    <description>Longest wavelength that the sensor is capable of collecting within a designated
+      band</description>
+  </element>
+  <element name="gmd:maximumValue" id="356.0">
+    <label>Maximum value</label>
+    <description>Highest vertical extent contained in the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:measureDescription" id="102.0">
+    <label>Measure description</label>
+    <description>Description of the measure being determined</description>
+  </element>
+  <element name="gmd:measureIdentification" id="101.0">
+    <label>Measure identification</label>
+    <description>Code identifying a registered standard procedure</description>
+  </element>
+  <element name="gmd:mediumFormat" id="296.0">
+    <label>Medium format</label>
+    <description>Method used to write to the medium</description>
+  </element>
+  <element name="gmd:mediumNote" id="297.0">
+    <label>Medium note</label>
+    <description>Description of other limitations or requirements for using the
+      medium</description>
+  </element>
+  <element name="gmd:metadataConstraints" id="20.0" context="gmd:MD_Metadata">
+    <label>Metadata constraints</label>
+    <description>Provides restrictions on the access and use of metadata</description>
+  </element>
+  <element name="gmd:metadataConstraints">
+    <label>Metadata constraints</label>
+    <description>Provides restrictions on the access and use of data</description>
+  </element>
+  <element name="gmd:metadataExtensionInfo" id="14.0">
+    <description>Information describing metadata extensions</description>
+    <label>Metadata Extension Information</label>
+  </element>
+  <element name="gmd:metadataMaintenance" id="22.0">
+    <label>Metadata maintenance</label>
+    <description>Provides information about the frequency of metadata updates, and the scope of
+      those updates</description>
+  </element>
+  <element name="gmd:metadataStandardName" id="10.0">
+    <label>Metadata standard name</label>
+    <description>Name of the metadata standard (including profile name) used</description>
+  </element>
+  <element name="gmd:metadataStandardVersion" id="11.0">
+    <label>Metadata standard version</label>
+    <description>Version (profile) of the metadata standard used</description>
+  </element>
+  <element name="gmd:minValue" id="261.0">
+    <label>Minimum value</label>
+    <description>Shortest wavelength that the sensor is capable of collecting within a
+      designated band</description>
+  </element>
+  <element name="gmd:minimumValue" id="355.0">
+    <label>Minimum value</label>
+    <description>Lowest vertical extent contained in the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:name" context="gmd:MD_AbstractClass" id="560.0">
+    <label>Name</label>
+    <description>Name</description>
+  </element>
+  <element name="gmd:name" context="gmd:MD_Medium" id="292.0">
+    <label>Name</label>
+    <description>Name of the medium on which the resource can be received</description>
+  </element>
+  <element name="gmd:name" context="gmd:RS_ReferenceSystem" id="196.0">
+    <label>Name</label>
+    <description>Name of reference system used</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:name" context="gmd:MD_Format" id="285.0">
+    <label>File Format Name</label>
+    <description>Enter the name of the data transfer format(s). For a list of possible formats, see the 'suggestions' menu</description>
+    <help>name of the data transfer format(s)</help>
+    <condition>mandatory</condition>
+    <!--<helper rel="gmd:version">
+        <option value="Text">Text</option>
+        <option value="ESRI Shapefile" title="1.0">ESRI Shapefile</option>
+        <option value="Mapinfo MIF/MID" title="4.5">Mapinfo MIF/MID</option>
+        <option value="Mapinfo TAB">Mapinfo TAB</option>
+        <option value="KML">KML</option>
+        <option value="GeoTIFF" title="1.0">GeoTIFF</option>
+        <option value="TIFF">TIFF</option>
+        <option value="ECW">ECW</option>
+        <option value="ZIP">ZIP</option
+         <option value="bil">bil</option>
+         <option value="bmp">bmp</option>
+         <option value="bsq">bsq</option>
+         <option value="bzip2">bzip2</option>
+         <option value="cdr">cdr</option>
+         <option value="cgm">cgm</option>
+         <option value="cover">cover</option>
+         <option value="csv">csv</option>
+         <option value="dbf">dbf</option>
+         <option value="dgn">dgn</option>
+         <option value="doc">doc</option>
+         <option value="dwg">dwg</option>
+         <option value="dxf">dxf</option>
+         <option value="e00">e00</option>
+         <option value="ecw">ecw</option>
+         <option value="eps">eps</option>
+         <option value="ers">ers</option>
+         <option value="gdb">gdb</option>
+         <option value="geotiff">GeoTIFF</option>
+         <option value="gif">GIF</option>
+         <option value="gml">gml</option>
+         <option value="grid">grid</option>
+         <option value="gzip">gzip</option>
+         <option value="html">html</option>
+         <option value="jpg">JPG</option>
+         <option value="mdb">mdb</option>
+         <option value="mif">mif</option>
+         <option value="pbm">pbm</option>
+         <option value="pdf" title="1.7">PDF Version 1.7</option>
+         <option value="png">png</option>
+         <option value="ps">ps</option>
+         <option value="rtf">rtf</option>
+         <option value="sdc">sdc</option>
+         <option value="shp">shp</option>
+         <option value="sid">sid</option>
+         <option value="svg">svg</option>
+         <option value="tab">tab</option>
+         <option value="tar">tar</option>
+        <option value="tiff">tiff</option>
+        <option value="txt">txt</option>
+        <option value="xhtml">xhtml</option>
+        <option value="xls">xls</option>
+        <option value="xml" title="1.0">XML Version 1.0</option>
+        <option value="xwd">xwd</option>
+        <option value="zip">zip</option>
+        <option value="wpd">wpd</option>
+    </helper> >-->
+  </element>
+  <element name="gmd:name" context="gmd:MD_ExtendedElementInformation" id="307.0">
+    <label>Name</label>
+    <description>Name of the extended metadata element</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:name" context="gmd:MD_ApplicationSchemaInformation" id="321.0">
+    <label>Name</label>
+    <description>Name of the application schema used</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:name" context="gmd:CI_OnlineResource" id="400.0">
+    <label>Name</label>
+    <description>The name of the data resource</description>
+  </element>
+  <element name="gmd:name" context="gmd:CI_Series" id="404.0">
+    <label>Name</label>
+    <description>Name of the series, or aggregate dataset, of which the dataset is a
+      part</description>
+  </element>
+  <element name="gmd:name" context="gmd:MD_CodeDomain" id="537.0">
+    <label>Name</label>
+    <description>Name of the code domain</description>
+  </element>
+  <element name="gmd:name" context="gmd:MD_CodeValue" id="546.0">
+    <label>Name</label>
+    <description>Value name</description>
+  </element>
+  <element name="gmd:name" context="gmd:MD_Attribute" id="551.0">
+    <label>Name</label>
+    <description>Attribute name</description>
+  </element>
+  <element name="gmd:name" context="gmd:MD_Role" id="556.0">
+    <label>Name</label>
+    <description>Role name</description>
+  </element>
+  <element name="gmd:name">
+    <label>Name</label>
+    <description/>
+  </element>
+  <element name="gmd:nameOfMeasure" id="100.0">
+    <label>Name of measure</label>
+    <description>Name of the test applied to the data</description>
+    <!-- ISO19138 Data quality basic measures Annex C - under revision ISO 19157 http://www.iso.org/iso/fr/catalogue_detail.htm?csnumber=32575 -->
+    <helper rel="gmd:measureDescription">
+      <option value="">-- Completeness --</option>
+      <option value="Excess item" title="Indication that an item is incorrectly present in the data" id="ISO19138:2006:measure:1">Excess item</option>
+      <option value="Number of excess items" title="Number of items within the dataset, that should not have been in the dataset" id="ISO19138:2006:measure:2">Number of excess items</option>
+      <option value="Rate of excess items" title="Number of excess items in the dataset in relation to the number of items that should have been present" id="ISO19138:2006:measure:3">Rate of excess items</option>
+      <option value="Number of duplicate feature instances" title="Total number of exact duplications of feature instances within the data. Count of all items in the data that are incorrectly extracted with duplicate geometrie" id="ISO19138:2006:measure:4">Number of duplicate feature instances</option>
+      <option value="Missing item" title="Indicator that shows that a specific item is missing in the data" id="ISO19138:2006:measure:5">Missing item</option>
+      <option value="Number of missing items" title="Count of all items that should have been in the dataset and are missing" id="ISO19138:2006:measure:6">Number of missing items</option>
+      <option value="Rate of missing items" title="Number of missing items in the dataset in relation to the number of items that should have been present" id="ISO19138:2006:measure:7">Rate of missing items</option>
+      <option value="">-- Logical consistency / Conceptual consistency --</option>
+      <option value="Conceptual schema noncompliance" title="Indication that an item is not compliant to the rules of the relevant conceptual schema" id="ISO19138:2006:measure:8">Conceptual schema noncompliance</option>
+      <option value="Conceptual schema compliance" title="Indication that an item complies with the rules of the relevant conceptual schema" id="ISO19138:2006:measure:9">Conceptual schema compliance</option>
+      <option value="Number of items noncompliant to the rules of the conceptual schema" title="Count of all items in the dataset that are noncompliant to the rules of the conceptual schema. If the conceptual schema explicitly or implicitly describes rules, these rules have to be followed. Violations against such rules can e.g. be invalid placement of features within a defined tolerance, duplication of features and invalid overlap of features." id="ISO19138:2006:measure:10">Number of items noncompliant to the rules of the conceptual schema</option>
+      <option value="Number of invalid overlaps of surfaces" title="Total number of erroneous overlaps within the data Which surfaces may overlap and which must not is application dependent. Not all overlapping surfaces are necessarily erroneous. When reporting this data quality measure the types of feature classes corresponding to the illegal overlapping surfaces have to be reported as well." id="ISO19138:2006:measure:11">Number of invalid overlaps of surfaces</option>
+      <option value="Non-compliance rate with respect to the rules of the conceptual schema" title="Number of items in the dataset that are noncompliant to the rules of the conceptual schema in relation to the total number of these items supposed to be in the dataset" id="ISO19138:2006:measure:12">Non-compliance rate with respect to the rules of the conceptual schema</option>
+      <option value=" Compliance rate with the rules of the conceptual schema" title="number of items in the dataset in compliance with the rules of the conceptual schema in relation to the total number of items" id="ISO19138:2006:measure:13"> Compliance rate with the rules of the conceptual schema</option>
+      <option value="">-- Logical consistency / Domain consistency --</option>
+      <option value="Value domain non-conformance" title="Indication of if an item is not in conformance with its value domain" id="ISO19138:2006:measure:14">Value domain non-conformance</option>
+      <option value="Value domain conformance" title="Indication of if an item is conforming to its value domain" id="ISO19138:2006:measure:15">Value domain conformance</option>
+      <option value="Number of items not in conformance with their value domain" title="Count of all items in the dataset that are not in conformance with their value domain." id="ISO19138:2006:measure:16">Number of items not in conformance with their value domain</option>
+      <option value="Value domain conformance rate" title="Number of items in the dataset that are in conformance with their value domain in relation to the total number of items in the dataset" id="ISO19138:2006:measure:17">Value domain conformance rate</option>
+      <option value="Value domain non-conformance rate" title="the number of items in the dataset that are not in conformance with their value domain in relation to the total number of items" id="ISO19138:2006:measure:18">Value domain non-conformance rate</option>
+      <option value="Physical structure conflicts" title="Count of all items in the dataset that are stored in conflict with the physical structure of the dataset" id="ISO19138:2006:measure:19">Physical structure conflicts</option>
+      <option value="Physical structure conflict rate" title="Number of items in the dataset that are stored in conflict with the physical structure of the dataset divided by the total number of items" id="ISO19138:2006:measure:20">Physical structure conflict rate</option>
+      <option value="">-- Logical consistency / Topological consistency --</option>
+      <option value="Number of faulty point-curve connections" title="Number of faulty point-curve connections in the dataset. A point-curve connection exists where different curves touch. These curves have an intrinsic topological relationship that has to reflect the true constellation. If the point-curve connection contradicts the universe of discourse, the point-curve connection is faulty with respect to this data quality measure. The data quality measure counts the number of errors of this kind." id="ISO19138:2006:measure:21">Number of faulty point-curve connections</option>
+      <option value="Rate of faulty point-curve connections" title="Number of faulty link node connections in relation to the number of supposed link node connections" id="ISO19138:2006:measure:22">Rate of faulty point-curve connections</option>
+      <option value="Number of missing connection due to undershoots" title="Count of items in the dataset, within the parameter tolerance, that are mismatched due to undershoots" id="ISO19138:2006:measure:23">Number of missing connection due to undershoots</option>
+      <option value="Number of missing connections due to overshoots" title="Count of items in the dataset, within the parameter tolerance, that are mismatched due to overshoots" id="ISO19138:2006:measure:24">Number of missing connections due to overshoots</option>
+      <option value="Number of invalid slivers" title="Count of all items in the dataset that are invalid sliver surfaces. A sliver is an unintended area that occurs when adjacent surfaces are not digitized properly. The borders of the adjacent surfaces may unintentionally gap or overlap by small amounts to cause a topological error." id="ISO19138:2006:measure:25">Number of invalid slivers</option>
+      <option value="Number of invalid self intersect errors" title="Count of all items in the data that illegally intersect with themselves" id="ISO19138:2006:measure:26">Number of invalid self intersect errors</option>
+      <option value="Number of invalid self overlap errors" title="Count of all items in the data that illegally self overlap" id="ISO19138:2006:measure:27">Number of invalid self overlap errors</option>
+      <option value="">-- Positional accuracy / Absolute or external accuracy / General measures --</option>
+      <option value="Mean value of positional uncertainties" title="Mean value of the positional uncertainties for a set of positions where the positional uncertainties are defined as the distance between a measured position and what is considered as the corresponding true position" id="ISO19138:2006:measure:28">Mean value of positional uncertainties</option>
+      <option value="Mean value of positional uncertainties excluding outliers" title="For a set of points where the distance does not exceed a defined threshold the arithmetical average of distances between their measured positions and what is considered as the corresponding true positions" id="ISO19138:2006:measure:29">Mean value of positional uncertainties excluding outliers</option>
+      <option value="Number of positional uncertainties above a given threshold" title="Number of positional uncertainties above a given threshold for a set of positions. The errors are defined as the distance between a measured position and what is considered as the corresponding true position" id="ISO19138:2006:measure:30">Number of positional uncertainties above a given threshold</option>
+      <option value="Rate of positional errors above a given threshold" title="Number of positional uncertainties above a given threshold for a set of positions in relation to the total number of measured positions. The errors are defined as the distance between a measured position and what is considered as the corresponding true position." id="ISO19138:2006:measure:31">Rate of positional errors above a given threshold</option>
+      <option value="Covariance matrix" title="A symmetrical square matrix with variances of point coordinates on the main diagonal and covariances between these coordinates as off-diagonal elements." id="ISO19138:2006:measure:32">Covariance matrix</option>
+      <option value="">-- Positional accuracy / Absolute or external accuracy / Vertical --</option>
+      <option value="Linear error probable" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 50%." id="ISO19138:2006:measure:33">Linear error probable</option>
+      <option value="Standard linear error" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 68.3%." id="ISO19138:2006:measure:34">Standard linear error</option>
+      <option value="Linear map accuracy at 90% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 90%." id="ISO19138:2006:measure:35">Linear map accuracy at 90% significance level</option>
+      <option value="Linear map accuracy at 95% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 95%." id="ISO19138:2006:measure:36">Linear map accuracy at 95% significance level</option>
+      <option value="Linear map accuracy at 99% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 99%." id="ISO19138:2006:measure:37">Linear map accuracy at 99% significance level</option>
+      <option value="Near certainty linear error" title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 99.8%." id="ISO19138:2006:measure:38">Near certainty linear error</option>
+      <option value="Root mean square error" title="Standard deviation, where the true value is not estimated from the observations but known a priori." id="ISO19138:2006:measure:39">Root mean square error</option>
+      <option value="Absolute linear error at 90% significance level of biased vertical data (Alternative 1)" title="The absolute vertical accuracy of the data’s coordinates, expressed in terms of linear error at 90% probability given that a bias is present." id="ISO19138:2006:measure:40">Absolute linear error at 90% significance level of biased vertical data (Alternative 1)</option>
+      <option value="Absolute linear error at 90% significance level of biased vertical data" title="The absolute vertical accuracy of the data’s coordinates, expressed in terms of linear error at 90% probability given that a bias is present." id="ISO19138:2006:measure:41">Absolute linear error at 90% significance level of biased vertical data</option>
+      <option value="">-- Positional accuracy / Absolute or external accuracy / Horizontal --</option>
+      <option value="Circular standard deviation" title="Radius describing a circle, in which the true point location lies with the probability of 39.4%." id="ISO19138:2006:measure:42">Circular standard deviation</option>
+      <option value="Circular error probable" title="Radius describing a circle, in which the true point location lies with the probability of 50%." id="ISO19138:2006:measure:43">Circular error probable</option>
+      <option value=" Circular map accuracy standard" title="Radius describing a circle, in which the true point location lies with the probability of 90%." id="ISO19138:2006:measure:44"> Circular map accuracy standard</option>
+      <option value="Circular error at 95% significance level" title="Radius describing a circle, in which the true point location lies with the probability of 95%." id="ISO19138:2006:measure:45">Circular error at 95% significance level</option>
+      <option value="Circular near certainty error" title="Radius describing a circle, in which the true point location lies with the probability of 99.8%." id="ISO19138:2006:measure:46">Circular near certainty error</option>
+      <option value="Root mean square error of planimetry" title="Radius of a circle around the given point, in which the true value lies with probability P." id="ISO19138:2006:measure:47">Root mean square error of planimetry</option>
+      <option value="Absolute circular error at 90% significance level of biased data (Alternative 2)" title="The absolute horizontal accuracy of the data’s coordinates, expressed in terms of circular error at 90% probability given that a bias is present." id="ISO19138:2006:measure:48">Absolute circular error at 90% significance level of biased data (Alternative 2)</option>
+      <option value="Absolute circular error at 90% significance level of biased data" title="The absolute horizontal accuracy of the data’s coordinates, expressed in terms of circular error at 90% probability given that a bias is present." id="ISO19138:2006:measure:49">Absolute circular error at 90% significance level of biased data</option>
+      <option value="Uncertainty ellipse" title="2D ellipse with the two main axes indicating the direction and magnitude of the highest and the lowest uncertainty of a 2D point" id="ISO19138:2006:measure:50">Uncertainty ellipse</option>
+      <option value="Confidence ellipse" title="2D ellipse with the two main axes indicating the direction and magnitude of the highest and the lowest uncertainty of a 2D point" id="ISO19138:2006:measure:51">Confidence ellipse</option>
+      <option value="">-- Positional accuracy / Relative or internal accuracy --</option>
+      <option value="Relative vertical error" title="Evaluation of the random errors of one relief feature to another in the same dataset or on the same map/chart. It is a function of the random errors in the two elevations with respect to a common vertical datum." id="ISO19138:2006:measure:52">Relative vertical error</option>
+      <option value="Relative horizontal error" title="Evaluation of the random errors in the horizontal position of one feature to another in the same dataset or on the same map/chart." id="ISO19138:2006:measure:53">Relative horizontal error</option>
+      <option value="">-- Temporal accuracy / Accuracy of a time measurement --</option>
+      <option value="Time accuracy at 68.3% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 68.3%." id="ISO19138:2006:measure:54">Time accuracy at 68.3% significance level</option>
+      <option value="Time accuracy at 50% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 50%." id="ISO19138:2006:measure:55">Time accuracy at 50% significance level</option>
+      <option value="Time accuracy at 90% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 90%." id="ISO19138:2006:measure:56">Time accuracy at 90% significance level</option>
+      <option value="Time accuracy at 95% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 95%." id="ISO19138:2006:measure:57">Time accuracy at 95% significance level</option>
+      <option value="Time accuracy at 99% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 99%." id="ISO19138:2006:measure:58">Time accuracy at 99% significance level</option>
+      <option value="Time accuracy at 99.8% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 99.8%." id="ISO19138:2006:measure:59">Time accuracy at 99.8% significance level</option>
+      <option value="">-- Thematic accuracy / Classification correctness --</option>
+      <option value="Number of incorrectly classified features" title="Number of incorrectly classified features" id="ISO19138:2006:measure:60">Number of incorrectly classified features</option>
+      <option value="Misclassification rate" title="number of incorrectly classified features in relation to the number of features that are supposed to be there" id="ISO19138:2006:measure:61">Misclassification rate</option>
+      <option value="Misclassification matrix" title="matrix that indicates the number of items of class (i) classified as class (j)." id="ISO19138:2006:measure:62">Misclassification matrix</option>
+      <option value="Relative misclassification matrix" title="matrix that indicates the number of items of class (i) classified as class (i) divided by the number of items of class (i)" id="ISO19138:2006:measure:63">Relative misclassification matrix</option>
+      <option value="Kappa coefficient" title="Coefficient to quantify the proportion of agreement of assignments to classes by removing misclassifications" id="ISO19138:2006:measure:64">Kappa coefficient</option>
+      <option value="">-- Thematic accuracy / Non-quantitative attribute correctness --</option>
+      <option value="Number of incorrect attribute values" title="Total number of erroneous attribute values within the relevant part of the dataset" id="ISO19138:2006:measure:65">Number of incorrect attribute values</option>
+      <option value="Rate of correct attribute values" title="Number of correct attribute values in relation to the total number of attribute values" id="ISO19138:2006:measure:66">Rate of correct attribute values</option>
+      <option value="Rate of incorrect attribute values" title="Number of attribute values where incorrect values are assigned in relation to the total number of attribute values" id="ISO19138:2006:measure:67">Rate of incorrect attribute values</option>
+      <option value="">-- Thematic accuracy / Quantitative attribute accuracy --</option>
+      <option value="Attribute value uncertainty at 68.3% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 68.3%." id="ISO19138:2006:measure:68">Attribute value uncertainty at 68.3% significance level</option>
+      <option value="Attribute value uncertainty at 50% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 50%." id="ISO19138:2006:measure:69">Attribute value uncertainty at 50% significance level</option>
+      <option value="Attribute value uncertainty at 90% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 90%." id="ISO19138:2006:measure:70">Attribute value uncertainty at 90% significance level</option>
+      <option value="Attribute value uncertainty at 95% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 95%." id="ISO19138:2006:measure:71">Attribute value uncertainty at 95% significance level</option>
+      <option value="Attribute value uncertainty at 99% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 99%." id="ISO19138:2006:measure:72">Attribute value uncertainty at 99% significance level</option>
+      <option value="Attribute value uncertainty at 99.8% significance level" title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 99.8%." id="ISO19138:2006:measure:73">Attribute value uncertainty at 99.8% significance level</option>
+    </helper>
+  </element>
+  <element name="gmd:northBoundLatitude" id="347.0">
+    <label>North bound</label>
+    <description>Northern-most, coordinate of the limit of the dataset extent expressed in
+      latitude in decimal degrees (positive north)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:numberOfDimensions" id="158.0">
+    <label>Number of dimensions</label>
+    <description>Number of independent spatial-temporal axes</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:obligation" id="311.0">
+    <label>Obligation</label>
+    <description>Obligation of the extended element</description>
+  </element>
+  <element name="gmd:offLine" id="278.0">
+    <label>Offline</label>
+    <description>Information about offline media on which the resource can be
+      obtained</description>
+  </element>
+  <element name="gmd:offset" id="267.0">
+    <label>Offset</label>
+    <description>The physical value corresponding to a cell value of zero</description>
+  </element>
+  <element name="gmd:onLine" id="277.0">
+    <label>Online Resource</label>
+    <description>Information about online sources from which the resource can be
+      obtained</description>
+  </element>
+  <element name="gmd:onlineResource" id="390.0">
+    <!--<help>Define URL to access the website</help>-->
+    <label>Website</label>
+    <description>On-line information that can be used to contact the individual or
+      organisation</description>
+  </element>
+  <element name="gmd:orderingInstructions" id="301.0">
+    <label>Ordering instructions</label>
+    <description>General instructions, terms and services provided by the
+      distributor</description>
+  </element>
+  <element name="gmd:organisationName" id="376.0">
+    <label>Organization Name</label>
+    <description>Name of the responsible organization</description>
+    <!--<condition>conditional</condition>-->
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:orientationParameterAvailability" id="172.0">
+    <label>Orientation parameter availability</label>
+    <description>Indication of whether or not orientation parameters are available</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:orientationParameterDescription" id="173.0">
+    <label>Orientation parameter description</label>
+    <description>Description of parameters used to describe sensor orientation</description>
+  </element>
+  <element name="gmd:other" id="155.0">
+    <label>Other</label>
+    <description>Class of information that does not fall into the other categories to which the
+      information applies</description>
+    <condition/>
+  </element>
+  <element name="gmd:otherCitationDetails" id="370.0">
+    <label>Other citation details</label>
+    <description>Other information required to complete the citation that is not recorded
+      elsewhere</description>
+  </element>
+  <element name="gmd:otherConstraints" id="72.0">
+    <label>Other constraints</label>
+    <description>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:page" id="406.0">
+    <label>Page</label>
+    <description>Details on which pages of the publication the article was
+      published</description>
+  </element>
+  <element name="gmd:parameterCitation" id="175.0">
+    <label>Parameter citation</label>
+    <description>Reference providing description of the parameters</description>
+  </element>
+  <element name="gmd:parentEntity" id="316.0">
+    <label>Parent entity</label>
+    <description>Name of the metadata entity(s) under which this extended metadata element may
+      appear. The name(s) may be standard metadata element(s) or other extended metadata
+      element(s).</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:parentIdentifier" id="5.0">
+    <label>Parent identifier</label>
+    <description>File identifier of the metadata to which this metadata is a subset
+      (child)</description>
+  </element>
+  <element name="gmd:pass" id="132.0">
+    <label>Pass</label>
+    <description>Indication of the conformance result where 0 = fail and 1 = pass</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:peakResponse" id="263.0">
+    <label>Peak response</label>
+    <description>Wavelength at which the response is the highest</description>
+  </element>
+  <element name="gmd:phone" id="526.0">
+    <label>Phone</label>
+    <description>Telephone numbers at which the organization or individual may be
+      contacted</description>
+  </element>
+  <element name="gmd:plannedAvailableDateTime" id="300.0">
+    <label>Planned available datetime</label>
+    <description>Date and time when the dataset will be available
+      (CCYY-MM-DDThh:mm:ss)</description>
+  </element>
+  <element name="gmd:pointInPixel" id="167.0">
+    <label>Point in Pixel</label>
+    <description>Point in a pixel corresponding to the Earth location of the pixel</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:pointOfContact" id="29.0">
+    <label>Point of Contact</label>
+    <description>Identification of, and means of communication with, person(s) and
+      organizations(s) associated with the resource(s)</description>
+  </element>
+  <element name="gmd:polygon" id="342.0">
+    <label>Polygon</label>
+    <description>Sets of points defining the bounding polygon</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:portrayalCatalogueCitation" id="269.0">
+    <label>Portrayal catalogue citation</label>
+    <description>Bibliographic reference to the portrayal catalogue cited</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:portrayalCatalogueInfo" id="19.0">
+    <label>Portrayal catalogue info</label>
+    <description>Provides information about the catalogue of rules defined for the portrayal of
+      a resource(s)</description>
+  </element>
+  <element name="gmd:positionName" id="377.0">
+    <label>Position Name</label>
+    <description>Role or position of the responsible person</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:postalCode" id="384.0">
+    <label>Postal Code / ZIP Code</label>
+    <description>Postal Code or other ZIP code</description>
+  </element>
+  <element name="gmd:presentationForm" id="368.0">
+    <label>Presentation form</label>
+    <description>Mode in which the resource is represented</description>
+  </element>
+  <element name="gmd:processStep" id="84.0">
+    <label>Process step</label>
+    <description>Information about an event in the creation process for the data specified by
+      the scope</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:processingLevelCode" id="249.0">
+    <label>Processing level code</label>
+    <description>Image distributor_s code that identifies the level of radiometric and geometric
+      processing that has been applied</description>
+  </element>
+  <element name="gmd:processor" id="90.0">
+    <label>Processor</label>
+    <description>Identification of, and means of communication with, person(s) and
+      organization(s) associated with the process step</description>
+  </element>
+  <element name="gmd:protocol" id="398.0" alias="protocol">
+    <label>Protocol</label>
+    <description>Select the appropriate protocol from the drop down list. If your dataset is available online, select 'web address (URL)'</description>
+    <helper sort="true">
+      <option value="HTTP">HTTP</option>
+      <option value="HTTPS">HTTPS</option>
+      <option value="FTP">FTP</option>
+      <option value="ESRI REST: Map Service">ESRI REST: Map Service</option>
+    </helper>
+  </element>
+  <element name="gmd:purpose" id="26.0">
+    <label>Purpose</label>
+    <description>Summary of the intentions with which the resource(s) was
+      developed</description>
+  </element>
+  <element name="gmd:radiometricCalibrationDataAvailability" id="252.0">
+    <label>Radiometric calibration data availability</label>
+    <description>Indication of whether or not the radiometric calibration information for
+      generating the radiometrically calibrated standard data product is
+      available</description>
+  </element>
+  <element name="gmd:rationale" id="88.0">
+    <label>Rationale</label>
+    <description>Requirement or purpose for the process step</description>
+  </element>
+  <element name="gmd:rationale" id="318.0" context="gmd:MD_ExtendedElementInformation">
+    <label>Rationale</label>
+    <description>Reason for creating the extended element</description>
+  </element>
+  <element name="gmd:referenceSystemIdentifier" id="187.0">
+    <label>Reference system identifier</label>
+    <description>Name of reference system</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:referenceSystemInfo" id="13.0">
+    <label>Reference System Information</label>
+    <btnLabel>Add Reference System Information</btnLabel>
+    <description>Description of the spatial and temporal reference systems used in the
+      dataset</description>
+  </element>
+  <element name="gmd:report" id="80.0">
+    <label>Report</label>
+    <description>Quantitative quality information for the data specified by the
+      scope</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:resolution" id="182.0">
+    <label>Resolution</label>
+    <description>Degree of detail in the grid dataset</description>
+  </element>
+  <element name="gmd:resourceConstraints" id="35.0">
+    <label>Resource constraints</label>
+    <description>Provides information about constraints which apply to the
+      resource(s)</description>
+  </element>
+  <element name="gmd:resourceFormat" id="32.0">
+    <label>Resource format</label>
+    <description>Provides a description of the format of the resource(s)</description>
+  </element>
+  <element name="gmd:resourceMaintenance" id="30.0">
+    <label>Resource maintenance</label>
+    <description>Provides information about the frequency of resource updates, and the scope of
+      those updates</description>
+  </element>
+  <element name="gmd:resourceSpecificUsage" id="34.0">
+    <label>Resource specific usage</label>
+    <description>Provides basic information about specific application(s) for which the
+      resource(s) has/have been or is being used by different users</description>
+  </element>
+  <element name="gmd:result" id="107.0">
+    <label>Result</label>
+    <description>Value (or set of values) obtained from applying a data quality measure or the
+      out come of evaluating the obtained value (or set of values) against a specified
+      acceptable conformance quality level</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:role" id="566.0" context="gmd:MD_Association">
+    <label>Role</label>
+    <description>Reference to the ends (roles) of a concrete association</description>
+  </element>
+  <element name="gmd:role" id="379.0">
+    <label>Role</label>
+    <description>Select the appropriate role from the list provided. The role of Data Steward identifies the individual who is accountable for the dataset.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:rule" id="317.0">
+    <label>Rule</label>
+    <description>Specifies how the extended element relates to other existing elements and
+      entities</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:scaleDenominator" id="94.0">
+    <label>Scale Denominator</label>
+    <description>Denominator of the representative fraction on a source map</description>
+  </element>
+  <element name="gmd:scaleFactor" id="266.0">
+    <label>Scale factor</label>
+    <description>Scale factor which has been applied to the cell value</description>
+  </element>
+  <element name="gmd:schemaAscii" id="324.0">
+    <description>Full application schema given as an ASCII file</description>
+    <label>Schema ASCII</label>
+  </element>
+  <element name="gmd:schemaLanguage" id="322.0">
+    <label>Schema language</label>
+    <description>Identification of the schema language used</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:scope" id="79.0">
+    <label>Scope</label>
+    <description>The specific data to which the data quality information applies</description>
+  </element>
+  <element name="gmd:sequenceIdentifier" id="257.0">
+    <label>Sequence identifier</label>
+    <description>Number that uniquely identifies instances of bands of wavelengths on which a
+      sensor operates</description>
+  </element>
+  <element name="gmd:series" id="369.0">
+    <label>Series</label>
+    <description>Information about the series, or aggregate dataset, of which the dataset is a
+      part</description>
+  </element>
+  <element name="gmd:shortName" id="308.0">
+    <label>Short name</label>
+    <description>Short form suitable for use in an implementation method such as XML or SGML.
+      NOTE other methods may be used</description>
+  </element>
+  <element name="gmd:softwareDevelopmentFile" id="326.0">
+    <label>Software development file</label>
+    <description>Full application schema given as a software development file</description>
+  </element>
+  <element name="gmd:softwareDevelopmentFileFormat" id="327.0">
+    <label>Software development file format</label>
+    <description>Software dependent format used for the application schema software dependent
+      file</description>
+  </element>
+  <element name="gmd:source" id="85.0">
+    <label>Source</label>
+    <description>Information about the source data used in creating the data specified by the
+      scope</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:source" id="319.0" context="gmd:MD_ExtendedElementInformation">
+    <condition>mandatory</condition>
+    <label>Source</label>
+    <description>Name of the person or organization creating the extended element</description>
+  </element>
+  <element name="gmd:sourceCitation" id="96.0">
+    <label>Source citation</label>
+    <description>Recommended reference to be used for the source data</description>
+  </element>
+  <element name="gmd:sourceExtent" id="97.0">
+    <label>Source extent</label>
+    <description>Information about the spatial, vertical and temporal extent of the source
+      data</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:sourceReferenceSystem" id="95.0">
+    <label>Source reference system</label>
+    <description>Spatial reference system used by the source data</description>
+  </element>
+  <element name="gmd:sourceStep" id="98.0">
+    <label>Source step</label>
+    <description>Information about an event in the creation process for the source
+      data</description>
+  </element>
+  <element name="gmd:southBoundLatitude" id="346.0">
+    <label>South bound</label>
+    <description>Southern-most coordinate of the limit of the dataset extent, expressed in
+      latitude in decimal degrees (positive north)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:spatialExtent" id="353.0">
+    <label>Spatial extent</label>
+    <description>Spatial extent component of composite spatial and temporal extent</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:spatialRepresentationInfo" id="12.0">
+    <label>Spatial representation info</label>
+    <description>Digital representation of spatial information in the dataset</description>
+  </element>
+  <element name="gmd:spatialRepresentationType" id="37.0">
+    <label>Spatial representation type</label>
+    <description>Method used to spatially represent geographic information</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:spatialResolution" id="38.0">
+    <label>Spatial resolution</label>
+    <description>Factor which provides a general understanding of the density of spatial data in
+      the dataset</description>
+  </element>
+  <element name="gmd:specificUsage" id="63.0">
+    <label>Specific usage</label>
+    <description>Brief description of the resource and/or resource series usage</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:specification" id="130.0" context="gmd:DQ_ConformanceResult">
+    <condition>mandatory</condition>
+    <label>Specification</label>
+    <description>Citation of product specification or user requirement against which data is
+      being evaluated</description>
+  </element>
+  <element name="gmd:specification" id="288.0" context="gmd:MD_Format">
+    <label>Specification</label>
+    <description>Name of a subset, profile, or product specification of the format</description>
+  </element>
+  <element name="gmd:specification">
+    <label>Specification</label>
+  </element>
+  <element name="gmd:statement" id="83.0">
+    <label>Statement</label>
+    <description>General explanation of the data producer_s knowledge about the lineage of a
+      dataset</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:status" id="28.0">
+    <label>Status</label>
+    <btnLabel>Add status</btnLabel>
+    <description>Select the status of the dataset from the list. i.e.. If your dataset is not yet complete, select 'Planned'.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:supplementalInformation" id="46.0">
+    <label>Supplemental Information</label>
+    <description>This field can be used to provide any additional information about the dataset not captured in the form. Use it to link to program information, data quality reports, data dictionaries, etc.</description>
+  </element>
+  <element name="gmd:temporalElement" id="337.0">
+    <label>Temporal element</label>
+    <description>Provides temporal component of the extent of the referring object</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:textGroup" id="602.0">
+    <label>TextGroup</label>
+    <description>TextGroup</description>
+  </element>
+  <element name="gmd:thesaurusName" id="55.0">
+    <label>Thesaurus name</label>
+    <description>You can add a keyword from a list by first selecting your thesaurus here. Once you select a thesaurus the keyword field will provide you with a drop-down menu to choose from. </description>
+  </element>
+  <element name="gmd:title" id="360.0">
+    <label>Title</label>
+    <description>Identifies the title of the resource being described. Enter the full, official name by which the cited resource is known</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:title" id="507.0" context="gmd:MD_Legislation">
+    <label>Title</label>
+    <description>Reference to legal title</description>
+  </element>
+  <element name="gmd:toneGradation" id="265.0">
+    <label>Tone gradation</label>
+    <description>Number of discrete numerical values in the grid data</description>
+  </element>
+  <element name="gmd:topicCategory" id="41.0">
+    <label>Topic category</label>
+    <btnLabel>Add topic category</btnLabel>
+    <description>Please select the most appropriate category from the list provided. These categories help to group datasets for easier discovery. This element is repeatable; select all category codes that apply to the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:MD_TopicCategoryCode">
+    <label>Topic category</label>
+    <description>Please select the most appropriate category from the list provided. These categories help to group datasets for easier discovery. This element is repeatable; select all category codes that apply to the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:topologyLevel" id="177.0">
+    <label>Topology level</label>
+    <description>Code which identifies the degree of complexity of the spatial
+      relationships</description>
+  </element>
+  <element name="gmd:transferOptions" id="273.0">
+    <label>Transfer options</label>
+    <description>Provides information about technical means and media by which a resource is
+      obtained from the distributor</description>
+  </element>
+  <element name="gmd:transferSize" id="276.0">
+    <label>Transfer size</label>
+    <description>Estimated size of a unit in the specified transfer format, expressed in
+      megabytes. The transfer size is &gt; 0.0</description>
+  </element>
+  <element name="gmd:transformationDimensionDescription" id="168.0">
+    <label>Transformation dimension description</label>
+    <description>Description of the information about which grid dimensions are the spatial
+      dimensions</description>
+  </element>
+  <element name="gmd:transformationDimensionMapping" id="169.0">
+    <label>Transformation dimension mapping</label>
+    <description>Information about which grid dimensions are the spatial
+      dimensions</description>
+  </element>
+  <element name="gmd:transformationParameterAvailability" id="161.0">
+    <label>Transformation parameter availability</label>
+    <condition>mandatory</condition>
+    <description>Indication of whether or not parameters for transformation between image
+      coordinates and geographic or map coordinates exist (are available)</description>
+  </element>
+  <element name="gmd:triangulationIndicator" id="251.0">
+    <label>Triangulation indicator</label>
+    <description>Indication of whether or not triangulation has been performed upon the
+      image</description>
+  </element>
+  <element name="gmd:turnaround" id="302.0">
+    <label>Turnaround</label>
+    <description>Typical turnaround time for the filling of an order</description>
+  </element>
+  <element name="gmd:type" id="54.0">
+    <label>Type</label>
+    <description>Subject matter used to group similar keywords. Select the most appropriate from the list.</description>
+  </element>
+  <element name="gmd:type" id="540.0" context="gmd:MD_CodeDomain">
+    <label>Type</label>
+    <description>Datatype of the code domain</description>
+  </element>
+  <element name="gmd:type" id="543.0" context="gmd:MD_Type">
+    <label>Type definition</label>
+    <description>Data type definition</description>
+    <help>Data type definition, formal of informal (i.e. Text12, Line)</help>
+  </element>
+  <element name="gmd:units" id="262.0">
+    <label>Value unit</label>
+    <description>Units in which sensor wavelengths are expressed</description>
+  </element>
+  <element name="gmd:unitsOfDistribution" id="275.0">
+    <label>Units of distribution</label>
+    <description>Tiles, layers, geographic areas, etc., in which data is available</description>
+  </element>
+  <element name="gmd:updateScope" id="146.0">
+    <label>Update scope</label>
+    <description>Scope of data to which maintenance is applied</description>
+  </element>
+  <element name="gmd:updateScopeDescription" id="147.0">
+    <label>Update scope description</label>
+    <description>Additional information about the range or extent of the resource</description>
+  </element>
+  <element name="gmd:usageDateTime" id="64.0">
+    <label>Usage datetime</label>
+    <description>Date and time of the first use or range of uses of the resource and/or resource
+      series (YYYY-MM-DDThh:mm:ss)</description>
+  </element>
+  <element name="gmd:useConstraints" id="71.0">
+    <label>Use Constraints</label>
+    <description>This element allows you to indicate any additional or special restrictions or limitations that may exist on use of the resource, outside of those which are covered by existing departmental restrictions.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:useLimitation" id="68.0">
+    <label>Use Limitation</label>
+    <description>Limitation affecting the fitness for use of the resource. Example, _not to be
+      used for navigation_</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:userContactInfo" id="66.0">
+    <label>User contact info</label>
+    <description>Identification of and means of communicating with person(s) and organization(s)
+      using the resource(s)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:userDefinedMaintenanceFrequency" id="145.0">
+    <label>User defined maintenance frequency</label>
+    <description>Maintenance period other than those defined</description>
+  </element>
+  <element name="gmd:userDeterminedLimitations" id="65.0">
+    <label>User determined limitations</label>
+    <description>Applications, determined by the user for which the resource and/or resource
+      series is not suitable</description>
+  </element>
+  <element name="gmd:userNote" id="75.0">
+    <label>Security User note</label>
+    <description>Explanation of the application of the legal constraints or other restrictions
+      and legal prerequisites for obtaining and using the resource or metadata</description>
+  </element>
+  <element name="gmd:value" id="137.0" context="gmd:DQ_QuantitativeResult">
+    <condition>mandatory</condition>
+    <label>Value</label>
+    <description>Quantitative value or values, content determined by the evaluation procedure
+      used</description>
+  </element>
+  <element name="gmd:value">
+    <label>Value</label>
+    <description/>
+  </element>
+  <element name="gmd:value" id="544.0" context="gmd:MD_Type">
+    <label>Value</label>
+    <description>Data type value</description>
+  </element>
+  <element name="gmd:valueType" id="134.0">
+    <label>Value type</label>
+    <description>Quantitative conformance quality level value or range of values</description>
+    <helper>
+      <option value="Boolean">Boolean</option>
+      <option value="Real">Real</option>
+      <option value="Integer">Integer</option>
+      <option value="Ratio">Ratio</option>
+      <option value="Percentage">Percentage</option>
+      <option value="Measure(s) (value(s) + unit(s))">Measure(s) (value(s) + unit(s))</option>
+    </helper>
+  </element>
+  <element name="gmd:valueUnit" id="135.0">
+    <label>Value unit</label>
+    <description>Value unit for reporting a data quality result</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gmd:version" id="208.2" context="gmd:RS_Identifier">
+    <label>Version</label>
+    <description>Version identifier for the namespace</description>
+  </element>
+  <element name="gmd:version" context="gmd:MD_Format" id="286.0">
+    <label>File Format Version</label>
+    <description>Enter the version of the data transfer format(s). For a list of possible versions, see the 'suggestions' menu. If the version is unknown, enter "unknown"</description>
+  </element>
+  <element name="gmd:verticalElement" id="338.0">
+    <label>Vertical element</label>
+    <description>Provides vertical component of the extent of the referring object</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="gmd:voice" id="408.0">
+    <label>Telephone Number (Voice)</label>
+    <description>Telephone number by which individuals can speak to the responsible organization or individual</description>
+  </element>
+  <element name="gmd:volumes" id="295.0">
+    <label>Volumes</label>
+    <description>Number of items in the media identified</description>
+  </element>
+  <element name="gmd:westBoundLongitude" id="344.0">
+    <label>West bound</label>
+    <description>Western-most coordinate of the limit of the dataset extent, expressed in
+      longitude in decimal degrees (positive east)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gml:beginPosition">
+    <label>Begin Date</label>
+    <description>Enter the date on which data collection began or is scheduled to begin. You may use the calendar to select the date or enter it in YYYY-MM-DD format for full date, YYYY-MM format for month/year or YYYY format for year.</description>
+  </element>
 
-    <element name="gml:endPosition">
-        <label>End Date</label>
-        <description>Enter the date on which data collection ended or is scheduled to end. You may use the calendar to select the date or enter it in YYYY-MM-DD format for full date, YYYY-MM format for month/year or YYYY format for year.</description>
-    </element>
+  <element name="gml:endPosition">
+    <label>End Date</label>
+    <description>Enter the date on which data collection ended or is scheduled to end. You may use the calendar to select the date or enter it in YYYY-MM-DD format for full date, YYYY-MM format for month/year or YYYY format for year.</description>
+  </element>
 
-    <element name="gml:relatedTime">
-        <label>Related time</label>
-        <description>Defines the relation of a given time to the object.</description>
-    </element>
+  <element name="gml:relatedTime">
+    <label>Related time</label>
+    <description>Defines the relation of a given time to the object.</description>
+  </element>
 
-    <element name="gml:coordinates">
-        <label>Coordinates</label>
-        <description>Used to record an array of tuples or coordinates.</description>
-    </element>
+  <element name="gml:coordinates">
+    <label>Coordinates</label>
+    <description>Used to record an array of tuples or coordinates.</description>
+  </element>
 
-    <element name="gml:Polygon">
-        <label>Polygon</label>
-        <description>A gml:Polygon is a special surface that is defined by a single surface patch.
-            The boundary of this patch is coplanar and the polygon uses planar interpolation in its
-            interior.</description>
-    </element>
+  <element name="gml:Polygon">
+    <label>Polygon</label>
+    <description>A gml:Polygon is a special surface that is defined by a single surface patch.
+      The boundary of this patch is coplanar and the polygon uses planar interpolation in its
+      interior.</description>
+  </element>
 
-    <element name="gml:Point">
-        <label>Point</label>
-        <description>A gml:Point is defined by a single coordinate tuple.</description>
-        <example>74. -37.</example>
-    </element>
+  <element name="gml:Point">
+    <label>Point</label>
+    <description>A gml:Point is defined by a single coordinate tuple.</description>
+    <example>74. -37.</example>
+  </element>
 
-    <element name="gml:LineString">
-        <label>Line</label>
-        <description>A gml:LineString is a special curve that consists of a single segment with
-            linear interpolation. It is defined by two or more coordinate tuples, with linear
-            interpolation between them.</description>
-    </element>
+  <element name="gml:LineString">
+    <label>Line</label>
+    <description>A gml:LineString is a special curve that consists of a single segment with
+      linear interpolation. It is defined by two or more coordinate tuples, with linear
+      interpolation between them.</description>
+  </element>
 
-    <element name="gml:LinearRing">
-        <label>Linear ring</label>
-        <description>A gml:LinearRing is defined by four or more coordinate tuples, with linear
-            interpolation between them; the first and last coordinates shall be
-            coincident.</description>
-    </element>
+  <element name="gml:LinearRing">
+    <label>Linear ring</label>
+    <description>A gml:LinearRing is defined by four or more coordinate tuples, with linear
+      interpolation between them; the first and last coordinates shall be
+      coincident.</description>
+  </element>
 
-    <element name="gml:exterior">
-        <label>Outer boundary</label>
-        <description>The outer boundary of a solid.</description>
-    </element>
+  <element name="gml:exterior">
+    <label>Outer boundary</label>
+    <description>The outer boundary of a solid.</description>
+  </element>
 
-    <element name="gml:interior">
-        <label>Inner boundary</label>
-        <description>The inner boundary of a solid</description>
-    </element>
-
-
-    <element name="gml:begin">
-        <label>Begin</label>
-        <description/>
-    </element>
-    <element name="gml:end">
-        <label>End</label>
-        <description/>
-    </element>
-    <element name="gml:duration">
-        <label>Duration</label>
-    	<description>Conforms to the ISO 8601 syntax for temporal length as implemented by the XML Schema duration type.</description>
-    </element>
-    <element name="gml:timeInterval">
-        <label>Time interval</label>
-    	<description>conforms to ISO 11404 which is based on floating point values for temporal length.
-    		ISO 11404 syntax specifies the use of a positiveInteger together with appropriate values for radix and factor. The resolution of the time interval is to one radix ^(-factor) of the specified time unit.
-    		The value of the unit is either selected from the units for time intervals from ISO 31-1:1992, or is another suitable unit.  The encoding is defined for GML in gml:TimeUnitType. The second component of this union type provides a method for indicating time units other than the six standard units given in the enumeration.</description>
-    </element>
-	<element name="gml:name">
-		<label>Name</label>
-		<description></description>
-	</element>
-	<element name="gml:metaDataProperty">
-		<label>Metadata property</label>
-		<description></description>
-	</element>
-	<element name="gml:identifier">
-		<label>Identifier</label>
-		<description></description>
-	</element>
-	<element name="gml:description">
-		<label>Description</label>
-		<description>Text description of the element</description>
-	</element>
-	<element name="gml:descriptionReference">
-		<label>Description reference</label>
-		<description></description>
-	</element>
-	<element name="gml:TimeInstant">
-        <label>Time instant</label>
-        <description/>
-    </element>
-    <element name="gml:TimePosition">
-        <label>Time position</label>
-        <description/>
-    </element>
-	<element name="gml:timePosition">
-		<label>Time position</label>
-		<description/>
-	</element>
-    <element name="gml:TimePeriod">
-        <label>Time period</label>
-        <description/>
-    </element>
-    <element name="gml:TimeNode">
-        <label>Time node</label>
-        <description/>
-    </element>
-    <element name="gml:TimeEdge">
-        <label>Time edge</label>
-        <description/>
-    </element>
-    <element name="gml:ProjectedCRS">
-        <label>Projected CRS</label>
-        <description/>
-    </element>
-
-    <element name="gml:id">
-        <label>Identifier</label>
-        <description>Unique identifier</description>
-    </element>
-
-    <element name="gml:id" id="191.0" context="gmd:MD_CRS">
-        <label>Ellipsoid</label>
-        <description>Identity of the ellipsoid used</description>
-        <help>identity of the ellipsoid used</help>
-    </element>
-    <element name="id" id="191.0">
-        <label>Identifier</label>
-        <description>Unique identifier</description>
-    </element>
-	<element name="indeterminatePosition">
-		<label>Indeterminate position</label>
-		<description></description>
-	</element>
-	<element name="frame">
-		<label>Frame</label>
-		<description>Frame attribute provides a URI reference that identifies a description of the reference system</description>
-	</element>
-	<element name="calendarEraName">
-		<label>Name of the calendar era</label>
-		<description></description>
-	</element>
-	<element name="unit">
-		<label>Unit</label>
-		<description></description>
-	</element>
-	<element name="radix">
-		<label>Radix</label>
-		<description></description>
-	</element>
-	<element name="factor">
-		<label>Factor</label>
-		<description></description>
-	</element>
+  <element name="gml:interior">
+    <label>Inner boundary</label>
+    <description>The inner boundary of a solid</description>
+  </element>
 
 
+  <element name="gml:begin">
+    <label>Begin</label>
+    <description/>
+  </element>
+  <element name="gml:end">
+    <label>End</label>
+    <description/>
+  </element>
+  <element name="gml:duration">
+    <label>Duration</label>
+    <description>Conforms to the ISO 8601 syntax for temporal length as implemented by the XML Schema duration type.</description>
+  </element>
+  <element name="gml:timeInterval">
+    <label>Time interval</label>
+    <description>conforms to ISO 11404 which is based on floating point values for temporal length.
+      ISO 11404 syntax specifies the use of a positiveInteger together with appropriate values for radix and factor. The resolution of the time interval is to one radix ^(-factor) of the specified time unit.
+      The value of the unit is either selected from the units for time intervals from ISO 31-1:1992, or is another suitable unit.  The encoding is defined for GML in gml:TimeUnitType. The second component of this union type provides a method for indicating time units other than the six standard units given in the enumeration.</description>
+  </element>
+  <element name="gml:name">
+    <label>Name</label>
+    <description></description>
+  </element>
+  <element name="gml:metaDataProperty">
+    <label>Metadata property</label>
+    <description></description>
+  </element>
+  <element name="gml:identifier">
+    <label>Identifier</label>
+    <description></description>
+  </element>
+  <element name="gml:description">
+    <label>Description</label>
+    <description>Text description of the element</description>
+  </element>
+  <element name="gml:descriptionReference">
+    <label>Description reference</label>
+    <description></description>
+  </element>
+  <element name="gml:TimeInstant">
+    <label>Time instant</label>
+    <description/>
+  </element>
+  <element name="gml:TimePosition">
+    <label>Time position</label>
+    <description/>
+  </element>
+  <element name="gml:timePosition">
+    <label>Time position</label>
+    <description/>
+  </element>
+  <element name="gml:TimePeriod">
+    <label>Time period</label>
+    <description/>
+  </element>
+  <element name="gml:TimeNode">
+    <label>Time node</label>
+    <description/>
+  </element>
+  <element name="gml:TimeEdge">
+    <label>Time edge</label>
+    <description/>
+  </element>
+  <element name="gml:ProjectedCRS">
+    <label>Projected CRS</label>
+    <description/>
+  </element>
 
-    <element name="srv:SV_ServiceIdentification">
-        <label>Service Identification (19119)</label>
-        <description>ISO 19119-2005 Service Identification</description>
-    </element>
-    <element name="srv:SV_ParameterDirection">
-        <label>Parameter direction</label>
-    </element>
-    <element name="srv:serviceType"><!-- readonly="true" -->
-        <label>Service Type</label>
-        <description>Service type name from a registry of services. For example, the values of the
-            nameSpace and name attributes of GeneralName may be 'OGC' and 'catalogue'</description>
-        <helper>
-        	<option value="OGC:WMS">OGC Web Map Service (OGC:WMS)</option>
-            <option value="OGC:WFS">OGC Web Feature Service (OGC:WFS)</option>
-            <option value="OGC:WCS">OGC Web Coverage Service (OGC:WCS)</option>
-            <option value="W3C:HTML:DOWNLOAD">Download (W3C:HTML:DOWNLOAD)</option>
-            <option value="W3C:HTML:LINK">Information (W3C:HTML:LINK)</option>
-        	<!--INSPIRE Service type defined in MD IR / 1.3.1 Spatial data service type
-            <option value="discovery">Discovery Service (discovery)</option>
-            <option value="view">View Service (view)</option>
-            <option value="download">Download Service (download)</option>
-            <option value="transformation">Transformation Service (transformation)</option>
-            <option value="other">Other Services (other)</option>  -->
-        </helper>
-    </element>
-    <element name="srv:serviceTypeVersion">
-        <label>Service Version</label>
-        <description>Provides for searching based on the version of serviceType. For example, we may
-            only be interested in OGC Catalogue V1.1 services. If version is maintained as a
-            separate attribute, users can easily search for all services of a type regardless of the
-            version</description>
-    </element>
-    <element name="srv:accessProperties">
-        <label>Access Properties</label>
-        <description>Information about the availability of the service eg. fees, availability,
-            oredering instructions</description>
-    </element>
-    <element name="srv:restrictions">
-        <label>Restrictions</label>
-        <description>Legal and security constraints on accessing the service and distributing data
-            generated by the service</description>
-    </element>
-    <element name="srv:containsOperations">
-        <label>Contains Operations</label>
-        <description>Provides information about the operations that comprise the
-            service</description>
-    </element>
-    <element name="srv:operatesOn">
-        <label>Operates On</label>
-        <description>Provides information on the datasets that the service operates on</description>
-    </element>
-    <element name="srv:operationName">
-        <label>Operation Name</label>
-        <description>A unique identifier for this interface</description>
-    </element>
-    <element name="srv:SV_OperationMetadata">
-        <label>Operation</label>
-        <description>Operation Metadata</description>
-    </element>
-    <element name="srv:DCP">
-        <label>Distributed Computing Platforms</label>
-        <description>Distributed computing platforms on which the operation has been
-            implemented</description>
-    </element>
-    <element name="srv:operationDescription">
-        <label>Operation Description</label>
-        <description>Free text description of the intent of the operation and the results of the
-            operation</description>
-    </element>
-    <element name="srv:invocationName">
-        <label>Invocation Name</label>
-        <description>The name used to invoke this interface within the context of the DCP. The name
-            is identical for all DCPs</description>
-    </element>
-    <element name="srv:parameters">
-        <label>Parameters</label>
-        <description>The parameters that are required for this interface</description>
-    </element>
-    <element name="srv:SV_Parameter">
-        <label>Parameter</label>
-        <description>The parameters that are required for this interface</description>
-    </element>
-    <element name="srv:direction">
-        <label>Direction</label>
-    </element>
-    <element name="srv:valueType">
-        <label>Value type</label>
-    </element>
-    <element name="srv:connectPoint">
-        <label>Connect Point</label>
-        <description>Handle for accessing the service interface</description>
-    </element>
-    <element name="srv:dependsOn">
-        <label>Depends On</label>
-        <description>List of operations that must be completed immediately before current operation
-            is invoked, structured as a list for capturing alternate predecessor paths and sets for
-            capturing parallel predecessor paths</description>
-    </element>
-    <element name="srv:providerName">
-        <label>Provider Name</label>
-        <description>A unique identifier for this organization</description>
-    </element>
-    <element name="srv:serviceContact">
-        <label>Service Contact</label>
-        <description>Information for contacting the service provider</description>
-    </element>
-    <element name="srv:name">
-        <label>Name</label>
-        <description>The name, as used by the service for this chain or paramater</description>
-    </element>
-    <element name="srv:description">
-        <label>Description</label>
-        <description>Narrative explanation of the services in the chain and resulting output or role
-            of the parameter</description>
-    </element>
-    <element name="srv:optionality">
-        <label>Optionality</label>
-        <description>Indication if the parameter is required</description>
-    </element>
-    <element name="srv:repeatability">
-        <label>Repeatability</label>
-        <description>Indication if more than one value of the parameter may be
-            provided</description>
-    </element>
-    <element name="srv:coupledResource">
-        <label>Coupled Resource</label>
-        <description>Details of services coupled with this one</description>
-        <inspireInfo>Optional in INSPIRE</inspireInfo>
-    </element>
-    <element name="srv:SV_CoupledResource">
-        <label>Coupled Resource</label>
-        <description>Details of services coupled with this one</description>
-    </element>
-    <element name="srv:identifier">
-        <label>Identifier</label>
-        <description>Identifier of resource to which the operation applies</description>
-    </element>
-    <element name="srv:couplingType">
-        <label>Coupling Type</label>
-        <description>Type of Coupling</description>
-    </element>
-    <element name="srv:extent">
-        <label>Extent</label>
-        <description>Geographic/Temporal Extent of Service</description>
-    </element>
-    <element name="srv:keywords">
-        <label>Keywords</label>
-        <description>Keywords describing service</description>
-    </element>
-    <element name="gmd:locale">
-        <label>Other language</label>
-        <description>Use this section to define other metadata language (multilingual metadata).</description>
-    </element>
-    <element name="gmd:describes">
-        <label>Describes</label>
-        <description>Describes</description>
-    </element>
-    <element name="gmd:propertyType">
-        <label>PropertyType</label>
-        <description>PropertyType</description>
-    </element>
-    <element name="gmd:PT_Locale">
-        <label>Locale</label>
-        <description>Locale</description>
-    </element>
-    <element name="gmd:PT_LocaleContainer">
-        <label>PT_LocaleContainer</label>
-        <description>PT_LocaleContainer</description>
-    </element>
-    <element name="gmd:featureType">
-        <label>Feature type</label>
-        <description>Subset of feature types from cited feature catalogue occurring in
-            data</description>
-    </element>
-    <element name="gmd:featureAttribute">
-        <label>Feature attribute</label>
-        <description/>
-    </element>
-    <element name="gmd:DS_Association">
-        <label>DS_Association</label>
-        <description>DS_Association</description>
-    </element>
-    <element name="gmd:DS_DataSet">
-        <label>DS_DataSet</label>
-        <description>DS_DataSet</description>
-    </element>
-    <element name="gmd:DS_Initiative">
-        <label>DS_Initiative</label>
-        <description>DS_Initiative</description>
-    </element>
-    <element name="gmd:DS_OtherAggregate">
-        <label>DS_OtherAggregate</label>
-        <description>DS_OtherAggregate</description>
-    </element>
-    <element name="gmd:DS_Platform">
-        <label>DS_Platform</label>
-        <description>DS_Platform</description>
-    </element>
-    <element name="gmd:DS_ProductionSeries">
-        <label>DS_ProductionSeries</label>
-        <description>DS_ProductionSeries</description>
-    </element>
-    <element name="gmd:DS_Sensor">
-        <label>DS_Sensor</label>
-        <description>DS_Sensor</description>
-    </element>
-    <element name="gmd:DS_Series">
-        <label>DS_Series</label>
-        <description>DS_Series</description>
-    </element>
-    <element name="gmd:DS_StereoMate">
-        <label>DS_StereoMate</label>
-        <description>DS_StereoMate</description>
-    </element>
-    <element name="gmd:languageCode">
-        <label>Language</label>
-        <description>Language code</description>
-    </element>
-	        <element name="gmd:LanguageCode">
-		<label>Other metadata language</label>
-		<description>Select the alternative language used to create the metadata</description>
-	</element>
-    <element name="gmd:characterEncoding">
-        <label>Character encoding</label>
-        <description>CharacterEncoding</description>
-    </element>
-    <element name="uuidref">
-        <label>Metadata uuid</label>
-        <description>Unique identifier</description>
-    </element>
-    <element name="uom">
-        <label>Units of measure</label>
-        <description/>
-        <helper>
-            <option value="m">meters</option>
-        </helper>
-    </element>
-    <element name="gco:Record">
-        <label>Record</label>
-        <description/>
-    </element>
-    <element name="gco:Binary">
-        <label>Binary</label>
-        <description/>
-    </element>
-    <element name="gco:MemberName">
-        <label>Member name</label>
-        <description/>
-    </element>
-    <element name="gco:aName">
-        <label>Name</label>
-        <description/>
-    </element>
-    <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:name/gco:attributeType/gco:TypeName/gco:aName">
-        <label>Type name</label>
-        <description/>
-        <helper>
-			<option value="BOOLEAN">BOOLEAN</option>
-			<option value="BYTE">BYTE</option>
-			<option value="CHARACTER">CHARACTER</option>
-			<option value="DATE">DATE</option>
-			<option value="DATETIME">DATETIME</option>
-			<option value="DOUBLE">DOUBLE</option>
-			<option value="FLOAT">FLOAT</option>
-			<option value="INTEGER">INTEGER</option>
-			<option value="NUMERIC">NUMERIC</option>
-			<option value="REAL">REAL</option>
-			<option value="SERIAL">SERIAL</option>
-			<option value="VARCHAR">VARCHAR</option>
-			<option value="TEXT">TEXT</option>
-		</helper>
+  <element name="gml:id">
+    <label>Identifier</label>
+    <description>Unique identifier</description>
+  </element>
+
+  <element name="gml:id" id="191.0" context="gmd:MD_CRS">
+    <label>Ellipsoid</label>
+    <description>Identity of the ellipsoid used</description>
+    <help>identity of the ellipsoid used</help>
+  </element>
+  <element name="id" id="191.0">
+    <label>Identifier</label>
+    <description>Unique identifier</description>
+  </element>
+  <element name="indeterminatePosition">
+    <label>Indeterminate position</label>
+    <description></description>
+  </element>
+  <element name="frame">
+    <label>Frame</label>
+    <description>Frame attribute provides a URI reference that identifies a description of the reference system</description>
+  </element>
+  <element name="calendarEraName">
+    <label>Name of the calendar era</label>
+    <description></description>
+  </element>
+  <element name="unit">
+    <label>Unit</label>
+    <description></description>
+  </element>
+  <element name="radix">
+    <label>Radix</label>
+    <description></description>
+  </element>
+  <element name="factor">
+    <label>Factor</label>
+    <description></description>
+  </element>
+
+
+
+  <element name="srv:SV_ServiceIdentification">
+    <label>Service Identification (19119)</label>
+    <description>ISO 19119-2005 Service Identification</description>
+  </element>
+  <element name="srv:SV_ParameterDirection">
+    <label>Parameter direction</label>
+  </element>
+  <element name="srv:serviceType"><!-- readonly="true" -->
+    <label>Service Type</label>
+    <description>Service type name from a registry of services. For example, the values of the
+      nameSpace and name attributes of GeneralName may be 'OGC' and 'catalogue'</description>
+    <helper>
+      <option value="OGC:WMS">OGC Web Map Service (OGC:WMS)</option>
+      <option value="OGC:WFS">OGC Web Feature Service (OGC:WFS)</option>
+      <option value="OGC:WCS">OGC Web Coverage Service (OGC:WCS)</option>
+      <option value="W3C:HTML:DOWNLOAD">Download (W3C:HTML:DOWNLOAD)</option>
+      <option value="W3C:HTML:LINK">Information (W3C:HTML:LINK)</option>
+      <!--INSPIRE Service type defined in MD IR / 1.3.1 Spatial data service type
+        <option value="discovery">Discovery Service (discovery)</option>
+        <option value="view">View Service (view)</option>
+        <option value="download">Download Service (download)</option>
+        <option value="transformation">Transformation Service (transformation)</option>
+        <option value="other">Other Services (other)</option>  -->
+    </helper>
+  </element>
+  <element name="srv:serviceTypeVersion">
+    <label>Service Version</label>
+    <description>Provides for searching based on the version of serviceType. For example, we may
+      only be interested in OGC Catalogue V1.1 services. If version is maintained as a
+      separate attribute, users can easily search for all services of a type regardless of the
+      version</description>
+  </element>
+  <element name="srv:accessProperties">
+    <label>Access Properties</label>
+    <description>Information about the availability of the service eg. fees, availability,
+      oredering instructions</description>
+  </element>
+  <element name="srv:restrictions">
+    <label>Restrictions</label>
+    <description>Legal and security constraints on accessing the service and distributing data
+      generated by the service</description>
+  </element>
+  <element name="srv:containsOperations">
+    <label>Contains Operations</label>
+    <description>Provides information about the operations that comprise the
+      service</description>
+  </element>
+  <element name="srv:operatesOn">
+    <label>Operates On</label>
+    <description>Provides information on the datasets that the service operates on</description>
+  </element>
+  <element name="srv:operationName">
+    <label>Operation Name</label>
+    <description>A unique identifier for this interface</description>
+  </element>
+  <element name="srv:SV_OperationMetadata">
+    <label>Operation</label>
+    <description>Operation Metadata</description>
+  </element>
+  <element name="srv:DCP">
+    <label>Distributed Computing Platforms</label>
+    <description>Distributed computing platforms on which the operation has been
+      implemented</description>
+  </element>
+  <element name="srv:operationDescription">
+    <label>Operation Description</label>
+    <description>Free text description of the intent of the operation and the results of the
+      operation</description>
+  </element>
+  <element name="srv:invocationName">
+    <label>Invocation Name</label>
+    <description>The name used to invoke this interface within the context of the DCP. The name
+      is identical for all DCPs</description>
+  </element>
+  <element name="srv:parameters">
+    <label>Parameters</label>
+    <description>The parameters that are required for this interface</description>
+  </element>
+  <element name="srv:SV_Parameter">
+    <label>Parameter</label>
+    <description>The parameters that are required for this interface</description>
+  </element>
+  <element name="srv:direction">
+    <label>Direction</label>
+  </element>
+  <element name="srv:valueType">
+    <label>Value type</label>
+  </element>
+  <element name="srv:connectPoint">
+    <label>Connect Point</label>
+    <description>Handle for accessing the service interface</description>
+  </element>
+  <element name="srv:dependsOn">
+    <label>Depends On</label>
+    <description>List of operations that must be completed immediately before current operation
+      is invoked, structured as a list for capturing alternate predecessor paths and sets for
+      capturing parallel predecessor paths</description>
+  </element>
+  <element name="srv:providerName">
+    <label>Provider Name</label>
+    <description>A unique identifier for this organization</description>
+  </element>
+  <element name="srv:serviceContact">
+    <label>Service Contact</label>
+    <description>Information for contacting the service provider</description>
+  </element>
+  <element name="srv:name">
+    <label>Name</label>
+    <description>The name, as used by the service for this chain or paramater</description>
+  </element>
+  <element name="srv:description">
+    <label>Description</label>
+    <description>Narrative explanation of the services in the chain and resulting output or role
+      of the parameter</description>
+  </element>
+  <element name="srv:optionality">
+    <label>Optionality</label>
+    <description>Indication if the parameter is required</description>
+  </element>
+  <element name="srv:repeatability">
+    <label>Repeatability</label>
+    <description>Indication if more than one value of the parameter may be
+      provided</description>
+  </element>
+  <element name="srv:coupledResource">
+    <label>Coupled Resource</label>
+    <description>Details of services coupled with this one</description>
+    <inspireInfo>Optional in INSPIRE</inspireInfo>
+  </element>
+  <element name="srv:SV_CoupledResource">
+    <label>Coupled Resource</label>
+    <description>Details of services coupled with this one</description>
+  </element>
+  <element name="srv:identifier">
+    <label>Identifier</label>
+    <description>Identifier of resource to which the operation applies</description>
+  </element>
+  <element name="srv:couplingType">
+    <label>Coupling Type</label>
+    <description>Type of Coupling</description>
+  </element>
+  <element name="srv:extent">
+    <label>Extent</label>
+    <description>Geographic/Temporal Extent of Service</description>
+  </element>
+  <element name="srv:keywords">
+    <label>Keywords</label>
+    <description>Keywords describing service</description>
+  </element>
+  <element name="gmd:locale">
+    <label>Other language</label>
+    <description>Use this section to define other metadata language (multilingual metadata).</description>
+  </element>
+  <element name="gmd:describes">
+    <label>Describes</label>
+    <description>Describes</description>
+  </element>
+  <element name="gmd:propertyType">
+    <label>PropertyType</label>
+    <description>PropertyType</description>
+  </element>
+  <element name="gmd:PT_Locale">
+    <label>Locale</label>
+    <description>Locale</description>
+  </element>
+  <element name="gmd:PT_LocaleContainer">
+    <label>PT_LocaleContainer</label>
+    <description>PT_LocaleContainer</description>
+  </element>
+  <element name="gmd:featureType">
+    <label>Feature type</label>
+    <description>Subset of feature types from cited feature catalogue occurring in
+      data</description>
+  </element>
+  <element name="gmd:featureAttribute">
+    <label>Feature attribute</label>
+    <description/>
+  </element>
+  <element name="gmd:DS_Association">
+    <label>DS_Association</label>
+    <description>DS_Association</description>
+  </element>
+  <element name="gmd:DS_DataSet">
+    <label>DS_DataSet</label>
+    <description>DS_DataSet</description>
+  </element>
+  <element name="gmd:DS_Initiative">
+    <label>DS_Initiative</label>
+    <description>DS_Initiative</description>
+  </element>
+  <element name="gmd:DS_OtherAggregate">
+    <label>DS_OtherAggregate</label>
+    <description>DS_OtherAggregate</description>
+  </element>
+  <element name="gmd:DS_Platform">
+    <label>DS_Platform</label>
+    <description>DS_Platform</description>
+  </element>
+  <element name="gmd:DS_ProductionSeries">
+    <label>DS_ProductionSeries</label>
+    <description>DS_ProductionSeries</description>
+  </element>
+  <element name="gmd:DS_Sensor">
+    <label>DS_Sensor</label>
+    <description>DS_Sensor</description>
+  </element>
+  <element name="gmd:DS_Series">
+    <label>DS_Series</label>
+    <description>DS_Series</description>
+  </element>
+  <element name="gmd:DS_StereoMate">
+    <label>DS_StereoMate</label>
+    <description>DS_StereoMate</description>
+  </element>
+  <element name="gmd:languageCode">
+    <label>Language</label>
+    <description>Language code</description>
+  </element>
+  <element name="gmd:LanguageCode">
+    <label>Other metadata language</label>
+    <description>Select the alternative language used to create the metadata</description>
+  </element>
+  <element name="gmd:characterEncoding">
+    <label>Character encoding</label>
+    <description>CharacterEncoding</description>
+  </element>
+  <element name="uuidref">
+    <label>Metadata uuid</label>
+    <description>Unique identifier</description>
+  </element>
+  <element name="uom">
+    <label>Units of measure</label>
+    <description/>
+    <helper>
+      <option value="m">meters</option>
+    </helper>
+  </element>
+  <element name="gco:Record">
+    <label>Record</label>
+    <description/>
+  </element>
+  <element name="gco:Binary">
+    <label>Binary</label>
+    <description/>
+  </element>
+  <element name="gco:MemberName">
+    <label>Member name</label>
+    <description/>
+  </element>
+  <element name="gco:aName">
+    <label>Name</label>
+    <description/>
+  </element>
+  <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:name/gco:attributeType/gco:TypeName/gco:aName">
+    <label>Type name</label>
+    <description/>
+    <helper>
+      <option value="BOOLEAN">BOOLEAN</option>
+      <option value="BYTE">BYTE</option>
+      <option value="CHARACTER">CHARACTER</option>
+      <option value="DATE">DATE</option>
+      <option value="DATETIME">DATETIME</option>
+      <option value="DOUBLE">DOUBLE</option>
+      <option value="FLOAT">FLOAT</option>
+      <option value="INTEGER">INTEGER</option>
+      <option value="NUMERIC">NUMERIC</option>
+      <option value="REAL">REAL</option>
+      <option value="SERIAL">SERIAL</option>
+      <option value="VARCHAR">VARCHAR</option>
+      <option value="TEXT">TEXT</option>
+    </helper>
   </element>
   <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:valueType/gco:TypeName/gco:aName">
     <label>Value type name</label>
@@ -2630,109 +2630,109 @@
       <option value="VARCHAR">VARCHAR</option>
       <option value="TEXT">TEXT</option>
     </helper>
-    </element>
-    <element name="gco:attributeType">
-        <label>Attribute type</label>
-        <description/>
-    </element>
-    <element name="gco:TypeName">
-        <label>Type name</label>
-        <description/>
-    </element>
-    <element name="gco:LocalName">
-        <label>Local name</label>
-        <description/>
-    </element>
-    <element name="gco:ScopedName">
-        <label>Scoped name</label>
-        <description/>
-    </element>
-    <element name="gmd:has">
-        <label>Has</label>
-        <description>Has</description>
-    </element>
-    <element name="gmd:MD_PixelOrientationCode">
-        <label>Pixel orientation code</label>
-        <description>Point in a pixel corresponding to the Earth location of the pixel</description>
-    </element>
-    <element name="gmd:MD_ObligationCode">
-        <label>Obligation code</label>
-        <description>Obligation of the element or entity</description>
-    </element>
-    <element name="gmd:maximumOccurrence">
-        <label>Maximum occurrence</label>
-        <description>Maximum occurrence of the extended element</description>
-    </element>
-    <element name="gco:localName">
-        <label>Name</label>
-        <description/>
-    </element>
-    <element name="gmd:composedOf">
-        <label>ComposedOf</label>
-        <description>ComposedOf</description>
-    </element>
-    <element name="gmd:partOf">
-        <label>PartOf</label>
-        <description>PartOf</description>
-    </element>
-    <element name="gmd:seriesMetadata">
-        <label>SeriesMetadata</label>
-        <description>SeriesMetadata</description>
-    </element>
-    <element name="gmd:subset">
-        <label>Subset</label>
-        <description>Subset</description>
-    </element>
-    <element name="gmd:superset">
-        <label>Superset</label>
-        <description>Superset</description>
-    </element>
-    <element name="gmd:CI_RoleCode">
-        <label>Role code</label>
-        <description/>
-    </element>
-    <element name="gts:TM_PeriodDuration">
-        <label>Period duration</label>
-        <description>
-            The duration data type is used to specify a time interval.
+  </element>
+  <element name="gco:attributeType">
+    <label>Attribute type</label>
+    <description/>
+  </element>
+  <element name="gco:TypeName">
+    <label>Type name</label>
+    <description/>
+  </element>
+  <element name="gco:LocalName">
+    <label>Local name</label>
+    <description/>
+  </element>
+  <element name="gco:ScopedName">
+    <label>Scoped name</label>
+    <description/>
+  </element>
+  <element name="gmd:has">
+    <label>Has</label>
+    <description>Has</description>
+  </element>
+  <element name="gmd:MD_PixelOrientationCode">
+    <label>Pixel orientation code</label>
+    <description>Point in a pixel corresponding to the Earth location of the pixel</description>
+  </element>
+  <element name="gmd:MD_ObligationCode">
+    <label>Obligation code</label>
+    <description>Obligation of the element or entity</description>
+  </element>
+  <element name="gmd:maximumOccurrence">
+    <label>Maximum occurrence</label>
+    <description>Maximum occurrence of the extended element</description>
+  </element>
+  <element name="gco:localName">
+    <label>Name</label>
+    <description/>
+  </element>
+  <element name="gmd:composedOf">
+    <label>ComposedOf</label>
+    <description>ComposedOf</description>
+  </element>
+  <element name="gmd:partOf">
+    <label>PartOf</label>
+    <description>PartOf</description>
+  </element>
+  <element name="gmd:seriesMetadata">
+    <label>SeriesMetadata</label>
+    <description>SeriesMetadata</description>
+  </element>
+  <element name="gmd:subset">
+    <label>Subset</label>
+    <description>Subset</description>
+  </element>
+  <element name="gmd:superset">
+    <label>Superset</label>
+    <description>Superset</description>
+  </element>
+  <element name="gmd:CI_RoleCode">
+    <label>Role code</label>
+    <description/>
+  </element>
+  <element name="gts:TM_PeriodDuration">
+    <label>Period duration</label>
+    <description>
+      The duration data type is used to specify a time interval.
 
-            The time interval is specified in the following form "PnYnMnDTnHnMnS" where:
+      The time interval is specified in the following form "PnYnMnDTnHnMnS" where:
 
-            * P indicates the period (required)
-            * nY indicates the number of years
-            * nM indicates the number of months
-            * nD indicates the number of days
-            * T indicates the start of a time section (required if you are going to specify hours, minutes, or seconds)
-            * nH indicates the number of hours
-            * nM indicates the number of minutes
-            * nS indicates the number of seconds
-        </description>
-    </element>
-    <element name="gco:CharacterString">
-        <label>Text</label>
-        <description/>
-    </element>
-    <element name="gco:nilReason">
-        <label>Nil reason</label>
-        <description/>
-    </element>
-    <element name="srv:DCPList">
-        <label>Distributed Computing Platforms list</label>
-    </element>
-    <element name="gmd:verticalCRS">
-        <label>Vertical CRS</label>
-        <description>Provides information about the origin from which the maximum and minimum elevation values are measured</description>
-    </element>
-    <element name="gmx:FileName">
-        <label>File name</label>
-        <description>File name and source URL.</description>
-    </element>
-    <element name="src">
-        <label>Source URL</label>
-        <description>URL of the document.</description>
-    </element>
+      * P indicates the period (required)
+      * nY indicates the number of years
+      * nM indicates the number of months
+      * nD indicates the number of days
+      * T indicates the start of a time section (required if you are going to specify hours, minutes, or seconds)
+      * nH indicates the number of hours
+      * nM indicates the number of minutes
+      * nS indicates the number of seconds
+    </description>
+  </element>
+  <element name="gco:CharacterString">
+    <label>Text</label>
+    <description/>
+  </element>
+  <element name="gco:nilReason">
+    <label>Nil reason</label>
+    <description/>
+  </element>
+  <element name="srv:DCPList">
+    <label>Distributed Computing Platforms list</label>
+  </element>
+  <element name="gmd:verticalCRS">
+    <label>Vertical CRS</label>
+    <description>Provides information about the origin from which the maximum and minimum elevation values are measured</description>
+  </element>
+  <element name="gmx:FileName">
+    <label>File name</label>
+    <description>File name and source URL.</description>
+  </element>
+  <element name="src">
+    <label>Source URL</label>
+    <description>URL of the document.</description>
+  </element>
 
-    <element name="gmx:Anchor">
+  <element name="gmx:Anchor">
     <label>Anchor</label>
     <description>Supports hyper-linking capabilities and ensures a web-like implementation of
       CharacterStrings
@@ -2748,7 +2748,7 @@
       resource fragment) [W3C XLINK]
     </description>
   </element>
-    <element name="CoreSubjectThesaurus">
-      <label>GC Core Subject Thesaurus</label>
-    </element>
+  <element name="CoreSubjectThesaurus">
+    <label>GC Core Subject Thesaurus</label>
+  </element>
 </labels>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -106,21 +106,21 @@
   <element name="gmd:CI_Address" id="380.0">
     <label>Adresse</label>
     <description>Type de données pour la localisation de l'organisation ou la personne individuelle responsable</description>
-    <help>Type de données avec indication d'adresse.</help>
+    <!--<help>Type de données avec indication d'adresse.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:CI_Citation" id="359.0">
     <label>Information de référence</label>
     <description>Type de données pour la description standardisée des informations de références de la ressource</description>
-    <help>Type de données destiné à une description unifiée des sources (renvoi standardisé aux sources). Ce type de données permet une indication standardisée des sources (CI_Citation). Il contient également des types de données pour la description des services en charge de données et de métadonnées (CI_ResponsibleParty). La description du service compétent peut intégrer le nom de l'organisation comme celui de la personne responsable au sein de cette organisation. Il est également impératif de décrire sa fonction (son rôle). CI_Contact recèle des informations sur le mode de communication avec le service compétent. CI_Citation contient les principaux attributs permettant l'identification d'un jeu de données ou d'une source. Parmi ceux-ci on peut citer le titre, sa forme abrégée, l'édition ou la date. Le type de données CI_Citation est alors appelé lorsque l'identification complète d'une information supplémentaire d'une source de données est à fournir. Des renvois sont effectués à partir de ce type de données vers chacun des autres types de données du groupe ?Citation?. CI_Citation est un regroupement de classes pouvant être appelées par plusieurs attributs de la norme.</help>
+    <!--<help>Type de données destiné à une description unifiée des sources (renvoi standardisé aux sources). Ce type de données permet une indication standardisée des sources (CI_Citation). Il contient également des types de données pour la description des services en charge de données et de métadonnées (CI_ResponsibleParty). La description du service compétent peut intégrer le nom de l'organisation comme celui de la personne responsable au sein de cette organisation. Il est également impératif de décrire sa fonction (son rôle). CI_Contact recèle des informations sur le mode de communication avec le service compétent. CI_Citation contient les principaux attributs permettant l'identification d'un jeu de données ou d'une source. Parmi ceux-ci on peut citer le titre, sa forme abrégée, l'édition ou la date. Le type de données CI_Citation est alors appelé lorsque l'identification complète d'une information supplémentaire d'une source de données est à fournir. Des renvois sont effectués à partir de ce type de données vers chacun des autres types de données du groupe ?Citation?. CI_Citation est un regroupement de classes pouvant être appelées par plusieurs attributs de la norme.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:CI_Contact" id="387.0">
     <label>Contact</label>
     <description>Type de données avec l'information utilisée pour permettre le contact avec la personne et/ou l'organisation responsable</description>
-    <help>Type de données intégrant des informations telles qu''un numéro de téléphone, de télécopie, des heures d'ouverture ou d'autres indications, toujours en rapport avec la personne ou le service désigné dans CI_ResponsibleParty.</help>
+    <!--<help>Type de données intégrant des informations telles qu''un numéro de téléphone, de télécopie, des heures d'ouverture ou d'autres indications, toujours en rapport avec la personne ou le service désigné dans CI_ResponsibleParty.</help>-->
     <condition/>
 
   </element>
@@ -134,14 +134,14 @@
   <element name="gmd:CI_OnlineResource" id="396.0">
     <label>Ressource en ligne</label>
     <description>Type de données pour l'information sur les sources en ligne, grâce auxquelles les éléments de métadonnées étendus sur le jeu de données, la spécification ou le profil peuvent être obtenus</description>
-    <help>Type de données contenant des informations relatives à la possibilité et dans l'affirmative, à la manière d'accéder en ligne au jeu de données.</help>
+    <!--<help>Type de données contenant des informations relatives à la possibilité et dans l'affirmative, à la manière d'accéder en ligne au jeu de données.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:CI_ResponsibleParty" id="374.0">
     <label>Responsable</label>
     <description>Type de données pour l'identification des personnes et organisations, ainsi que pour la description des modes de communication avec, associées avec le jeu de données</description>
-    <help>Type de données destiné à l'identification de personnes et/ou d'organisations en relation avec le jeu de données (en tant que responsable, en charge du traitement, propriétaire, etc.), intégrant par ailleurs d'autres informations telles que le numéro de téléphone, l'adresse (postale, messagerie électronique) permettant d'entrer en contact avec ces personnes et/ou organisations. Les trois premiers attributs (individualName, organisationName, positionName) de ce type de données permettent de savoir s'il s'agit de la description d'une personne, d'un service ou de la domiciliation d'une personne précédemment définie. Une indication au moins est obligatoire. La liste de sélection CI_RoleCode spécifie alors la nature de la responsabilité endossée par le service désigné. Cf. CI_Citation pour d'autres informations.</help>
+    <!--<help>Type de données destiné à l'identification de personnes et/ou d'organisations en relation avec le jeu de données (en tant que responsable, en charge du traitement, propriétaire, etc.), intégrant par ailleurs d'autres informations telles que le numéro de téléphone, l'adresse (postale, messagerie électronique) permettant d'entrer en contact avec ces personnes et/ou organisations. Les trois premiers attributs (individualName, organisationName, positionName) de ce type de données permettent de savoir s'il s'agit de la description d'une personne, d'un service ou de la domiciliation d'une personne précédemment définie. Une indication au moins est obligatoire. La liste de sélection CI_RoleCode spécifie alors la nature de la responsabilité endossée par le service désigné. Cf. CI_Citation pour d'autres informations.</help>-->
     <condition/>
 
   </element>
@@ -213,9 +213,9 @@
     <help>Classe comportant des informations relatives à la qualité du jeu de données. La qualité des données est exprimée par les éléments de métadonnées des classes DQ_DataQuality, LI_Lineage et DQ_Legislation. l'étendue des indications de qualité est définie et décrite dans la classe du champ d'application (DQ_Scope). La filiation ou la provenance des données est décrite dans la classe LI_Lineage qui est une agrégation des deux classes LI_Source (indications concernant les données source) et LI_ProcessStep (informations relatives aux étapes de traitement). Les différentes étapes de traitement peuvent à leur tour présenter une relation avec les données source. "+lineage" est obligatoire si "scope.DQ_Scope.level" = "Jeu de données".
       Les prescriptions de qualité applicables au jeu de données à décrire figurent dans la classe DQ_Legislation.
 
-    <!-- Réglement 1205-2008-->
-    La totalité des caractéristiques d’un produit qui lui confèrent l’aptitude à satisfaire des besoins exprimés ou
-    implicites, conformément à la norme EN ISO 19101.
+      <!-- Réglement 1205-2008-->
+      La totalité des caractéristiques d’un produit qui lui confèrent l’aptitude à satisfaire des besoins exprimés ou
+      implicites, conformément à la norme EN ISO 19101.
     </help>
     <condition/>
 
@@ -315,7 +315,7 @@
     ]]>
     </help>
     <help for="france">
-    <![CDATA[
+      <![CDATA[
     <b>Commentaire :</b>
     En pratique, ne sont concernées que les données respectant les spécifications de données INSPIRE et rentrant
     dans un cas de modèle de réseau (hydrographie, transport, services d’utilité publique).
@@ -341,14 +341,14 @@
   <element name="gmd:EX_Extent" id="334.0">
     <label>Étendue</label>
     <description>Type de données pour l'information sur l'étendue horizontale, verticale et temporelle du jeu de données</description>
-    <help>Type de données contenant des informations relatives à l'extension horizontale, verticale et temporelle du jeu de données. Les types de données de cette classe contiennent des éléments de métadonnées décrivant l'extension spatiale et temporelle des données. EX_Extent est une agrégation des classes EX_GeographicExtent (description de l'extension géographique), EX_TemporalExtent (extension temporelle des données) et EX_VerticalExtent (extension verticale des données). l'extension géographique est spécifiée plus avant par une délimitation au moyen d'un polygone (EX_BoundingPolygon) comme par un rectangle de délimitation géographique (EX_GeographicBoundingBox) et une description textuelle (EX_GeographicDescription). Pour EX_Extent comme pour CI_Citation, il s'agit d'un regroupement de classes pouvant être appelées par plusieurs attributs de la norme.</help>
+    <!--<help>Type de données contenant des informations relatives à l'extension horizontale, verticale et temporelle du jeu de données. Les types de données de cette classe contiennent des éléments de métadonnées décrivant l'extension spatiale et temporelle des données. EX_Extent est une agrégation des classes EX_GeographicExtent (description de l'extension géographique), EX_TemporalExtent (extension temporelle des données) et EX_VerticalExtent (extension verticale des données). l'extension géographique est spécifiée plus avant par une délimitation au moyen d'un polygone (EX_BoundingPolygon) comme par un rectangle de délimitation géographique (EX_GeographicBoundingBox) et une description textuelle (EX_GeographicDescription). Pour EX_Extent comme pour CI_Citation, il s'agit d'un regroupement de classes pouvant être appelées par plusieurs attributs de la norme.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:EX_GeographicBoundingBox" id="343.0">
     <label>Étendue géographique</label>
     <description>Un rectangle représentant la région géographique couverte par la ressource.</description>
-    <help>Type de données destiné à la description de la position géographique du jeu de données. Il s'agit ici de la définition d'une enveloppe sommaire (délimitation en latitude et en longitude). Des informations supplémentaires peuvent être trouvées sous EX_Extent et EX_GeographicExtent.</help>
+    <!--<help>Type de données destiné à la description de la position géographique du jeu de données. Il s'agit ici de la définition d'une enveloppe sommaire (délimitation en latitude et en longitude). Des informations supplémentaires peuvent être trouvées sous EX_Extent et EX_GeographicExtent.</help>
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b> Étendue de la ressource dans l’espace géographique, exprimée sous la forme d’un rectangle de délimitation
     <ul>
       <li>Ce rectangle de délimitation est défini par les longitudes est et ouest et les latitudes sud et nord en degrés décimaux, avec une précision d’au moins deux chiffres après la virgule.</li>
@@ -377,7 +377,7 @@
       <li>E : 10,81</li>
       <li>N : 50,79</li>
     </ul>
-    ]]></help>
+    ]]></help>-->
     <condition>Obligatoire</condition>
 
   </element>
@@ -398,7 +398,7 @@
   <element name="gmd:EX_TemporalExtent" id="350.0">
     <label>Étendue temporelle</label>
     <description>Type de données pour la description de la période de temps couverte par le contenu du jeu de donnée</description>
-    <help>La validité temporelle du jeu de données est définie dans cette classe. Cette classe connaît la représentation EX_SpatialTemporalExtent. Des informations supplémentaires peuvent être trouvées sous EX_Extent.</help>
+    <!--<help>La validité temporelle du jeu de données est définie dans cette classe. Cette classe connaît la représentation EX_SpatialTemporalExtent. Des informations supplémentaires peuvent être trouvées sous EX_Extent.</help>-->
     <condition/>
 
   </element>
@@ -419,7 +419,7 @@
   <element name="gmd:ISSN" id="373.0">
     <label>ISSN</label>
     <description>Numéro international normalisé d'une publication en série (ISSN)</description>
-    <help>Numéro international normalisé d'une série de publications (ISSN)</help>
+    <!--<help>Numéro international normalisé d'une série de publications (ISSN)</help>-->
     <condition/>
 
   </element>
@@ -498,7 +498,7 @@
   <element name="gmd:MD_DataIdentification" id="36.0">
     <label>Identification des données</label>
     <description>Classe avec l'information utile pour identifier un jeu de données</description>
-    <help>Classe contenant des informations de base utilisées pour l'identification sans équivoque du ou des jeux de données. Il s'agit de la description du jeu de données concret. La classe MD_DataIdentification est la représentation de MD_Identification pour les données. Elle intègre des informations relatives à la caractérisation spatiale et temporelle des données, au jeu de caractères et à la langue utilisés, de même que d'autres informations descriptives. Une extension spatiale minimale des données est à indiquer par l'intermédiaire de l'option "geographicBox" (rectangle de délimitation géographique), de l'option "geographicDescription" (description textuelle de l'extension) ou des deux simultanément. Il est en outre possible de restreindre l'extension par le biais de l'attribut "extent", aussi bien au niveau spatial (via un polygone) que temporel. La norme prévoit une liste internationale de 19 thèmes (MD_TopicCategoryCode) pour la classification thématique des données, gérée par l'intermédiaire de l'attribut "topicCategory". Une recherche standardisée par thèmes est de la sorte possible au plan international.</help>
+    <!--<help>Classe contenant des informations de base utilisées pour l'identification sans équivoque du ou des jeux de données. Il s'agit de la description du jeu de données concret. La classe MD_DataIdentification est la représentation de MD_Identification pour les données. Elle intègre des informations relatives à la caractérisation spatiale et temporelle des données, au jeu de caractères et à la langue utilisés, de même que d'autres informations descriptives. Une extension spatiale minimale des données est à indiquer par l'intermédiaire de l'option "geographicBox" (rectangle de délimitation géographique), de l'option "geographicDescription" (description textuelle de l'extension) ou des deux simultanément. Il est en outre possible de restreindre l'extension par le biais de l'attribut "extent", aussi bien au niveau spatial (via un polygone) que temporel. La norme prévoit une liste internationale de 19 thèmes (MD_TopicCategoryCode) pour la classification thématique des données, gérée par l'intermédiaire de l'attribut "topicCategory". Une recherche standardisée par thèmes est de la sorte possible au plan international.</help>-->
     <condition/>
 
   </element>
@@ -519,14 +519,14 @@
   <element name="gmd:MD_Distribution" id="270.0">
     <label>Distribution</label>
     <description>Classe avec l'information sur le distributeur de données et sur les possibilités d'obtenir les ressources</description>
-    <help>Classe contenant des informations relatives au distributeur des données de même qu''aux possibilités d'obtention du jeu de données. Cette classe recèle des indications sur le lieu de délivrance des données ainsi que sur la forme de leur obtention. MD_Distribution est une agrégation des informations concernant le transfert de données numériques (MD_DigitalTransferOptions) et des informations relatives au format des données (MD_Format).</help>
+    <!--<help>Classe contenant des informations relatives au distributeur des données de même qu''aux possibilités d'obtention du jeu de données. Cette classe recèle des indications sur le lieu de délivrance des données ainsi que sur la forme de leur obtention. MD_Distribution est une agrégation des informations concernant le transfert de données numériques (MD_DigitalTransferOptions) et des informations relatives au format des données (MD_Format).</help>-->
     <condition/>
 
   </element>
   <element name="gmd:MD_Distributor" id="279.0">
     <label>Distributeur</label>
     <description>Classe avec l'information sur le distributeur</description>
-    <help>Classe contenant les informations relatives au distributeur des données (nom, rôle, adresse, etc.). d'autres informations peuvent être trouvées sous MD_Distribution.</help>
+    <!--<help>Classe contenant les informations relatives au distributeur des données (nom, rôle, adresse, etc.). d'autres informations peuvent être trouvées sous MD_Distribution.</help>-->
     <condition/>
 
   </element>
@@ -547,7 +547,7 @@
   <element name="gmd:MD_Format" id="284.0">
     <label>Format</label>
     <description>Classe avec la description du format informatique avec lequel la représentation du jeu de donnée peut être enregistrée et transférée, sous la forme d'un enregistrement de données, d'un fichier, d'un message, d'un support de stockage ou d'un canal de transmission</description>
-    <help>Classe contenant la description du format de fichier dans lequel le jeu de données peut être stocké et transféré sur un support de données, dans un fichier, via un courrier électronique, un périphérique de stockage ou un canal de transmission.</help>
+    <!--<help>Classe contenant la description du format de fichier dans lequel le jeu de données peut être stocké et transféré sur un support de données, dans un fichier, via un courrier électronique, un périphérique de stockage ou un canal de transmission.</help>-->
     <condition/>
 
   </element>
@@ -603,14 +603,14 @@
   <element name="gmd:MD_LegalConstraints" id="69.0">
     <label>Contraintes légales</label>
     <description>Classe pour les restrictions et conditions préalables légales pour accéder et utiliser les ressources où de métadonnées</description>
-    <help>Classe contenant des informations relatives aux restrictions juridiques s'appliquant à la ressource, au jeu de métadonnées ou à leur utilisation. Cette classe est une représentation de la classe MD_Constraints. Cf. MD_Constraints pour de plus amples informations.</help>
+    <!--<help>Classe contenant des informations relatives aux restrictions juridiques s'appliquant à la ressource, au jeu de métadonnées ou à leur utilisation. Cette classe est une représentation de la classe MD_Constraints. Cf. MD_Constraints pour de plus amples informations.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:MD_MaintenanceInformation" id="142.0">
     <label>Information de maintenance</label>
     <description>Classe sur la raison, l'étendue et la fréquence des mises à jour.</description>
-    <help>Les informations concernant l'étendue, la fréquence et la date de mise à jour des données sont contenues dans la classe MD_MaintenanceInformation. Cette classe recèle des attributs renseignant sur la fréquence et l'étendue de la mise à jour et de la réactualisation des données du jeu. Seule l'indication de la fréquence est impérative et doit être sélectionnée dans la liste MD_MaintenanceFrequencyCode. l'étendue de la mise à jour, les attributs qu''elle concerne et les descriptions associées sont des informations qu''il est possible d'indiquer via les attributs "updateScope" et "updateScopeDescription". Il n''est pas prévu d'indiquer l'extension spatiale de la mise à jour. Si seules des parties d'un jeu de données sont mises à jour ou si toutes ses parties ne sont pas mises à jour simultanément, alors les parties concernées par la description de la mise à jour peuvent être précisées via "+updateScopeDescription" dans la classe MD_ScopeDescription.</help>
+    <!--<help>Les informations concernant l'étendue, la fréquence et la date de mise à jour des données sont contenues dans la classe MD_MaintenanceInformation. Cette classe recèle des attributs renseignant sur la fréquence et l'étendue de la mise à jour et de la réactualisation des données du jeu. Seule l'indication de la fréquence est impérative et doit être sélectionnée dans la liste MD_MaintenanceFrequencyCode. l'étendue de la mise à jour, les attributs qu''elle concerne et les descriptions associées sont des informations qu''il est possible d'indiquer via les attributs "updateScope" et "updateScopeDescription". Il n''est pas prévu d'indiquer l'extension spatiale de la mise à jour. Si seules des parties d'un jeu de données sont mises à jour ou si toutes ses parties ne sont pas mises à jour simultanément, alors les parties concernées par la description de la mise à jour peuvent être précisées via "+updateScopeDescription" dans la classe MD_ScopeDescription.</help>-->
     <condition/>
 
   </element>
@@ -652,7 +652,7 @@
   <element name="gmd:MD_ReferenceSystem" id="186.0">
     <label>Système de référence</label>
     <description>Classe pour l'information sur le système de référence</description>
-    <help>La classe MD_ReferenceSystem décrit le système de référence spatial et temporel utilisé pour le jeu de données. Dans cette classe, le lien avec le système géodésique de référence est établi à l'aide de l'attribut "referenceSystemIdentifier". Seuls le nom du système de référence et l'organisation associée sont saisis, aucun paramètre concret n''est entré.</help>
+    <!--<help>La classe MD_ReferenceSystem décrit le système de référence spatial et temporel utilisé pour le jeu de données. Dans cette classe, le lien avec le système géodésique de référence est établi à l'aide de l'attribut "referenceSystemIdentifier". Seuls le nom du système de référence et l'organisation associée sont saisis, aucun paramètre concret n''est entré.</help>
 
     <help><![CDATA[<b>Système de coordonnées</b>]]></help>
 
@@ -691,7 +691,7 @@
     <b>Recommandations :</b>
     <li>Il est recommandé d’utiliser le calendrier grégorien.</li>
     <li>Dans le cas où le calendrier grégorien n’est pas utilisé (par exemple, dans certains domaines comme la géologie), ce champ doit impérativement être renseigné.</li>
-    ]]></help>
+    ]]></help>-->
 
     <condition/>
 
@@ -720,7 +720,7 @@
   <element name="gmd:MD_SecurityConstraints" id="73.0">
     <label>Contraintes de sécurité</label>
     <description>Classe avec les restrictions de manipulation imposées sur les ressources où de métadonnées pour la sécurité nationale ou des situations de sécurité similaires</description>
-    <help>Classe contenant des informations relatives aux restrictions de sécurité liées à des questions de sécurité de portée nationale ou assimilée (exemple : secret, confidentialité, etc.). Cette classe est une représentation de la classe MD_Constraints. Cf. MD_Constraints pour d'autres informations.</help>
+    <!--<help>Classe contenant des informations relatives aux restrictions de sécurité liées à des questions de sécurité de portée nationale ou assimilée (exemple : secret, confidentialité, etc.). Cette classe est une représentation de la classe MD_Constraints. Cf. MD_Constraints pour d'autres informations.</help>-->
     <condition/>
 
   </element>
@@ -762,7 +762,7 @@
   <element name="gmd:RS_Identifier" id="208.0">
     <label>Identifiant du système de référence</label>
     <description>Classe pour l'identifiant utilisé pour les systèmes de référence</description>
-    <help>Classe réservée aux identifiants de systèmes de référence. Cette classe est une représentation de MD_Identifier pour l'identification d'un système de référence par des attributs supplémentaires. Cf. également sous MD_Identifier.</help>
+    <!--<help>Classe réservée aux identifiants de systèmes de référence. Cette classe est une représentation de MD_Identifier pour l'identification d'un système de référence par des attributs supplémentaires. Cf. également sous MD_Identifier.</help>-->
     <condition/>
 
   </element>
@@ -806,7 +806,7 @@
   <element name="gmd:abstract" id="25.0">
     <label>Résumé</label>
     <description>Donner un aperçu du contenu, de la méthodologie et des conclusions de l'ensemble de données en texte libre.</description>
-    <help>Court résumé descriptif du contenu du jeu de données. Cet attribut est du type PT_FreeText et est géré dans la classe du même nom.</help>
+    <!--<help>Court résumé descriptif du contenu du jeu de données. Cet attribut est du type PT_FreeText et est géré dans la classe du même nom.</help>
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     <ul>
       <li>Cet élément doit fournir un bref résumé narratif du contenu de la ressource.</li>
@@ -824,14 +824,14 @@
     ]]></help>
     <help for="inspire"><![CDATA[<b>Contre-exemple :</b>
       PPRI de Paris_ PPRi détaillé_ 1:5000
-    ]]></help>
+    ]]></help>-->
     <condition>Obligatoire</condition>
 
   </element>
   <element name="gmd:accessConstraints" id="70.0">
     <label>Contraintes d'accès</label>
     <description>Cet élément permet d'indiquer toute restriction ou limitation supplémentaire ou particulière existante quant à l'accès à la ressource, outre celles couvertes par les restrictions ministérielles existantes.</description>
-    <help>Restrictions d'accès relatives à la garantie de la propriété privée ou intellectuelle et restrictions de toutes natures visant à la conservation de la ressource ou des métadonnées. Elles peuvent être sélectionnées parmi les éléments suivants : droit d'auteur, brevet, brevet en voie de délivrance, marque, licence, propriété intellectuelle, diffusion limitée, autres restrictions.</help>
+    <!--<help>Restrictions d'accès relatives à la garantie de la propriété privée ou intellectuelle et restrictions de toutes natures visant à la conservation de la ressource ou des métadonnées. Elles peuvent être sélectionnées parmi les éléments suivants : droit d'auteur, brevet, brevet en voie de délivrance, marque, licence, propriété intellectuelle, diffusion limitée, autres restrictions.</help>-->
     <condition>mandatory</condition>
 
   </element>
@@ -845,14 +845,14 @@
   <element name="gmd:address" id="389.0">
     <label>Adresse</label>
     <description>Adresse physique et électronique à laquelle la personne ou l'organisation responsable peut être contactée</description>
-    <help>Adresse postale ou électronique d'un premier niveau de contact (par exemple un secrétariat). Ces informations sont du type CI_Address et sont gérées dans la classe du même nom.</help>
+    <!--<help>Adresse postale ou électronique d'un premier niveau de contact (par exemple un secrétariat). Ces informations sont du type CI_Address et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:administrativeArea" id="383.0">
     <label>Province/État</label>
     <description>Canton ou département de l'emplacement</description>
-    <help>Canton</help>
+    <!--<help>Canton</help>-->
     <condition/>
 
   </element>
@@ -871,35 +871,35 @@
   <element name="gmd:aggregationInfo" id="35.1">
     <label>Information sur les agrégations</label>
     <description>Met à dispositionles les informations sur le jeu de données rassemblé</description>
-    <help>Informations concernant le jeu de données de rang supérieur et les relations qu''il entretient avec le jeu de données décrit. Ces informations sont du type MD_AggregateInformation et sont gérées dans la classe du même nom.</help>
+    <!--<help>Informations concernant le jeu de données de rang supérieur et les relations qu''il entretient avec le jeu de données décrit. Ces informations sont du type MD_AggregateInformation et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:alternateTitle" id="361.0">
     <label>Titre court</label>
     <description>Nom raccourci ou autre façon d'écrire le nom, sous lequel l'information des informations de références est connue. Exemple : DCW pour "Digital Chart of the World"</description>
-    <help>Nom abrégé ou orthographe du titre/nom différente de celle sous laquelle l'information correspondante est connue. Exemple : DCW pour "Digital Chart of the World"</help>
+    <!--<help>Nom abrégé ou orthographe du titre/nom différente de celle sous laquelle l'information correspondante est connue. Exemple : DCW pour "Digital Chart of the World"</help>-->
     <condition/>
 
   </element>
   <element name="gmd:amendmentNumber" id="287.0">
     <label>Numéro de version du format</label>
     <description>Numéro d'amélioration du format</description>
-    <help>Numéro de la modification apportée au format.</help>
+    <!--<help>Numéro de la modification apportée au format.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:applicationProfile" id="399.0">
     <label>Profil d'application</label>
     <description>Nom d'un profil d'application qui peut être utilisé avec les ressources en ligne</description>
-    <help>Nom d'un profil d'application pouvant être utilisé pour la source en ligne.</help>
+    <!--<help>Nom d'un profil d'application pouvant être utilisé pour la source en ligne.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:applicationSchemaInfo" id="21.0">
     <label>Renseignements sur le schéma conceptuel</label>
     <description>Renseignements sur le schéma conceptuel du jeu de données</description>
-    <help>Informations relatives au schéma conceptuel du jeu de données</help>
+    <!--<help>Informations relatives au schéma conceptuel du jeu de données</help>-->
     <condition/>
 
   </element>
@@ -932,7 +932,7 @@
   <element name="gmd:authority" id="206.0">
     <label>Autorité</label>
     <description>Personne ou service responsable pour la maintenance du domaine de valeurs</description>
-    <help>Personne ou organisation responsable de cet espace nominal, par exemple un service. Ces informations sont du type CI_Citation et sont gérées dans la classe du même nom.</help>
+    <!--<help>Personne ou organisation responsable de cet espace nominal, par exemple un service. Ces informations sont du type CI_Citation et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
@@ -974,13 +974,13 @@
   <element name="gmd:characterSet" id="4.0" context="gmd:MD_Metadata">
     <label>Jeu de caractère</label>
     <description>Nom complet du standard de code de caractères utilisé pour le jeu de métadonnées</description>
-    <help>Nom complet du code de caractères normalisé utilisé pour le fichier de métadonnées. Le paramètre par défaut est "utf8". Les fichiers de texte contiennent normalement des valeurs d'octets représentant un sous-ensemble de valeurs de caractères via un codage (8859_1, ISO Latin-1), un format de transfert (Unicode-Transfer-Format UTF8) ou tout autre moyen.</help>
+    <!--<help>Nom complet du code de caractères normalisé utilisé pour le fichier de métadonnées. Le paramètre par défaut est "utf8". Les fichiers de texte contiennent normalement des valeurs d'octets représentant un sous-ensemble de valeurs de caractères via un codage (8859_1, ISO Latin-1), un format de transfert (Unicode-Transfer-Format UTF8) ou tout autre moyen.</help>-->
     <condition>Par défaut UTF-8</condition>
   </element>
   <element name="gmd:characterSet" id="40.0" context="gmd:MD_DataIdentification">
     <label>Jeu de caractère</label>
     <description>Nom entier du standard de code de caractères utilisé pour le jeu de données</description>
-    <help>Nom complet du code de caractères normalisé utilisé pour le fichier de métadonnées. Le paramètre par défaut est "utf8". Les fichiers de texte contiennent normalement des valeurs d'octets représentant un sous-ensemble de valeurs de caractères via un codage (8859_1, ISO Latin-1), un format de transfert (Unicode-Transfer-Format UTF8) ou tout autre moyen.</help>
+    <!--<help>Nom complet du code de caractères normalisé utilisé pour le fichier de métadonnées. Le paramètre par défaut est "utf8". Les fichiers de texte contiennent normalement des valeurs d'octets représentant un sous-ensemble de valeurs de caractères via un codage (8859_1, ISO Latin-1), un format de transfert (Unicode-Transfer-Format UTF8) ou tout autre moyen.</help>
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     Est l’encodage de caractères utilisé dans la série de données.
     Cet élément n’est obligatoire (pour les données de l’Annexe 1) que si l’encodage utilisé n’est pas basé sur UTF-8. Il ne peut pas être répété.
@@ -993,13 +993,13 @@
     <help for="france"><![CDATA[<b>Recommandations :</b>
     Même si le jeu de caractère de la donnée est UTF-8, le préciser.
     Cette information, purement technique, est disponible auprès de votre administrateur de données.
-    ]]></help>
+    ]]></help>-->
     <condition>Par défaut UTF-8</condition>
   </element>
   <element name="gmd:characterSet" id="4.0">
     <label>Jeu de caractère</label>
     <description>Nom complet du standard de code de caractères utilisé pour le jeu de métadonnées</description>
-    <help>Nom complet du code de caractères normalisé utilisé pour le fichier de métadonnées. Le paramètre par défaut est "utf8". Les fichiers de texte contiennent normalement des valeurs d'octets représentant un sous-ensemble de valeurs de caractères via un codage (8859_1, ISO Latin-1), un format de transfert (Unicode-Transfer-Format UTF8) ou tout autre moyen.</help>
+    <!--<help>Nom complet du code de caractères normalisé utilisé pour le fichier de métadonnées. Le paramètre par défaut est "utf8". Les fichiers de texte contiennent normalement des valeurs d'octets représentant un sous-ensemble de valeurs de caractères via un codage (8859_1, ISO Latin-1), un format de transfert (Unicode-Transfer-Format UTF8) ou tout autre moyen.</help>-->
     <condition>Par défaut UTF-8</condition>
   </element>
   <element name="gmd:checkPointAvailability" id="163.0">
@@ -1018,7 +1018,7 @@
   <element name="gmd:citation" id="24.0" context="gmd:MD_DataIdentification">
     <label>Information de référence</label>
     <description>Information de référence sur les ressources</description>
-    <help>Indication des sources du jeu de données décrit. Le nom ou le titre du fichier du jeu de données de même qu''une date du type adéquat (création, publication, traitement) sont gérés ici. Cet attribut est du type CI_Citation et est géré dans la classe du même nom.</help>
+    <!--<help>Indication des sources du jeu de données décrit. Le nom ou le titre du fichier du jeu de données de même qu''une date du type adéquat (création, publication, traitement) sont gérés ici. Cet attribut est du type CI_Citation et est géré dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
@@ -1046,28 +1046,28 @@
   <element name="gmd:citedResponsibleParty" id="367.0">
     <label>Responsable</label>
     <description>Information sur le nom et la position d'une personne individuelle ou d'une organisation responsable pour la ressource</description>
-    <help>Informations concernant le nom et la domiciliation de la personne ou de l'organisation responsable de la source citée. Ces informations sont du type CI_ResponsibleParty et sont gérées dans la classe du même nom.</help>
+    <!--<help>Informations concernant le nom et la domiciliation de la personne ou de l'organisation responsable de la source citée. Ces informations sont du type CI_ResponsibleParty et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:city" id="382.0">
     <label>Ville</label>
     <description>Ville de l'emplacement</description>
-    <help>Ville, localité</help>
+    <!--<help>Ville, localité</help>-->
     <condition/>
 
   </element>
   <element name="gmd:classification" id="74.0">
     <label>Restrictions de manipulation</label>
     <description>Noms des restrictions de manipulation sur les ressources où de métadonnées</description>
-    <help>Type de restriction. Sélection dans la liste suivante : non classé, diffusion restreinte, confidentiel, secret, top secret.</help>
+    <!--<help>Type de restriction. Sélection dans la liste suivante : non classé, diffusion restreinte, confidentiel, secret, top secret.</help>-->
     <condition>Obligatoire</condition>
 
   </element>
   <element name="gmd:classificationSystem" id="76.0">
     <label>Système de classification</label>
     <description>Nom du système de classification</description>
-    <help>Le nom du système de classification peut être indiqué ici, s'il en existe un.</help>
+    <!--<help>Le nom du système de classification peut être indiqué ici, s'il en existe un.</help>-->
     <condition/>
 
   </element>
@@ -1081,7 +1081,7 @@
   <element name="gmd:code" id="207.0" context="gmd:RS_Identifier">
     <label>Code</label>
     <description>Valeur alphanumérique pour l'identification d'une occurrence dans le domaine de valeurs</description>
-    <help>Code alphanumérique de l'identifiant. Ces informations sont du type PT_FreeText et sont gérées dans la classe du même nom.</help>
+    <!--<help>Code alphanumérique de l'identifiant. Ces informations sont du type PT_FreeText et sont gérées dans la classe du même nom.</help>-->
     <condition>mandatory</condition>
     <helper rel="gmd:codeSpace">
       <option title="http://www.epsg-registry.org" value="EPSG:3857">EPSG:3857 WGS 84 / Pseudo-Mercator</option>
@@ -1121,13 +1121,13 @@
   <element name="gmd:codeSpace" id="208.1">
     <label>Nom de l'identifiant</label>
     <description>Nom ou identification de la personne ou de l'organisation responsable pour la domaine de valeurs</description>
-    <help>Informations sur la personne ou l'organisation en charge de l'espace nominal ou de l'identifiant.</help>
+    <!--<help>Informations sur la personne ou l'organisation en charge de l'espace nominal ou de l'identifiant.</help>-->
     <condition/>
   </element>
   <element name="gmd:collectiveTitle" id="371.0">
     <label>Titre collectif</label>
     <description>Titre commun avec indication d'une appartenance. Note : le titre identifie des éléments d'une série collective, combiné avec l'information sur quels volumes sont à disposition à la source citée</description>
-    <help>Cet élement est utilisé en Suisse pour designer le nom d'une géodonnées de base qui correspond à l'entrée du catalogue Annexe I de la OGéo, car il est possible que plusieurs jeux de données "physiques" soient attribuée à une entrée "juridique". Ex.: L'entrée no. 47 "Cartes géophysiques" consiste de 3 jeux de données "Cartes géophysiques 1:500000", "Cartes géophysisques spéciales" et "Atlas gravimétrique 1:100000"</help>
+    <!--<help>Cet élement est utilisé en Suisse pour designer le nom d'une géodonnées de base qui correspond à l'entrée du catalogue Annexe I de la OGéo, car il est possible que plusieurs jeux de données "physiques" soient attribuée à une entrée "juridique". Ex.: L'entrée no. 47 "Cartes géophysiques" consiste de 3 jeux de données "Cartes géophysiques 1:500000", "Cartes géophysisques spéciales" et "Atlas gravimétrique 1:100000"</help>-->
     <condition/>
 
   </element>
@@ -1175,7 +1175,7 @@
   <element name="gmd:contact" id="148.1" context="gmd:MD_MaintenanceInformation">
     <label>Contact pour la mise à jour</label>
     <description>Indications concernant la personne ou l'organisation qui est responsable de la mis à jour des métadonnées</description>
-    <help>Informations concernant la personne ou l'organisation responsable de la mise à jour des données. Ces informations sont du type CI_ResponsibleParty et sont gérées dans la classe du même nom.</help>
+    <!--<help>Informations concernant la personne ou l'organisation responsable de la mise à jour des données. Ces informations sont du type CI_ResponsibleParty et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
@@ -1183,21 +1183,21 @@
   <element name="gmd:contactInfo" id="378.0">
     <label>Coordonnées de la personne-contact</label>
     <description>Heures de service du service responsable</description>
-    <help>Adresse du service responsable. Ces informations sont du type CI_Contact et sont gérées dans la classe du même nom.</help>
+    <!--<help>Adresse du service responsable. Ces informations sont du type CI_Contact et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:contactInstructions" id="392.0">
     <label>Instructions pour la personne-contact</label>
     <description>Instructions supplémentaires sur quand et comment contacter la personne ou l'organisation responsable</description>
-    <help>Informations supplémentaires pour la prise de contact.</help>
+    <!--<help>Informations supplémentaires pour la prise de contact.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:contentInfo" id="16.0">
     <label>Information sur le contenu</label>
     <description>Informations sur le catalogue d'objet et sur les descriptions de la couverture et des charactéristiques raster</description>
-    <help>Description du contenu du jeu de données. Renvoi au catalogue d'objets, au modèle de données ou à la description des données. Le contenu de ces catalogues et de ces descriptions ne fait toutefois pas partie des métadonnées. Ces informations sont gérées dans la classe MD_ContentInformation.</help>
+    <!--<help>Description du contenu du jeu de données. Renvoi au catalogue d'objets, au modèle de données ou à la description des données. Le contenu de ces catalogues et de ces descriptions ne fait toutefois pas partie des métadonnées. Ces informations sont gérées dans la classe MD_ContentInformation.</help>-->
     <condition/>
 
   </element>
@@ -1225,7 +1225,7 @@
   <element name="gmd:country" id="612.0">
     <label>Pays</label>
     <description>Pays dans la langue duquel l'URL libre est écrit</description>
-    <help>Pays dans la langue duquel l'URL libre est écrit, la sélection s'opère dans la liste des pays ISO.</help>
+    <!--<help>Pays dans la langue duquel l'URL libre est écrit, la sélection s'opère dans la liste des pays ISO.</help>-->
     <condition/>
   </element>
   <element name="gmd:country" id="508.0" context="gmd:MD_Legislation">
@@ -1245,21 +1245,21 @@
   <element name="gmd:credit" id="27.0">
     <label>Reconnaissance</label>
     <description>Reconnaissance de ceux qui ont contribués à ces ressources</description>
-    <help>Reconnaissance ou confirmation des intervenants ayant apporté leur contribution à cette ressource.</help>
+    <!--<help>Reconnaissance ou confirmation des intervenants ayant apporté leur contribution à cette ressource.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:dataQualityInfo" id="18.0">
     <label>Renseignements sur la qualité des données</label>
     <description>Estimation de la qualité des ressources</description>
-    <help>Estimation de la qualité du jeu de données. Ces informations sont gérées dans la classe DQ_DataQuality.</help>
+    <!--<help>Estimation de la qualité du jeu de données. Ces informations sont gérées dans la classe DQ_DataQuality.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:dataSetURI" id="11.1">
     <label>Désignation de la donnée (URI)</label>
     <description>Ce champ permet d'indiquer un lien URL pour l'ensemble de données, si disponible, ou un identificateur unique comme un identificateur d'objet numérique (DOI) pour la ressource, si disponible.</description>
-    <help>Identifiant URI (Uniformed Resource Identifier) du jeu de données auquel les métadonnées renvoient. Une adresse URL est indiquée ici, par exemple www.cosig.ch.</help>
+    <!--<help>Identifiant URI (Uniformed Resource Identifier) du jeu de données auquel les métadonnées renvoient. Une adresse URL est indiquée ici, par exemple www.cosig.ch.</help>-->
     <condition/>
 
   </element>
@@ -1291,22 +1291,22 @@
     <condition/>
     <condition>Conditional</condition>
   </element>-->
-    <element name="gmd:date" id="362.0" context="gmd:CI_Citation">
-        <condition>mandatory</condition>
-        <label>Date</label>
-        <description>Date de référence pour la ressource en question</description>
-        <_condition>M</_condition>
-    </element>
-    <element name="gmd:date" id="394.0" context="gmd:CI_Date">
-        <condition>mandatory</condition>
-        <label>Date</label>
-        <description>Date de référence pour la ressource en question</description>
-        <_condition>M</_condition>
-    </element>
+  <element name="gmd:date" id="362.0" context="gmd:CI_Citation">
+    <condition>mandatory</condition>
+    <label>Date</label>
+    <description>Date de référence pour la ressource en question</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="gmd:date" id="394.0" context="gmd:CI_Date">
+    <condition>mandatory</condition>
+    <label>Date</label>
+    <description>Date de référence pour la ressource en question</description>
+    <_condition>M</_condition>
+  </element>
   <element name="gmd:date" id="144.0" context="gmd:MD_MaintenanceInformation">
     <label>Date de la prochaine mise à jour</label>
     <description>Date de la prochaine mise à jour de la ressource</description>
-    <help>Date de la prochaine mise à jour (jj.mm.aaaa).</help>
+    <!--<help>Date de la prochaine mise à jour (jj.mm.aaaa).</help>-->
     <condition/>
 
   </element>
@@ -1367,14 +1367,14 @@
   <element name="gmd:dateOfNextUpdate" id="144.0">
     <label>Date de la prochaine mise à jour</label>
     <description>Date de la prochaine mise à jour de la ressource</description>
-    <help>Date de la prochaine mise à jour (jj.mm.aaaa).</help>
+    <!--<help>Date de la prochaine mise à jour (jj.mm.aaaa).</help>-->
     <condition/>
 
   </element>
   <element name="gmd:dateStamp" id="9.0">
     <label>Date de création</label>
     <description>Date de création des métadonnées</description>
-    <help>Date de création des métadonnées. Elle est automatiquement attribuée par l'application.</help>
+    <!--<help>Date de création des métadonnées. Elle est automatiquement attribuée par l'application.</help>
 
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>Ceci est la date à laquelle l’enregistrement de métadonnées a été créé ou actualisé.
     <ul>
@@ -1382,7 +1382,7 @@
     <li>Cet élément est obligatoire et ne peut pas être répété.</li>
     </ul>
     ]]>
-    </help>
+    </help>-->
 
     <condition>Obligatoire</condition>
 
@@ -1425,7 +1425,7 @@
   <element name="gmd:deliveryPoint" id="381.0">
     <label>Adresse</label>
     <description>Inscrire l'adresse municipale de l'organisation ou de la personne responsable. Par ex. 123, rue Principale.</description>
-    <help>Nom de la rue</help>
+    <!--<help>Nom de la rue</help>-->
     <condition/>
 
   </element>
@@ -1435,15 +1435,15 @@
     <help>La valeur se trouvant sous la barre de fraction. Il s'agit ici de l'échelle : dans le cas d'une carte à l'échelle du 1:25000, seul le terme "25000" est entré. Cette valeur peut également représenter une indication de précision dans le cas d'un jeu de données vectorielles. Exemple : des limites saisies à une échelle de 1:25'000 et présentant ce niveau de précision.</help>
     <condition>Il faut saisir ou une échelle ou une distance</condition>
     <helper>
-        <option value="5000">1:5 000</option>
-        <option value="10000">1:10 000</option>
-        <option value="25000">1:25 000</option>
-        <option value="50000">1:50 000</option>
-        <option value="100000">1:100 000</option>
-        <option value="200000">1:200 000</option>
-        <option value="300000">1:300 000</option>
-        <option value="500000">1:500 000</option>
-        <option value="1000000">1:1 000 000</option>
+      <option value="5000">1:5 000</option>
+      <option value="10000">1:10 000</option>
+      <option value="25000">1:25 000</option>
+      <option value="50000">1:50 000</option>
+      <option value="100000">1:100 000</option>
+      <option value="200000">1:200 000</option>
+      <option value="300000">1:300 000</option>
+      <option value="500000">1:500 000</option>
+      <option value="1000000">1:1 000 000</option>
     </helper>
   </element>
   <element name="gmd:density" id="293.0">
@@ -1474,13 +1474,13 @@
   <element name="gmd:description" id="335.0" context="gmd:EX_Extent">
     <label>Description</label>
     <description>Étendue spatiale et temporelle pour l'objet en question</description>
-    <help>Description sous forme textuelle de l'extension spatiale et temporelle de l'objet considéré.</help>
+    <!--<help>Description sous forme textuelle de l'extension spatiale et temporelle de l'objet considéré.</help>-->
     <condition/>
   </element>
   <element name="gmd:description" id="401.0" context="gmd:CI_OnlineResource">
     <label>Description</label>
     <description>Texte descriptif détaillé sur ce que la ressource en ligne est/fait</description>
-    <help>Description détaillée de ce que propose la source en ligne.</help>
+    <!--<help>Description détaillée de ce que propose la source en ligne.</help>-->
     <condition/>
 
   </element>
@@ -1493,16 +1493,16 @@
   <element name="gmd:descriptiveKeywords" id="33.0">
     <label>Mots clés descriptifs</label>
     <description>Catégorie, type et source de référence des mots clés</description>
-    <help>
+    <!--<help>
       En Europe, si la ressource est une série de données géographiques ou un ensemble de séries de données géographiques, il
       convient de fournir au moins un mot clé du thésaurus multilingue de l’environnement (GEMET, General Environ­mental Multi-lingual Thesaurus)
       décrivant le thème dont relèvent les données géographiques, conformément aux
-      définitions des annexes I, II ou III de la directive 2007/2/CE.
-      <!-- [2] -->
+      définitions des annexes I, II ou III de la directive 2007/2/CE.-->
+    <!-- [2] -->
 
-      Catégorie du mot clé, décrivant si ce dernier concerne la discipline, le lieu, la couche, l'intervalle de temps, ou le thème. Ces informations sont gérées dans la classe MD_Keywords.</help>
+    <!--Catégorie du mot clé, décrivant si ce dernier concerne la discipline, le lieu, la couche, l'intervalle de temps, ou le thème. Ces informations sont gérées dans la classe MD_Keywords.</help>-->
     <condition/>
-    <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
+    <!--<help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     La catégorie thématique étant trop imprécise pour des recherches détaillées, les mots clés permettent d’affiner la recherche en texte intégral et permettent une recherche structurée par mot clé.
     <ul>
       <li>Si le mot clé provient d’un vocabulaire contrôlé (thésaurus), le nom et la date de publication de celui-ci doivent être précisés.</li>
@@ -1540,7 +1540,7 @@
     Formattage : Les mots-clés doivent être fournis en minuscule, accentués, au pluriel.
     ]]></help>
     <help><![CDATA[<b>Exemple :</b> Zones à risque naturel
-    ]]></help>
+    ]]></help>-->
   </element>
   <element name="gmd:descriptor" id="258.0">
     <label>Description de l'étendue de valeur</label>
@@ -1589,9 +1589,9 @@
     <label>Format de distribution</label>
     <btnLabel>Ajouter format de distribution</btnLabel>
     <description>Description du format de distribution</description>
-    <help>Ces informations sont gérées dans la classe MD_Format.</help>
+    <!--<help>Ces informations sont gérées dans la classe MD_Format.</help>-->
     <condition/>
-    <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
+    <!--<help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     Description du ou des concepts en langage machine spécifiant la représentation des objets de données dans un enregistrement, un fichier, un message, un dispositif de stockage ou un canal de transmission.
     Cet élément est obligatoire (pour les données de l’Annexe 1) et répétable.
     <p>
@@ -1607,33 +1607,33 @@
     <li>Dans le cadre de la mise en place des métadonnées, il est reconnu que les données décrites ne sont pas nécessairement déjà encodées selon les règles des spécifications de données INSPIRE. Dans ce cas, le format utilisé doit être décrit selon la recommandation 2.</help>
     </li>
     </ul>
-    ]]></help>
+    ]]></help>-->
   </element>
   <element name="gmd:distributionInfo" id="17.0">
     <label>Renseignements sur la distribution</label>
     <description>Renseignements sur le distributeur et sur la façon d'acquérir les ressources</description>
-    <help>Informations relatives au distributeur et au mode d'acquisition de la ou des ressources. Indications concernant le lieu et la forme d'obtention des données. Ces informations sont gérées dans la classe MD_Distribution.</help>
+    <!--<help>Informations relatives au distributeur et au mode d'acquisition de la ou des ressources. Indications concernant le lieu et la forme d'obtention des données. Ces informations sont gérées dans la classe MD_Distribution.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:distributionOrderProcess" id="281.0">
     <label>Processus de distribution et de commande</label>
     <description>Informations sur comment les données peuvent êtres commandées, ainsi que sur leur coûts et sur les formatlités de commandes</description>
-    <help>Informations relatives au mode de commande des données, à leur coût ainsi qu''à d'autres instructions de commande. Ces informations sont gérées dans la classe MD_StandardOrderProcess.</help>
+    <!--<help>Informations relatives au mode de commande des données, à leur coût ainsi qu''à d'autres instructions de commande. Ces informations sont gérées dans la classe MD_StandardOrderProcess.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:distributor" id="272.0">
     <label>Distributeur</label>
     <description>Informations sur le distributeur et sur la façon d'acquérir les ressources</description>
-    <help>Informations relatives au distributeur.</help>
+    <!--<help>Informations relatives au distributeur.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:distributorContact" id="280.0">
     <label>Contact</label>
     <description>Services depuis lesquels la ressource peut être obtenue. Cette liste n''a pas besoin d'être exhaustive</description>
-    <help>Personne ou organisation compétente auprès de laquelle le jeu de données peut être obtenu. Une seule information est permise. La référence est du type de données CI_ResponsibleParty et est gérée dans la classe du même nom.</help>
+    <!--<help>Personne ou organisation compétente auprès de laquelle le jeu de données peut être obtenu. Une seule information est permise. La référence est du type de données CI_ResponsibleParty et est gérée dans la classe du même nom.</help>-->
     <condition>Obligatoire</condition>
 
   </element>
@@ -1680,28 +1680,28 @@
   <element name="gmd:edition" id="363.0">
     <label>Edition</label>
     <description>Version de la ressource en question</description>
-    <help>Version/édition de la source mentionnée</help>
+    <!--<help>Version/édition de la source mentionnée</help>-->
     <condition/>
 
   </element>
   <element name="gmd:editionDate" id="364.0">
     <label>Date d'édition</label>
     <description>Date de l'édition</description>
-    <help>Date de la version / de l'édition (jj.mm.aaaa).</help>
+    <!--<help>Date de la version / de l'édition (jj.mm.aaaa).</help>-->
     <condition/>
 
   </element>
   <element name="gmd:electronicMailAddress" id="386.0">
     <label>Courriel</label>
     <description>Adresse du courrier électronique de l'organisation ou de la personne individuelle responsable</description>
-    <help>Adresse de courrier électronique de l'organisation ou de la personne responsable</help>
+    <!--<help>Adresse de courrier électronique de l'organisation ou de la personne responsable</help>-->
     <condition>mandatory</condition>
   </element>
 
   <element name="gmd:environmentDescription" id="44.0">
     <label>Description de l'environnement de travail</label>
     <description>Description de l'environnement de travail dans lequel le jeu de données a été créé, incluant des choses telles que logiciel, système d'exploitation, nom de fichier et taille du jeu de données</description>
-    <help>Description de l'environnement de travail dans lequel le jeu de données est créé, incluant des éléments tels que le logiciel utilisé, le système d'exploitation, le nom et la taille du fichier.</help>
+    <!--<help>Description de l'environnement de travail dans lequel le jeu de données est créé, incluant des éléments tels que le logiciel utilisé, le système d'exploitation, le nom et la taille du fichier.</help>-->
     <condition/>
 
   </element>
@@ -1765,7 +1765,7 @@
   <element name="gmd:extent" id="45.0" context="gmd:MD_DataIdentification">
     <label>Étendue</label>
     <description>Information complémentaire sur les étendues spatiales et temporelles du jeu de données, incluant le polygone de délimitation et les dimensions verticales et temporelles</description>
-    <help>Informations supplémentaires concernant l'extension spatiale et temporelle des données, incluant le polygone de délimitation, les altitudes et la durée de validité. Ces informations sont du type EX_Extent et sont gérées dans la classe du même nom.</help>
+    <!--<help>Informations supplémentaires concernant l'extension spatiale et temporelle des données, incluant le polygone de délimitation, les altitudes et la durée de validité. Ces informations sont du type EX_Extent et sont gérées dans la classe du même nom.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:extent" id="140.0" context="gmd:DQ_Scope">
@@ -1778,7 +1778,7 @@
   <element name="gmd:extent" id="351.0" context="gmd:EX_TemporalExtent">
     <label>Étendue</label>
     <description>Date et temps pour le contenu du jeu de donnée</description>
-    <help>Date et heure du domaine de validité du jeu de données (texte).</help>
+    <!--<help>Date et heure du domaine de validité du jeu de données (texte).</help>
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     L’étendue temporelle définit la période de temps couverte par le contenu de la ressource.
     Cette période peut être exprimée de l’une des manières suivantes :
@@ -1799,7 +1799,7 @@
     <li>2011-08-24</li>
     <li>2013-08-24</li>
     </ul>
-    ]]></help>
+    ]]></help>-->
     <condition>Condition</condition>
 
   </element>
@@ -1813,7 +1813,7 @@
   <element name="gmd:facsimile" id="409.0">
     <label>Numéro de télécopieur</label>
     <description>Numéro de télécopieur de la personne ou organisation responsable</description>
-    <help>Numéro de télécopieur.</help>
+    <!--<help>Numéro de télécopieur.</help>-->
     <condition/>
 
   </element>
@@ -1853,7 +1853,7 @@
   <element name="gmd:fileDecompressionTechnique" id="289.0">
     <label>Technique de décompression du fichier</label>
     <description>Recommandations sur les algorithmes et les processus qui peuvent être appliqués pour lire ou ouvrir une ressource, à laquelle des techniques de compressions ont été appliquées.</description>
-    <help>Remarques relatives aux algorithmes ou aux processus à mettre en ?uvre pour la lecture ou l'extension de la ressource en cas de compression de cette dernière.</help>
+    <!--<help>Remarques relatives aux algorithmes ou aux processus à mettre en ?uvre pour la lecture ou l'extension de la ressource en cas de compression de cette dernière.</help>-->
     <condition/>
 
   </element>
@@ -1867,7 +1867,7 @@
   <element name="gmd:fileIdentifier" id="2.0">
     <label>Identifiant du fichier</label>
     <description>Identifiant unique pour ce fichier de métadonnées</description>
-    <help>Identifiant unique pour ce fichier de métadonnées. Il correspond à un et un seul nom de fichier.</help>
+    <!--<help>Identifiant unique pour ce fichier de métadonnées. Il correspond à un et un seul nom de fichier.</help>-->
     <condition/>
 
   </element>
@@ -1902,14 +1902,14 @@
   <element name="gmd:function" id="402.0">
     <label>Fonction</label>
     <description>Code pour une fonction accomplie par la ressource on-line</description>
-    <help>Rôle de la source en ligne, sélection dans la liste suivante : téléchargement, information, accès hors ligne, commande ou recherche.</help>
+    <!--<help>Rôle de la source en ligne, sélection dans la liste suivante : téléchargement, information, accès hors ligne, commande ou recherche.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:geographicElement" id="336.0">
     <label>Élément géographique</label>
     <description>Informations sur l'étendue géographique</description>
-    <help>Informations concernant l'extension géographique. Ces informations sont gérées dans la classe EX_GeographicExtent.</help>
+    <!--<help>Informations concernant l'extension géographique. Ces informations sont gérées dans la classe EX_GeographicExtent.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:geographicIdentifier" id="349.0">
@@ -1950,7 +1950,7 @@
   <element name="gmd:graphicOverview" id="31.0">
     <label>Aperçus</label>
     <description>Vue générale graphique illustrant les ressources (y inclus une légende)</description>
-    <help>Vue d'ensemble graphique de la ressource (légende incluse). Ces informations sont gérées dans la classe MD_BrowseGraphic.</help>
+    <!--<help>Vue d'ensemble graphique de la ressource (légende incluse). Ces informations sont gérées dans la classe MD_BrowseGraphic.</help>-->
     <condition/>
 
   </element>
@@ -1964,16 +1964,16 @@
   <element name="gmd:handlingDescription" id="77.0">
     <label>Description de manipulation</label>
     <description>Information complémentaire sur les restrictions au sujet de la manipulation des ressources où de métadonnées</description>
-    <help>Description de la manière dont la restriction est à appliquer, des cas dans lesquels elle doit l'être et des exceptions recensées.</help>
+    <!--<help>Description de la manière dont la restriction est à appliquer, des cas dans lesquels elle doit l'être et des exceptions recensées.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:hierarchyLevel" id="6.0">
     <label>Type de ressource</label>
     <description>Sélectionner le champ de la liste auquel s'appliquent les métadonnées. La valeur par défaut est « Jeu de données ». Si les métadonnées servent à décrire une série d’ensembles de données dans une relation parent/enfant, « Série » est la valeur la plus appropriée.</description>
-    <help>Domaine auquel les métadonnées se rapportent. La catégorie d'informations à laquelle l'entité se réfère peut être indiquée dans la liste des codes (exemple : attributs, objets géométriques, jeu de données, etc.). "Jeu de données" est le paramètre par défaut.</help>
+    <!--<help>Domaine auquel les métadonnées se rapportent. La catégorie d'informations à laquelle l'entité se réfère peut être indiquée dans la liste des codes (exemple : attributs, objets géométriques, jeu de données, etc.). "Jeu de données" est le paramètre par défaut.</help>-->
     <condition>mandatory</condition>
-    <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
+    <!--<help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     Cet élément de métadonnées renseigne le type de ressource décrit par la métadonnée.
     Seuls trois types de ressources sont dans le champ de la directive INSPIRE :
     <ul>
@@ -1999,7 +1999,7 @@
       <li>La Planche 14A du Plan local d’Urbanisme (PLU) de Marseille est a priori une série de données ;</li>
       <li>Le Plan Local d’Urbanisme (PLU) de Marseille, c’est-à-dire l’ensemble des planches composant le PLU de Marseille est a priori un ensemble de séries de données.</li>
     </ul>
-    ]]></help>
+    ]]></help>-->
   </element>
   <element name="gmd:hierarchyLevelName" id="7.0">
     <label>Nom du niveau de hiérarchie</label>
@@ -2010,27 +2010,27 @@
   <element name="gmd:hoursOfService" id="391.0">
     <label>Heures de service</label>
     <description>Fournir une case horaire (y compris le fuseau horaire) pour communiquer avec l'organisation ou la personne responsable.</description>
-    <help>Heures d'ouverture, indications fournies sous forme de texte libre, par exemple : "08h00 - 11h45h et 13h30 - 17h00" ou "De 08h00 à 11h45 et de 13h30 à 17h00"</help>
+    <!--<help>Heures d'ouverture, indications fournies sous forme de texte libre, par exemple : "08h00 - 11h45h et 13h30 - 17h00" ou "De 08h00 à 11h45 et de 13h30 à 17h00"</help>-->
     <condition/>
 
   </element>
   <element name="gmd:identificationInfo" id="15.0">
     <label>Renseignements sur l’identification</label>
     <description>Informations de base sur les ressources concernées par les métadonnées</description>
-    <help>Informations de base concernant la ressource (voire les ressources) ou le jeu de données auquel se rapportent les métadonnées. Ces informations sont gérées dans la classe MD_IdentificationInformation.</help>
+    <!--<help>Informations de base concernant la ressource (voire les ressources) ou le jeu de données auquel se rapportent les métadonnées. Ces informations sont gérées dans la classe MD_IdentificationInformation.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:identifier" id="365.0">
     <label>Identificateur</label>
     <description>Identificateur de l'indication de provenance</description>
-    <help>Identificateur de l'indication de provenance. La classe MD_Identifier permet d'affecter une indication de provenance à un registre existant.</help>
+    <!--<help>Identificateur de l'indication de provenance. La classe MD_Identifier permet d'affecter une indication de provenance à un registre existant.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:identifier" id="573.0" context="gmd:CI_Citation">
     <label>Identifiant</label>
     <description>Identificateur de l'indication de provenance</description>
-    <help>Identificateur de l'indication de provenance. La classe MD_Identifier permet d'affecter une indication de provenance à un registre existant.</help>
+    <!--<help>Identificateur de l'indication de provenance. La classe MD_Identifier permet d'affecter une indication de provenance à un registre existant.</help>-->
     <condition/>
     <condition>Condition</condition>
   </element>
@@ -2079,7 +2079,7 @@
   <element name="gmd:individualName" id="375.0">
     <label>Nom de la personne</label>
     <description>Nom de la personne responsable. Prénom, nom et titre sont séparés par un signe de délimitation</description>
-    <help>Nom de la personne responsable. Des séparateurs (virgules) figurent entre le prénom, le nom et le titre.</help>
+    <!--<help>Nom de la personne responsable. Des séparateurs (virgules) figurent entre le prénom, le nom et le titre.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:initiativeType" id="66.5">
@@ -2106,7 +2106,7 @@
     <label>Langue</label>
     <btnLabel>Ajouter langue</btnLabel>
     <description>Sélectionner la langue d'usage pour la création de métadonnées.</description>
-    <help>La sélection s'opère dans la liste des langues ISO. Exemple : "fr" pour le français, "de" pour l'allemand, "en" pour l'anglais, "it" pour l'italien, "rm" pour le romanche, ...</help>
+    <!--<help>La sélection s'opère dans la liste des langues ISO. Exemple : "fr" pour le français, "de" pour l'allemand, "en" pour l'anglais, "it" pour l'italien, "rm" pour le romanche, ...</help>
 
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>C’est la langue utilisée dans les métadonnées.
     <ul>
@@ -2120,7 +2120,7 @@
     <![CDATA[
     <b>Recommandations :</b>
     Cet élément doit être fixé à fre pour les métadonnées du GéoCatalogue utilisée pour le rapportage INSPIRE.
-    ]]></help>
+    ]]></help>-->
 
     <condition>Obligatoire</condition>
   </element>
@@ -2128,9 +2128,9 @@
     <label>Langue</label>
     <btnLabel>Ajouter langue</btnLabel>
     <description>Langue utilisée pour le jeu de données</description>
-    <help>Langue utilisée pour la documentation des données. La sélection s'opère dans la liste des langues ISO. Exemple : "fr" pour le français, "de" pour l'allemand, "en" pour l'anglais, "it" pour l'italien, "rm" pour le romanche, ...</help>
+    <!--<help>Langue utilisée pour la documentation des données. La sélection s'opère dans la liste des langues ISO. Exemple : "fr" pour le français, "de" pour l'allemand, "en" pour l'anglais, "it" pour l'italien, "rm" pour le romanche, ...</help>-->
     <condition>mandatory</condition>
-    <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
+    <!--<help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     Ce sont la ou les langues utilisées dans la ressource.
     <ul>
     <li>Les valeurs autorisées sont celles définies dans la norme ISO 639-2 (code à trois lettres).</li>
@@ -2149,7 +2149,7 @@
     <help><![CDATA[<b>Exemple :</b> fre, bre, baq, ger
     ]]></help>
     <help><![CDATA[<b>Contre-exemple :</b> FR, FRA, french, français
-    ]]></help>
+    ]]></help>-->
   </element>
   <element name="gmd:language" id="235.0" context="gmd:MD_FeatureCatalogueDescription">
     <label>Langue</label>
@@ -2192,7 +2192,7 @@
     ]]>
     </help>
     <help for="france">
-    <![CDATA[
+      <![CDATA[
     <b>Commentaire :</b>
     <ul>
     <li>La généalogie de la ressource décrit l’historique d’un jeu de données et, s’il est connu, le cycle de vie de celui-ci, depuis l’acquisition et la saisie de l’information jusqu’à sa compilation avec d’autres jeux et les variantes de sa forme actuelle. Il s’agit d’apporter une description littérale et concise soit de l’histoire du jeu de données, soit des moyens, procédures ou traitements informatiques mis en œuvre au moment de l’acquisition du jeu de données. Par exemple, la généalogie peut consigner l’échelle de saisie si cette information est importante pour l’utilisation du jeu de données.</li>
@@ -2211,21 +2211,21 @@
   <element name="gmd:linkage" id="397.0">
     <label>Adresse Internet</label>
     <description>URL ou indication semblable d'une adresse Internet pour un accès on-line , par exemple http://www.isotc211.org</description>
-    <help>Lien Internet, par exemple www.cosig.ch.</help>
+    <!--<help>Lien Internet, par exemple www.cosig.ch.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:maintenanceAndUpdateFrequency" id="143.0">
     <label>Fréquence de mise à jour</label>
     <description>La fréquence des changements et des ajouts sont faits à la ressource après l'achèvement initial de la ressource. Pour une surveillance continue des données, sélectionner la valeur appropriée pour décrire la façon dont les données ont été recueillies.</description>
-    <help>Fréquence à laquelle des changements et des ajouts sont apportés à la ressource. La valeur concernée est à sélectionner dans la liste suivante : en permanence, quotidienne, hebdomadaire, bimensuelle, mensuelle, trimestrielle, semestrielle, annuelle, au besoin, irrégulière, non prévue, inconnue, définie par l'utilisateur.</help>
+    <!--<help>Fréquence à laquelle des changements et des ajouts sont apportés à la ressource. La valeur concernée est à sélectionner dans la liste suivante : en permanence, quotidienne, hebdomadaire, bimensuelle, mensuelle, trimestrielle, semestrielle, annuelle, au besoin, irrégulière, non prévue, inconnue, définie par l'utilisateur.</help>-->
     <condition>Obligatoire</condition>
 
   </element>
   <element name="gmd:maintenanceNote" id="148.0">
     <label>Remarque sur la mise à jour</label>
     <description>Informations ou remarques en ce qui concerne les besoins spécifiques concernant la maintenance des ressources</description>
-    <help>Informations ou remarques concernant la prise en compte de besoins spécifiques lors de la mise à jour des ressources.</help>
+    <!--<help>Informations ou remarques concernant la prise en compte de besoins spécifiques lors de la mise à jour des ressources.</help>-->
     <condition/>
 
   </element>
@@ -2273,7 +2273,7 @@
   <element name="gmd:metadataConstraints" id="20.0" context="gmd:MD_Metadata">
     <label>Contraites sur les métadonnées</label>
     <description>Contraintes sur l'accès et l'utilisation des métadonnées</description>
-    <help>Restrictions d'accès et d'utilisation des métadonnées (exemple : copyright, conditions d'octroi de licence, etc.). Ces informations sont gérées dans la classe MD_Constraints.</help>
+    <!--<help>Restrictions d'accès et d'utilisation des métadonnées (exemple : copyright, conditions d'octroi de licence, etc.). Ces informations sont gérées dans la classe MD_Constraints.</help>-->
     <condition/>
 
   </element>
@@ -2294,21 +2294,21 @@
   <element name="gmd:metadataMaintenance" id="22.0">
     <label>Mise à jour des métadonnées</label>
     <description>Informations sur la fréquence de mise à jour des métadonnées, ainsi que de leur étendue</description>
-    <help>Informations concernant la fréquence, l'étendue, la date et la validité des mises à jour. Ces informations sont gérées dans la classe MD_MaintenanceInformation.</help>
+    <!--<help>Informations concernant la fréquence, l'étendue, la date et la validité des mises à jour. Ces informations sont gérées dans la classe MD_MaintenanceInformation.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:metadataStandardName" id="10.0">
     <label>Nom de la norme pour les métadonnées</label>
     <description>Nom du standard (incluant le nom du profil) de métadonnées utilisé</description>
-    <help>Nom de la norme sur les métadonnées utilisée, profil inclus (exemple : GM03Core, GM03Profil).</help>
+    <!--<help>Nom de la norme sur les métadonnées utilisée, profil inclus (exemple : GM03Core, GM03Profil).</help>-->
     <condition/>
 
   </element>
   <element name="gmd:metadataStandardVersion" id="11.0">
     <label>Version de la norme pour les métadonnées</label>
     <description>Version (du profil) du standard de métadonnées utilisé.</description>
-    <help>Version (du profil) de la norme sur les métadonnées utilisée.</help>
+    <!--<help>Version (du profil) de la norme sur les métadonnées utilisée.</help>-->
     <condition/>
 
   </element>
@@ -2349,65 +2349,65 @@
   <element name="gmd:name" id="285.0" context="gmd:MD_Format">
     <label>Nom du format</label>
     <description>Indiquer le nom du format de transfert de données. Pour une liste de formats possibles, consulter le menu « Suggestions ».</description>
-    <help>Nom du format de transfert de données, par exemple TIFF, ZIP, etc.</help>
+    <!--<help>Nom du format de transfert de données, par exemple TIFF, ZIP, etc.</help>-->
     <condition>Obligatoire</condition>
-      <!--<helper rel="gmd:version">
-        <option value="Texte">Texte</option>
-        <option value="ESRI Shapefile" title="1.0">ESRI Shapefile</option>
-        <option value="Mapinfo MIF/MID" title="4.5">Mapinfo MIF/MID</option>
-        <option value="Mapinfo TAB">Mapinfo TAB</option>
-        <option value="KML">KML</option>
-        <option value="GeoTIFF" title="1.0">GeoTIFF</option>
-        <option value="TIFF">TIFF</option>
-        <option value="ECW">ECW</option>
-        <option value="ZIP">ZIP</option>
-       <option value="bil">bil</option>
-       <option value="bmp">bmp</option>
-       <option value="bsq">bsq</option>
-       <option value="bzip2">bzip2</option>
-       <option value="cdr">cdr</option>
-       <option value="cgm">cgm</option>
-       <option value="cover">cover</option>
-       <option value="csv">csv</option>
-       <option value="dbf">dbf</option>
-       <option value="dgn">dgn</option>
-       <option value="doc">doc</option>
-       <option value="dwg">dwg</option>
-       <option value="dxf">dxf</option>
-       <option value="e00">e00</option>
-       <option value="ecw">ecw</option>
-       <option value="eps">eps</option>
-       <option value="ers">ers</option>
-       <option value="gdb">gdb</option>
-       <option value="geotiff">geotiff</option>
-       <option value="gif">gif</option>
-       <option value="gml">gml</option>
-       <option value="grid">grid</option>
-       <option value="gzip">gzip</option>
-       <option value="html">html</option>
-       <option value="jpg">jpg</option>
-       <option value="mdb">mdb</option>
-       <option value="mif">mif</option>
-       <option value="pbm">pbm</option>
-       <option value="pdf">pdf</option>
-       <option value="png">png</option>
-       <option value="ps">ps</option>
-       <option value="rtf">rtf</option>
-       <option value="sdc">sdc</option>
-       <option value="shp">shp</option>
-       <option value="sid">sid</option>
-       <option value="svg">svg</option>
-       <option value="tab">tab</option>
-       <option value="tar">tar</option>
-      <option value="tiff">tiff</option>
-      <option value="txt">txt</option>
-      <option value="xhtml">xhtml</option>
-      <option value="xls">xls</option>
-      <option value="xml">xml</option>
-      <option value="xwd">xwd</option>
-      <option value="zip">zip</option>
-      <option value="wpd">wpd</option>
-    </helper>-->
+    <!--<helper rel="gmd:version">
+      <option value="Texte">Texte</option>
+      <option value="ESRI Shapefile" title="1.0">ESRI Shapefile</option>
+      <option value="Mapinfo MIF/MID" title="4.5">Mapinfo MIF/MID</option>
+      <option value="Mapinfo TAB">Mapinfo TAB</option>
+      <option value="KML">KML</option>
+      <option value="GeoTIFF" title="1.0">GeoTIFF</option>
+      <option value="TIFF">TIFF</option>
+      <option value="ECW">ECW</option>
+      <option value="ZIP">ZIP</option>
+     <option value="bil">bil</option>
+     <option value="bmp">bmp</option>
+     <option value="bsq">bsq</option>
+     <option value="bzip2">bzip2</option>
+     <option value="cdr">cdr</option>
+     <option value="cgm">cgm</option>
+     <option value="cover">cover</option>
+     <option value="csv">csv</option>
+     <option value="dbf">dbf</option>
+     <option value="dgn">dgn</option>
+     <option value="doc">doc</option>
+     <option value="dwg">dwg</option>
+     <option value="dxf">dxf</option>
+     <option value="e00">e00</option>
+     <option value="ecw">ecw</option>
+     <option value="eps">eps</option>
+     <option value="ers">ers</option>
+     <option value="gdb">gdb</option>
+     <option value="geotiff">geotiff</option>
+     <option value="gif">gif</option>
+     <option value="gml">gml</option>
+     <option value="grid">grid</option>
+     <option value="gzip">gzip</option>
+     <option value="html">html</option>
+     <option value="jpg">jpg</option>
+     <option value="mdb">mdb</option>
+     <option value="mif">mif</option>
+     <option value="pbm">pbm</option>
+     <option value="pdf">pdf</option>
+     <option value="png">png</option>
+     <option value="ps">ps</option>
+     <option value="rtf">rtf</option>
+     <option value="sdc">sdc</option>
+     <option value="shp">shp</option>
+     <option value="sid">sid</option>
+     <option value="svg">svg</option>
+     <option value="tab">tab</option>
+     <option value="tar">tar</option>
+    <option value="tiff">tiff</option>
+    <option value="txt">txt</option>
+    <option value="xhtml">xhtml</option>
+    <option value="xls">xls</option>
+    <option value="xml">xml</option>
+    <option value="xwd">xwd</option>
+    <option value="zip">zip</option>
+    <option value="wpd">wpd</option>
+  </helper>-->
   </element>
   <element name="gmd:name" id="307.0" context="gmd:MD_ExtendedElementInformation">
     <label>Nom</label>
@@ -2426,7 +2426,7 @@
   <element name="gmd:name" id="400.0" context="gmd:CI_OnlineResource">
     <label>Nom</label>
     <description>Nom de la ressource en ligne</description>
-    <help>Nom de la source en ligne.</help>
+    <!--<help>Nom de la source en ligne.</help>-->
     <condition>Obligatoire</condition>
 
   </element>
@@ -2584,7 +2584,7 @@
   <element name="gmd:onlineResource" id="390.0">
     <label>Adresse Internet</label>
     <description>Information on-line qui peut être utilisée pour contacter la personne ou l'organisation responsable</description>
-    <help>Information en ligne, par exemple l'adresse Internet de l'organisation.</help>
+    <!--<help>Information en ligne, par exemple l'adresse Internet de l'organisation.</help>-->
     <condition/>
 
   </element>
@@ -2598,7 +2598,7 @@
   <element name="gmd:organisationName" id="376.0">
     <label>Organisation</label>
     <description>Nom de l'organisation responsable</description>
-    <help>Nom de l'organisation responsable, s'il s'agit d'une personne isolée ou nom de l'organisation au sein de laquelle cette personne est employée. Ces informations sont du type PT_FreeText et sont gérées dans la classe du même nom.</help>
+    <!--<help>Nom de l'organisation responsable, s'il s'agit d'une personne isolée ou nom de l'organisation au sein de laquelle cette personne est employée. Ces informations sont du type PT_FreeText et sont gérées dans la classe du même nom.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:orientationParameterAvailability" id="172.0">
@@ -2624,14 +2624,14 @@
   <element name="gmd:otherCitationDetails" id="370.0">
     <label>Autres informations de référence</label>
     <description>Autre information utilisée pour compléter les informations de référence qui ne sont pas prévues ailleurs</description>
-    <help>Autre information requise pour une description complète de la source, non saisie ou impossible à saisir dans un autre attribut.</help>
+    <!--<help>Autre information requise pour une description complète de la source, non saisie ou impossible à saisir dans un autre attribut.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:otherConstraints" id="72.0">
     <label>Autres contraintes</label>
     <description>L'indication  'Autres restrictions' dans les champs « Contraintes d'accès » ou « Contraintes d'utilisation » permet de décrire ici d’autres contraintes quant à l'accès ou l'utilisation de la ressource</description>
-    <help>Autres restrictions et conditions préalables de nature juridique concernant l'accès et l'utilisation de la ressource ou des métadonnées. Ce champ doit être complété dès lors que l'un des deux champs précédents (accessConstraints, useConstraints) porte la mention "Autres restrictions".</help>
+    <!--<help>Autres restrictions et conditions préalables de nature juridique concernant l'accès et l'utilisation de la ressource ou des métadonnées. Ce champ doit être complété dès lors que l'un des deux champs précédents (accessConstraints, useConstraints) porte la mention "Autres restrictions".</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:page" id="406.0">
@@ -2656,7 +2656,7 @@
   <element name="gmd:parentIdentifier" id="5.0">
     <label>Identifiant du parent</label>
     <description>Identifiant du fichier de métadonnées parent.</description>
-    <help>Nom unique du fichier de métadonnées parent ou origine. Il peut s'agir d'un modèle prédéfini ou de données de rang supérieur (dans le cas par exemple d'une carte nationale au 1:25''000, le parent peut être la série de toutes les cartes au 1:25''000).</help>
+    <!--<help>Nom unique du fichier de métadonnées parent ou origine. Il peut s'agir d'un modèle prédéfini ou de données de rang supérieur (dans le cas par exemple d'une carte nationale au 1:25''000, le parent peut être la série de toutes les cartes au 1:25''000).</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:pass" id="132.0">
@@ -2667,7 +2667,7 @@
     ]]>
     </help>
     <help for="france">
-    <![CDATA[
+      <![CDATA[
     <b>Commentaire :</b>
     Pour chaque spécification visée en annexe A et B, le degré de conformité (conforme/non conforme/non évalué) doit être indiqué. Pour les autres spécifications, la valeur ne pourra être que (conforme/ non conforme).
     ]]></help>
@@ -2684,7 +2684,7 @@
   <element name="gmd:phone" id="388.0">
     <label>Téléphone</label>
     <description>Numéro de téléphone avec lequel la personne ou l'organisation responsable peut être contactée</description>
-    <help>Numéro de téléphone. Ces informations sont du type CI_Telephone et sont gérées dans la classe du même nom.</help>
+    <!--<help>Numéro de téléphone. Ces informations sont du type CI_Telephone et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
@@ -2705,7 +2705,7 @@
   <element name="gmd:pointOfContact" id="29.0">
     <label>Contact pour la ressource</label>
     <description>Identification, et mode de communication avec, des personnes ou des organisations associées aux ressources</description>
-    <help>Identification de la personne (voire des personnes) ou de l'organisation (voire des organisations) responsable du jeu de données décrit et mode de communication avec elle. Cette personne ou ce service endosse un rôle (propriétaire, prestataire, gestionnaire, etc.) bien spécifique pouvant être sélectionné dans la liste proposée. Les données correspondantes de la personne ou du service sont gérées dans la classe CI_ResponsibleParty. Ce rôle peut également servir à l'affectation d'un jeu de données à une commune. Exemple : le rôle de "propriétaire" permet ici d'affecter un lot de la MO à la commune correspondante.</help>
+    <!--<help>Identification de la personne (voire des personnes) ou de l'organisation (voire des organisations) responsable du jeu de données décrit et mode de communication avec elle. Cette personne ou ce service endosse un rôle (propriétaire, prestataire, gestionnaire, etc.) bien spécifique pouvant être sélectionné dans la liste proposée. Les données correspondantes de la personne ou du service sont gérées dans la classe CI_ResponsibleParty. Ce rôle peut également servir à l'affectation d'un jeu de données à une commune. Exemple : le rôle de "propriétaire" permet ici d'affecter un lot de la MO à la commune correspondante.</help>
 
     <help><![CDATA[<b>Organisation responsable</b>]]></help>
 
@@ -2738,7 +2738,7 @@
     <li>Préfecture de Paris-Direction de l’Urbanisme, du Logement et de l’Équipement </li>
     <li>Email : urbanisme@paris.pref.gouv.fr</li>
     </ul>
-    ]]></help>
+    ]]></help>-->
 
     <condition/>
   </element>
@@ -2759,27 +2759,27 @@
   <element name="gmd:portrayalCatalogueInfo" id="19.0">
     <label>Renseignements sur la réprésentation</label>
     <description>Informations sur le catalogue de règles concernant la représentation des ressources</description>
-    <help>Informations concernant le catalogue de règles établi pour la représentation de ressources.</help>
+    <!--<help>Informations concernant le catalogue de règles établi pour la représentation de ressources.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:positionName" id="377.0">
     <label>Position</label>
     <description>Rôle ou position de la personne responsable</description>
-    <help>Fonction ou position de la personne responsable.</help>
+    <!--<help>Fonction ou position de la personne responsable.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:postalCode" id="384.0">
     <label>Code postal</label>
     <description>Code postale ou autre code pour l'emplacement</description>
-    <help>Code postal</help>
+    <!--<help>Code postal</help>-->
     <condition/>
 
   </element>
   <element name="gmd:presentationForm" id="368.0">
     <label>Forme de la présentation</label>
     <description>Mode dans lequel la ressource est représentée</description>
-    <help>Forme sous laquelle la source est disponible. Exemple : document numérique ou analogique, image, carte, modèle, etc. (sélection dans une liste).</help>
+    <!--<help>Forme sous laquelle la source est disponible. Exemple : document numérique ou analogique, image, carte, modèle, etc. (sélection dans une liste).</help>-->
     <condition/>
 
   </element>
@@ -2806,7 +2806,7 @@
   <element name="gmd:protocol" id="398.0" alias="protocol">
     <label>Protocole</label>
     <description>Sélectionner le bon protocole de la liste déroulante. Si l'ensemble de données est disponible en ligne, sélectionner « Adresse Web (URL) ».</description>
-    <help>Protocole de connexion utilisé, par exemple FTP.</help>
+    <!--<help>Protocole de connexion utilisé, par exemple FTP.</help>-->
     <helper sort="true">
       <option value="HTTP">HTTP</option>
       <option value="HTTPS">HTTPS</option>
@@ -2819,7 +2819,7 @@
   <element name="gmd:purpose" id="26.0">
     <label>But</label>
     <description>Résumé des intentions pour lesquelles les ressources ont été développées</description>
-    <help>Motif(s) de la création de ce jeu de données.</help>
+    <!--<help>Motif(s) de la création de ce jeu de données.</help>-->
     <condition/>
 
   </element>
@@ -2847,7 +2847,7 @@
   <element name="gmd:referenceSystemIdentifier" id="187.0">
     <label>Nom du système de référence</label>
     <description>Nom du système de référence spatiale, par lequel sont définis la projection, l'ellipsoïde et le datum géodésique utilisés</description>
-    <help>Nom du système de référence spatial englobant la définition de la projection, de l'ellipsoïde et du datum géodésique utilisés. Ces informations sont du type RS_Identifier et sont gérées dans la classe du même nom.</help>
+    <!--<help>Nom du système de référence spatial englobant la définition de la projection, de l'ellipsoïde et du datum géodésique utilisés. Ces informations sont du type RS_Identifier et sont gérées dans la classe du même nom.</help>-->
     <condition>Condition</condition>
 
   </element>
@@ -2855,7 +2855,7 @@
     <label>Information sur le système de référence</label>
     <btnLabel>Ajouter information sur le système de référence</btnLabel>
     <description>Description des références spatiale et temporelle utilisées dans le jeu de données</description>
-    <help>Description des systèmes de référence spatiale et temporelle utilisés dans le jeu de données. Ces informations sont gérées dans la classe MD_ReferenceSystem.</help>
+    <!--<help>Description des systèmes de référence spatiale et temporelle utilisés dans le jeu de données. Ces informations sont gérées dans la classe MD_ReferenceSystem.</help>-->
     <condition/>
 
   </element>
@@ -2875,7 +2875,7 @@
   <element name="gmd:resourceConstraints" id="35.0">
     <label>Contraintes sur la ressource</label>
     <description>Informations sur les contraintes concernant les ressources</description>
-    <help>Ces informations sont gérées dans la classe MD_Constraints.</help>
+    <!--<help>Ces informations sont gérées dans la classe MD_Constraints.</help>
 
     <help><![CDATA[
     <b>Contraintes en matière d'accès et d'utilisation</b>
@@ -2902,7 +2902,7 @@
     <![CDATA[
     <b>Commentaire :</b>
     Il faut tout d’abord remarquer que ces deux éléments sont sémantiquement liés. En effet, dans le cas où une restriction est applicable à l’accès public, le champ définissant les conditions applicables à l’accès et à l’utilisation de la ressource sera fortement influencé par la restriction et définira dans quel cadre il est possible ou non d’obtenir la ressource.
-    ]]></help>
+    ]]></help>-->
     <condition/>
 
   </element>
@@ -2916,7 +2916,7 @@
   <element name="gmd:resourceMaintenance" id="30.0">
     <label>Mise à jour de la ressource</label>
     <description>Informations sur la fréquence de mise à jour des ressources, ainsi que de leur étendue</description>
-    <help>Informations concernant l'étendue et la date de mise à jour de la ressource. Si la mise à jour ne concerne pas la totalité du jeu de données, les options "updateScope" et "updateScopeDescription" permettent la description de la mise à jour individualisée de chacune des parties du jeu. Exemple : les biens-fonds de la MO sont actualisés annuellement, les nomenclatures ne l'étant qu''au besoin. Ces informations sont gérées dans la classe MD_MaintenanceInformation.</help>
+    <!--<help>Informations concernant l'étendue et la date de mise à jour de la ressource. Si la mise à jour ne concerne pas la totalité du jeu de données, les options "updateScope" et "updateScopeDescription" permettent la description de la mise à jour individualisée de chacune des parties du jeu. Exemple : les biens-fonds de la MO sont actualisés annuellement, les nomenclatures ne l'étant qu''au besoin. Ces informations sont gérées dans la classe MD_MaintenanceInformation.</help>-->
     <condition/>
 
   </element>
@@ -2937,7 +2937,7 @@
   <element name="gmd:role" id="379.0">
     <label>Rôle</label>
     <description>Sélectionner le rôle approprié dans la liste fournie. Le rôle de coordonnateur de données indique la personne responsable de l'ensemble de données.</description>
-    <help>Rôle endossé par le service responsable (prestataire, gestionnaire, propriétaire, utilisateur, distributeur, créateur de données, instance compétente, évaluateur de données, responsable de leur traitement ou de leur publication, auteur, éditeur ou partenaire commercial).</help>
+    <!--<help>Rôle endossé par le service responsable (prestataire, gestionnaire, propriétaire, utilisateur, distributeur, créateur de données, instance compétente, évaluateur de données, responsable de leur traitement ou de leur publication, auteur, éditeur ou partenaire commercial).</help>
 
     <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
       Cet élément définit le rôle que joue l’organisation responsable vis-à-vis de la ressource.
@@ -2948,7 +2948,7 @@
     <![CDATA[
     <b>Commentaire :</b>
     Dans le cas où une partie responsable a plusieurs rôles, les deux éléments de métadonnées devront être répétés pour chaque rôle.
-    ]]></help>
+    ]]></help>-->
 
     <condition>Obligatoire</condition>
 
@@ -3005,9 +3005,9 @@
   <element name="gmd:series" id="369.0">
     <label>Séries</label>
     <description>Information sur la série (ou sur le jeu de données global) de laquelle le jeu de données est une partie</description>
-    <help>Information relative à la série ou au jeu de données composé dont le jeu de données est issu.
+    <!--<help>Information relative à la série ou au jeu de données composé dont le jeu de données est issu.
       Exemple : la série de toutes les cartes nationales au 1:25'000.
-      Ces informations sont du type CI_Series et sont gérées dans la classe du même nom.</help>
+      Ces informations sont du type CI_Series et sont gérées dans la classe du même nom.</help>-->
     <condition/>
 
   </element>
@@ -3088,27 +3088,27 @@
   <element name="gmd:spatialRepresentationInfo" id="12.0">
     <label>Information sur la représentation spatiale</label>
     <description>Représentation digitale de l'information spatiale dans le jeu de données</description>
-    <help>Informations sur la manière dont les représentations spatiales sont définies. Une distinction est étable entre les données vectorielles et les données tramées. Dans le cas de données vectorielles, les indications concernent le type géométrique, la topologie, etc., tandis qu''elles se rapportent au nombre de pixels, à l'ordre de succession des axes, aux paramètres de géoréférencement, etc. dans le cas de données tramées. Ces informations sont gérées dans la classe MD_SpatialRepresentation.</help>
+    <!--<help>Informations sur la manière dont les représentations spatiales sont définies. Une distinction est étable entre les données vectorielles et les données tramées. Dans le cas de données vectorielles, les indications concernent le type géométrique, la topologie, etc., tandis qu''elles se rapportent au nombre de pixels, à l'ordre de succession des axes, aux paramètres de géoréférencement, etc. dans le cas de données tramées. Ces informations sont gérées dans la classe MD_SpatialRepresentation.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:spatialRepresentationType" id="37.0">
     <label>Type de représentation spatiale</label>
     <description>Méthode utilisée pour représenter spatialement l'information géographique</description>
-    <help>Méthode utilisée pour la représentation spatiale des informations géographiques par des vecteurs, un quadrillage, des cartes, des tableaux, ou d'autres moyens similaires.</help>
+    <!--<help>Méthode utilisée pour la représentation spatiale des informations géographiques par des vecteurs, un quadrillage, des cartes, des tableaux, ou d'autres moyens similaires.</help>-->
     <condition>mandatory</condition>
   </element>
   <element name="gmd:spatialResolution" id="38.0">
     <label>Résolution spatiale</label>
     <description>Facteur qui donne une indication générale sur la densité de données spatiales dans le jeu de données</description>
-    <help>Facteur donnant une indication générale de la résolution spatiale du jeu de données. Il est indiqué sous forme d'échelle ou d'élément de comparaison au sol. Ces informations sont gérées dans la classe MD_Resolution.
+    <!--<help>Facteur donnant une indication générale de la résolution spatiale du jeu de données. Il est indiqué sous forme d'échelle ou d'élément de comparaison au sol. Ces informations sont gérées dans la classe MD_Resolution.
       La résolution spatiale se rapporte au niveau de détail de la série de données. Elle est exprimée comme un ensemble
       de valeurs de distance de résolution allant de zéro à plusieurs valeurs (normalement utilisé pour des données
       maillées et des produits dérivés d’imagerie) ou exprimée en échelles équivalentes (habituellement utilisées pour les
-      cartes ou les produits dérivés de cartes).<!-- [2] -->
-    </help>
+      cartes ou les produits dérivés de cartes).--><!-- [2] -->
+    <!--</help>-->
 
-    <help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
+    <!--<help for="inspire"><![CDATA[<b>Exigence INSPIRE :</b>
     La résolution spatiale décrit le niveau de détail de la ressource.
     Elle est exprimée comme un ensemble de valeurs de distance de résolution allant de zéro
      à plusieurs valeurs ou exprimée en échelles équivalentes :
@@ -3140,7 +3140,7 @@
     Extrait du document "La qualité des données géographiques", CERTU, 2010 : "cette grandeur est exprimée soit par une échelle pour les données de type vecteur, soit par une distance pour les données de type raster.
     (...) La notion d’échelle proposée par INSPIRE pour qualifier la résolution spatiale d’un lot de données vecteur est également très subjective et sujette à interprétation."
     La plupart du temps, pour une donnée vectorielle, cela revient à noter l’échelle de la série de données source. A défaut, il s’agit de l’échelle optimum d’emploi de la donnée.
-    ]]></help>
+    ]]></help>-->
     <condition/>
 
   </element>
@@ -3161,7 +3161,7 @@
   <element name="gmd:specification" id="288.0" context="gmd:MD_Format">
     <label>Spécification</label>
     <description>Nom d'une spécification de sous-ensemble, profil ou produit du format</description>
-    <help>Nom d'une spécification partielle, de profil ou de produit du format.</help>
+    <!--<help>Nom d'une spécification partielle, de profil ou de produit du format.</help>-->
     <condition>Obligatoire</condition>
 
   </element>
@@ -3176,27 +3176,27 @@
     <label>Etat</label>
     <btnLabel>Ajouter état</btnLabel>
     <description>Sélectionner le statut de l'ensemble de données dans la liste. C'est-à-dire, si l'ensemble de données est incomplet, sélectionner « Planifié ».</description>
-    <help>Etat de traitement du jeu de données. Sélection de l'une des options suivantes : complet, archive historique, obsolète, en cours, en projet, nécessaire, à l'étude.</help>
+    <!--<help>Etat de traitement du jeu de données. Sélection de l'une des options suivantes : complet, archive historique, obsolète, en cours, en projet, nécessaire, à l'étude.</help>-->
     <condition>mandatory</condition>
   </element>
   <element name="gmd:supplementalInformation" id="46.0">
     <label>Renseignements supplémentaires</label>
     <description>Ce champ peut servir à fournir des renseignements supplémentaires concernant l'ensemble de données non saisi dans le formulaire. Il peut servir à lier les renseignements sur le programme, des rapports sur la qualité des données, des dictionnaires de données, etc.</description>
-    <help>Informations descriptives supplémentaires relatives au jeu de données présentant un intérêt général ou plus spécifiquement lié à l'utilisation, au traitement, etc. du jeu de données.</help>
+    <!--<help>Informations descriptives supplémentaires relatives au jeu de données présentant un intérêt général ou plus spécifiquement lié à l'utilisation, au traitement, etc. du jeu de données.</help>-->
     <condition/>
 
   </element>
   <element name="gmd:temporalElement" id="337.0">
     <label>Élément temporel</label>
     <description>Informations sur l'étendue temporelle</description>
-    <help>
+    <!--<help>
       L’étendue temporelle définit la période de temps couverte par le contenu de la ressource. Cette période peut être
       exprimée de l’une des manières suivantes : une date déterminée,
       un intervalle de dates exprimé par la date de début et la date de fin de l’intervalle,
-      un mélange de dates et d’intervalles.
-      <!-- [2] -->
+      un mélange de dates et d’intervalles.-->
+    <!-- [2] -->
 
-      Informations relatives à l'extension temporelle. Elles sont gérées dans la classe EX_TemporalExtent.</help>
+    <!--Informations relatives à l'extension temporelle. Elles sont gérées dans la classe EX_TemporalExtent.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:textGroup" id="602.0">
@@ -3221,9 +3221,9 @@
   </element>
 
   <element name="gmd:title" id="507.0" context="gmd:MD_Legislation">
-        <label>Title</label>
-        <description>Reference to legal title</description>
-    </element>
+    <label>Title</label>
+    <description>Reference to legal title</description>
+  </element>
 
   <element name="gmd:toneGradation" id="265.0">
     <label>Nombre de tons de gris</label>
@@ -3264,7 +3264,7 @@
   <element name="gmd:transferOptions" id="273.0">
     <label>Options de transfert</label>
     <description>Informations sur la façon de se procurer les données chez le distributeur</description>
-    <help>Informations relatives au mode d'obtention des données auprès du distributeur. Ces informations sont gérées dans la classe MD_DigitalTransferOptions.</help>
+    <!--<help>Informations relatives au mode d'obtention des données auprès du distributeur. Ces informations sont gérées dans la classe MD_DigitalTransferOptions.</help>-->
     <condition/>
 
   </element>
@@ -3334,14 +3334,14 @@
   <element name="gmd:updateScope" id="146.0">
     <label>Domaine de la mise à jour</label>
     <description>Domaine d'applicabilité des données sur lequel une mise à jour est appliquée</description>
-    <help>Domaine des données concerné par la mise à jour. La catégorie à laquelle l'information se rapporte peut être indiquée dans la liste de codes (exemple : attributs, objets géométriques, jeu de données, etc.).</help>
+    <!--<help>Domaine des données concerné par la mise à jour. La catégorie à laquelle l'information se rapporte peut être indiquée dans la liste de codes (exemple : attributs, objets géométriques, jeu de données, etc.).</help>-->
     <condition/>
 
   </element>
   <element name="gmd:updateScopeDescription" id="147.0">
     <label>Description du domaine de mise à jour</label>
     <description>Information supplémentaire sur le domaine ou l'étendue de la mise à jour</description>
-    <help>Informations supplémentaires relatives au domaine ou à l'étendue de la mise à jour. Ces données supplémentaires sont gérées dans la classe MD_ScopeDescription. La couche de la MO concernée par la mise à jour est par exemple précisée ici.</help>
+    <!--<help>Informations supplémentaires relatives au domaine ou à l'étendue de la mise à jour. Ces données supplémentaires sont gérées dans la classe MD_ScopeDescription. La couche de la MO concernée par la mise à jour est par exemple précisée ici.</help>-->
     <condition/>
 
   </element>
@@ -3355,13 +3355,13 @@
   <element name="gmd:useConstraints" id="71.0">
     <label>Contraintes d'utilisation</label>
     <description>Cet élément permet d'indiquer toute restriction ou limitation supplémentaire ou particulière existante quant à l'utilisation de la ressource, outre celles couvertes par les restrictions ministérielles existantes.</description>
-    <help>Restrictions d'utilisation à fondement juridique destinées à garantir la sphère privée, la propriété intellectuelle ou d'autres domaines similaires tels que les conditions d'octroi de licence. Elles peuvent être sélectionnées parmi les éléments suivants : droit d'auteur, brevet, brevet en voie de délivrance, marque, licence, propriété intellectuelle, diffusion limitée, autres restrictions.</help>
+    <!--<help>Restrictions d'utilisation à fondement juridique destinées à garantir la sphère privée, la propriété intellectuelle ou d'autres domaines similaires tels que les conditions d'octroi de licence. Elles peuvent être sélectionnées parmi les éléments suivants : droit d'auteur, brevet, brevet en voie de délivrance, marque, licence, propriété intellectuelle, diffusion limitée, autres restrictions.</help>-->
     <condition>mandatory</condition>
   </element>
   <element name="gmd:useLimitation" id="68.0">
     <label>Limitation d'utilisation</label>
     <description>Limitation d'utilisation de la ressource où de métadonnées. Exemple: "ne pas utiliser pour la navigation"</description>
-    <help>Restriction d'utilisation de la ressource ou des métadonnées. Exemple: "ne pas utiliser pour la navigation"</help>
+    <!--<help>Restriction d'utilisation de la ressource ou des métadonnées. Exemple: "ne pas utiliser pour la navigation"</help>
 
     <help><![CDATA[<b>Conditions applicables à l’accès et à l’utilisation</b>]]></help>
 
@@ -3395,7 +3395,7 @@
     <li>S’il s’agit d’une personne morale, la raison sociale du fournisseur ;</li>
     <li>L’adresse où il est établi, son adresse de courrier électronique, ainsi que des coordonnées téléphoniques permettant d’entrer effectivement en contact avec lui”.</li>
     <ul>
-    ]]></help>
+    ]]></help>-->
     <condition>mandatory</condition>
 
     <!--<helper>
@@ -3413,7 +3413,7 @@
   <element name="gmd:userDefinedMaintenanceFrequency" id="145.0">
     <label>Autre fréquence de mise à jour</label>
     <description>Rythmes de mise à jour autres que ceux définis</description>
-    <help>Rythme de mise à jour défini par l'utilisateur, si l'option "Définie par l'utilisateur" a été sélectionnée dans la liste de la "Fréquence d'entretien et de mise à jour".</help>
+    <!--<help>Rythme de mise à jour défini par l'utilisateur, si l'option "Définie par l'utilisateur" a été sélectionnée dans la liste de la "Fréquence d'entretien et de mise à jour".</help>-->
     <condition/>
 
   </element>
@@ -3427,7 +3427,7 @@
   <element name="gmd:userNote" id="75.0">
     <label>Explications sur les restrictions</label>
     <description>Explications sur l'application des contraintes légales, ou d'autres restrictions et conditions préalables légales, pour obtenir et utiliser les ressources où de métadonnées</description>
-    <help>Explication plus détaillée de la restriction.</help>
+    <!--<help>Explication plus détaillée de la restriction.</help>-->
     <condition/>
 
   </element>
@@ -3470,27 +3470,27 @@
   <element name="gmd:version" id="208.2" context="gmd:RS_Identifier">
     <label>Version</label>
     <description>Identification de la version pour la domaine de valeurs</description>
-    <help>Numéro de version de l'espace nominal / de l'identifiant (alphanumérique).</help>
+    <!--<help>Numéro de version de l'espace nominal / de l'identifiant (alphanumérique).</help>-->
     <condition/>
 
   </element>
   <element name="gmd:version" context="gmd:MD_Format" id="286.0">
     <label>Version</label>
     <description>Indiquer la version du format de transfert de données. Pour une liste de versions possibles, consulter le menu « Suggestions ». Si la version est inconnue, indiquer « inconnue ».</description>
-    <help>Version du format de données, par exemple 6.0.</help>
+    <!--<help>Version du format de données, par exemple 6.0.</help>-->
     <condition>Obligatoire</condition>
   </element>
 
   <element name="gmd:verticalElement" id="338.0">
     <label>Élément vertical</label>
     <description>Informations sur l'étendue verticale</description>
-    <help>Informations concernant l'extension verticale. Elles sont gérées dans la classe EX_VerticalExtent.</help>
+    <!--<help>Informations concernant l'extension verticale. Elles sont gérées dans la classe EX_VerticalExtent.</help>-->
     <condition>Condition</condition>
   </element>
   <element name="gmd:voice" id="408.0">
     <label>Numéro de téléphone</label>
     <description>Numéro de téléphone de la personne ou organisation responsable</description>
-    <help>Numéro de téléphone.</help>
+    <!--<help>Numéro de téléphone.</help>-->
     <condition/>
 
   </element>
@@ -3956,7 +3956,7 @@
     <label>Autre langue</label>
     <description>Sélectionner une autre langue d'usage pour la création de métadonnées.</description>
   </element>
-      <element name="gmd:characterEncoding">
+  <element name="gmd:characterEncoding">
     <label>CharacterEncoding</label>
     <description>CharacterEncoding</description>
     <help/>


### PR DESCRIPTION
There are two issues.

1) One is the help tool tip box has some duplicated text due to same text existed from description and help.

![image](https://user-images.githubusercontent.com/74916635/100884089-10116b00-347f-11eb-8413-c13f44415727.png)

The result:
![image](https://user-images.githubusercontent.com/74916635/100883907-df313600-347e-11eb-948b-82d77310bfdb.png)


2) Another issue is 99% of eng/labels contains only description without help. However fre/labels.xml contains a lot of help information which is inconsistent to the eng/label.xml (see one of the element in the following) and the help tool tip is a lot complicated.

![image](https://user-images.githubusercontent.com/74916635/100884527-94fc8480-347f-11eb-95bc-a87f2fee1ba6.png)


This version removes/comment out all unwanted help information from fre/labels/xml.