### PR TITLE
Schematron - fix missing:broken error message

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -39,6 +39,7 @@
   <InvalidUseConstraints>Use constraints code is not valid</InvalidUseConstraints>
   <DistributionFormatName>Value is required for distribution format - File name</DistributionFormatName>
   <DistributionFormatVersion>Value is required for distribution format - File version</DistributionFormatVersion>
+  <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
 
   <MapResourcesREST>REST Map Resources should be available in english and french</MapResourcesREST>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -67,8 +67,6 @@
   <CitedResponsiblePartyPhone>Cited Responsible Party - Phone should be empty or filled in English and French</CitedResponsiblePartyPhone>
   <DistributorPhone>Distributor - Phone should be empty or filled in English and French</DistributorPhone>
 
-  <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
-
   <ECCountry>Country should have a value as defined in the ISO 3166 code list. See https://www.iso.org/obp/ui/#search/code/</ECCountry>
   <ECThesaurusTitle>Thesaurus title is required</ECThesaurusTitle>
   <ECThesaurusPubDate>Thesaurus publication date is required</ECThesaurusPubDate>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -39,6 +39,7 @@
   <InvalidUseConstraints>Le code de contraintes d'utilisation n'est pas valide</InvalidUseConstraints>
   <DistributionFormatName>Une valeur est nécessaire pour: Nom du Format de distribution</DistributionFormatName>
   <DistributionFormatVersion>Une valeur est nécessaire pour: Version du Format de distribution</DistributionFormatVersion>
+  <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
 
   <MapResourcesREST>Les sources de la carte REST devraient être disponibles en anglais et en français</MapResourcesREST>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -67,8 +67,6 @@
   <CitedResponsiblePartyPhone>Responsable de la ressource - Numéro de téléphone devrait être vide ou rempli en anglais et en français</CitedResponsiblePartyPhone>
   <DistributorPhone>Responsable de la distribution - Numéro de téléphone devrait être vide ou rempli en anglais et en français</DistributorPhone>
 
-  <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
-
   <ECCountry>Pays devrait avoir une valeur telle que définie dans la liste de codes ISO 3166. Voir https://www.iso.org/obp/ui/fr/#search/code/</ECCountry>
   <ECThesaurusTitle>Le titre du thésaurus est requis</ECThesaurusTitle>
   <ECThesaurusPubDate>La date de publication du Thésaurus est requise</ECThesaurusPubDate>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -511,7 +511,7 @@
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
-      >$loc/strings/FreeTextKeyword</sch:assert>
+      >$loc/strings/Keyword</sch:assert>
 
     </sch:rule>
 


### PR DESCRIPTION
Fixed errors that were not working due to invalid message keys.