### PR TITLE
Add OGC:WMS / OGC:WFS protocols for online resources

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1757,6 +1757,8 @@
         <option value="HTTPS">HTTPS</option>
         <option value="FTP">FTP</option>
         <option value="ESRI REST: Map Service">ESRI REST: Map Service</option>
+        <option value="OGC:WMS">OGC:WMS</option>
+        <option value="OGC:WFS">OGC:WFS</option>
       </helper>
     </element>
     <element name="gmd:purpose" id="26.0">

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2812,6 +2812,8 @@
       <option value="HTTPS">HTTPS</option>
       <option value="FTP">FTP</option>
       <option value="ESRI REST: Map Service">ESRI REST: Map Service</option>
+      <option value="OGC:WMS">OGC:WMS</option>
+      <option value="OGC:WFS">OGC:WFS</option>
     </helper>
     <condition/>
 


### PR DESCRIPTION
Add `OGC:WMS` and `OGC:WFS` protocols to allow adding these types of services  in the metadata editor and link them to the map viewer:

![editor-wms](https://user-images.githubusercontent.com/1695003/102767450-de096f80-437f-11eb-9263-96954fb5bccb.png)

![metadata-detail-page-wms](https://user-images.githubusercontent.com/1695003/102767455-dfd33300-437f-11eb-966a-8ec7b0864d23.png)
