### PR TITLE
Remove lower case conversion.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -623,7 +623,7 @@
     <xsl:choose>
       <xsl:when test="gmd:hierarchyLevel">
         <xsl:for-each select="gmd:hierarchyLevel/gmd:MD_ScopeCode">
-          <Field name="type" string="{string(tokenize(lower-case(.), ';')[1])}" store="true" index="true"/>
+          <Field name="type" string="{string(tokenize(., ';')[1])}" store="true" index="true"/>
         </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -563,7 +563,7 @@
     <xsl:choose>
       <xsl:when test="gmd:hierarchyLevel">
         <xsl:for-each select="gmd:hierarchyLevel/gmd:MD_ScopeCode">
-          <Field name="type" string="{string(tokenize(lower-case(.), ';')[1])}" store="true" index="true"/>
+          <Field name="type" string="{string(tokenize(., ';')[1])}" store="true" index="true"/>
         </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>


### PR DESCRIPTION
The indexing lowercase conversion has brought issues to search API. In the current codelist of gmd:hierarchyLevel/gmd:MD_ScopeCode element it consists of upper cases values, 

![image](https://user-images.githubusercontent.com/74916635/104065121-34bed800-51cd-11eb-9ad5-6378606e8e31.png)


However when we index these fields, we force them to be lower cases only. Therefore, the search engine cannot find related label from codelist.xml and its translator. Since no label found, the value will be the key itself.

![image](https://user-images.githubusercontent.com/74916635/104065306-849d9f00-51cd-11eb-8735-b92123b939d8.png)
