### PR TITLE
Fixed security contstraint for usernote validations

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -50,18 +50,33 @@
   <xsl:function name="geonet:securityLevelList" as="xs:string">
     <xsl:param name="thesaurusDir" as="xs:string"/>
 
+    <xsl:variable name="locLang2char" select="if ($lang = 'fre') then 'fr' else 'en'"/>
     <xsl:variable name="security-level-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
 
     <xsl:variable name="v">
-      <xsl:for-each select="$security-level-list//rdf:Description[ns2:prefLabel[@xml:lang='en']]">
-        <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
-        <xsl:value-of select="replace(@rdf:about, 'http://geonetwork-opensource.org/EC/GC_Security_Classification#', '')" />
+      <xsl:for-each select="$security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$locLang2char]">
+        <xsl:sort select="lower-case(.)" order="ascending"/>
+        <xsl:value-of select="."/>
         <xsl:if test="position() != last()">, </xsl:if>
       </xsl:for-each>
     </xsl:variable>
 
     <xsl:value-of select="$v" />
   </xsl:function>
+
+
+  <xsl:function name="geonet:appendLocaleMessage">
+    <xsl:param name="localeStringNode"/>
+    <xsl:param name="appendText" as="xs:string"/>
+
+    <xsl:for-each select="$localeStringNode">
+       <xsl:copy>
+          <xsl:copy-of select="@*"/>
+          <xsl:value-of select="concat($localeStringNode, $appendText)"/>
+       </xsl:copy>
+    </xsl:for-each>
+  </xsl:function>
+
 
   <!-- Checks if the values in arg (can be a comma separate list of items) are all in the searchStrings list -->
   <xsl:function name="geonet:values-in" as="xs:boolean">
@@ -335,7 +350,7 @@
       >$loc/strings/OtherConstraintsNote</sch:assert>
     </sch:rule>
 
-    <sch:rule context="//gmd:MD_SecurityConstraints/gmd:userNote">
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:userNote">
 
       <sch:let name="missingTitle" value="not(string(gco:CharacterString))
               or (@gco:nilReason)" />
@@ -345,9 +360,9 @@
       <sch:let name="security-level-list" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
 
       <sch:let name="securityLevelList" value="geonet:securityLevelList($thesaurusDir)" />
-      <sch:let name="locMsg" value="concat($loc/strings/SecurityLevel, $securityLevelList)" />
+      <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityLevel, $securityLevelList)" />
 
-      <sch:assert test="$missingTitle or string($security-level-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', $securityLevel)])">$locMsg</sch:assert>
+      <sch:assert test="$missingTitle or $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel">$locMsg</sch:assert>
 
     </sch:rule>
 
@@ -400,7 +415,7 @@
 
 
       <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
-      <sch:let name="locMsg" value="concat($loc/strings/ResourceDescriptionFormat, $resourceFormatsList)" />
+      <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList)" />
 
       <sch:assert test="string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#', $format)])">$locMsg</sch:assert>
 


### PR DESCRIPTION
 Fixed security contstraint for usernote validations
  - it was checking the code values instead of the label/text
  - The listing of the items in the error were concatenated but the String element <SecurityLevel> was being lost.  And this was causing the error not to be properly displayed in the editor.
      - Fixed by using a function to append the strings without loosing the element.
      - Also fixed similar case for resource format.
  - Also the list of items in the error message were not translated correctly - it was always the code and English.