### PR TITLE
Add security note to metadata view.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -406,6 +406,8 @@
         <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
           <Field name="secConstr" string="true" store="true" index="true"/>
           <Field name="secUserNote" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote/gco:CharacterString}" store="true" index="true"/>
+          <!-- put secUserNote in MD_SecurityConstraintsUseLimitation so that it can be displayed on the view page -->
+          <Field name="MD_SecurityConstraintsUseLimitation" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote/gco:CharacterString}" store="true" index="true"/>
         </xsl:when>
         <xsl:otherwise>
           <Field name="secConstr" string="false" store="true" index="true"/>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -361,6 +361,8 @@
         <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
           <Field name="secConstr" string="true" store="true" index="true"/>
           <Field name="secUserNote" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId]}" store="true" index="true"/>
+          <!-- put secUserNote in MD_SecurityConstraintsUseLimitation so that it can be displayed on the view page -->
+          <Field name="MD_SecurityConstraintsUseLimitation" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId]}" store="true" index="true"/>
         </xsl:when>
         <xsl:otherwise>
           <Field name="secConstr" string="false" store="true" index="true"/>


### PR DESCRIPTION
Add security note to securityconstraint field used during the metadata view.

![image](https://user-images.githubusercontent.com/1868233/109228463-3c940500-7798-11eb-8f87-60a286b8c14d.png)
