### PR TITLE
Reorder element because validation api would fail

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -207,6 +207,15 @@
 				</xsl:when>
 			</xsl:choose>
 
+      <xsl:apply-templates select="
+        gmd:hierarchyLevel|
+        gmd:hierarchyLevelName|
+        gmd:contact|
+        gmd:dateStamp|
+        gmd:metadataStandardName|
+        gmd:metadataStandardVersion|
+        gmd:dataSetURI"/>
+
       <!-- Copy existing locales and create an extra one for the default metadata language. -->
         <xsl:apply-templates select="gmd:locale[*/gmd:languageCode/*/@codeListValue != $mainLanguage]"/>
         <gmd:locale>
@@ -243,7 +252,18 @@
             </gmd:characterEncoding>
           </gmd:PT_Locale>
         </gmd:locale>
- 			<xsl:apply-templates select="node()[name()!='gmd:language' and name()!='gmd:characterSet' and name()!='gmd:locale']"/>
+ 		<xsl:apply-templates select="node()[name()!='gmd:fileIdentifier' and
+                                            name()!='gmd:language' and
+                                            name()!='gmd:parentIdentifier' and
+                                            name()!='gmd:characterSet' and
+                                            name()!='gmd:hierarchyLevel' and
+                                            name()!='gmd:hierarchyLevelName' and
+                                            name()!='gmd:contact' and
+                                            name()!='gmd:dateStamp' and
+                                            name()!='gmd:metadataStandardName' and
+                                            name()!='gmd:metadataStandardVersion' and
+                                            name()!='gmd:dataSetURI' and
+                                            name()!='gmd:locale']"/>
 		</xsl:copy>
 	</xsl:template>
 


### PR DESCRIPTION
Reorder element because validation api would fail if the hierarchyLevel came after the gmd:locale

Steps to reproduce the error
 - edit a record 
 - validate (ensure it is valid) and save
 - Got to /geonetwork/doc/api/index.html#/records/validateRecords
 - validate the record that was just validated. 

It will fail validation.
Expected the validation to return valid results like in the editor.  

The problem is that the validation api validates records based on the value in the database which contains the changes from update-fixed-info.xsl and that version contains hierarchyLevel after the gmd:locale

This PR re-orders the elements so that it matches the order generated by iso19139

Note: This PR is related to https://github.com/geonetwork/core-geonetwork/pull/5231 and those changes have to be applied for the /geonetwork/doc/api/index.html#/records/validateRecords api to work correctly.


