### PR TITLE
Fix bug update-fixed-info.xsl where it was creating empty <gmd:PT_FreeText> 

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -471,18 +471,11 @@
             <xsl:otherwise>
 
               <!-- Populate PT_FreeText for default language if not existing and it is not null. -->
-              <xsl:choose>
-                <xsl:when test="$valueInPtFreeTextForMainLanguage !='' or not($isMainLanguageEmpty)">
-                  <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
-                </xsl:otherwise>
-              </xsl:choose>
+              <xsl:apply-templates select="gco:CharacterString|gmx:Anchor"/>
 
 
                 <!-- only put this in if there's stuff to put in, otherwise we get a <gmd:PT_FreeText/> in output -->
-                <xsl:if test="(normalize-space(gco:CharacterString|gmx:Anchor) != '') or gmd:PT_FreeText">
+              <xsl:if test="gmd:PT_FreeText">
                   <gmd:PT_FreeText>
                     <!-- do NOT put in the main language (again) -->
 <!--                    <xsl:if test="normalize-space(gco:CharacterString|gmx:Anchor) != ''"> &lt;!&ndash; default lang&ndash;&gt;-->


### PR DESCRIPTION
Fix bug where it would create an empty <gmd:PT_FreeText> if there was only a <gco:CharacterString> on a multilingual element.

Before fix

```
         <gmd:fileDescription>
            <gco:CharacterString>large_thumbnail</gco:CharacterString>
          </gmd:fileDescription>
```

would get converted to 

```
              <gmd:fileDescription xsi:type="gmd:PT_FreeText_PropertyType">
                     <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">large_thumbnail</gco:CharacterString>
                     <gmd:PT_FreeText xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2"/>
               </gmd:fileDescription>
```
And that was causing some validation errors.

With the fix it gets converted to 

```
              <gmd:fileDescription xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                                    xsi:type="gmd:PT_FreeText_PropertyType">
                  <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">large_thumbnail</gco:CharacterString>
               </gmd:fileDescription>
```
