### PR TITLE
Fix multilingual thesaurus title grouping in keywords indexing

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -329,10 +329,10 @@
       <xsl:variable name="listOfKeywords">{
         <xsl:variable name="keywordWithNoThesaurus"
                       select="//gmd:MD_Keywords[
-                                not(gmd:thesaurusName) or gmd:thesaurusName/*/gmd:title/*/text() = '']/
+                                not(gmd:thesaurusName) or gmd:thesaurusName/*/gmd:title/(gco:CharacterString|gmx:Anchor)/text() = '']/
                                   gmd:keyword[*/text() != '']"/>
-        <xsl:for-each-group select="//gmd:MD_Keywords[gmd:thesaurusName/*/gmd:title/*/text() != '']"
-                            group-by="gmd:thesaurusName/*/gmd:title/*/text()">
+        <xsl:for-each-group select="//gmd:MD_Keywords[gmd:thesaurusName/*/gmd:title/(gco:CharacterString|gmx:Anchor)/text() != '']"
+                            group-by="gmd:thesaurusName/*/gmd:title/(gco:CharacterString|gmx:Anchor)/text()">
           '<xsl:value-of select="replace(current-grouping-key(), '''', '\\''')"/>' :[
           <xsl:for-each select="current-group()/gmd:keyword/(gco:CharacterString|gmx:Anchor)">
             {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>,

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -266,7 +266,7 @@
         <xsl:variable name="listOfKeywords">{
           <xsl:variable name="keywordWithNoThesaurus"
                         select="//gmd:MD_Keywords[
-                                  not(gmd:thesaurusName) or gmd:thesaurusName/*/gmd:title/*/text() = '']/
+                                  not(gmd:thesaurusName) or gmd:thesaurusName/*/gmd:title/gmd:LocalisedCharacterString[@locale = $langId]/text() = '']/
                                     gmd:keyword//gmd:LocalisedCharacterString[@locale=$langId][*/text() != '']"/>
           <xsl:if test="count($keywordWithNoThesaurus) > 0">
             'keywords': [
@@ -279,9 +279,9 @@
             <xsl:if test="//gmd:MD_Keywords[gmd:thesaurusName]">,</xsl:if>
           </xsl:if>
           <xsl:for-each-group select="//gmd:MD_Keywords[
-                                        gmd:thesaurusName/*/gmd:title/*/text() != '' and
+                                        gmd:thesaurusName/*/gmd:title//gmd:LocalisedCharacterString[@locale = $langId]/text() != '' and
                                         count(gmd:keyword//gmd:LocalisedCharacterString[@locale = $langId and text() != '']) > 0]"
-                              group-by="gmd:thesaurusName/*/gmd:title/*/text()">
+                              group-by="gmd:thesaurusName/*/gmd:title//gmd:LocalisedCharacterString[@locale = $langId]/text()">
 
             '<xsl:value-of select="replace(current-grouping-key(), '''', '\\''')"/>' :[
             <xsl:for-each select="current-group()/gmd:keyword//gmd:LocalisedCharacterString[@locale = $langId and text() != '']">


### PR DESCRIPTION
In the metadata detail page keywords from Core Subject Thesaurus are displayed twice:

![keywords-1](https://user-images.githubusercontent.com/1695003/107001972-dadd0e00-678a-11eb-8787-d0488d8e339a.png)

This is caused by this code:

https://github.com/metadata101/iso19139.ca.HNAP/blob/c8901f36f968cdc7733258d08af45117d084d1ac/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl#L334-L335

The code processes `gco:CharacterString` getting the correct title and `gmd:PT_FreeText` getting empty string (similar issue in the file `language-default.xsl`

With the change:

![keywords-2](https://user-images.githubusercontent.com/1695003/107002083-019b4480-678b-11eb-8a32-ba8f332b4daf.png)

