### PR TITLE
Add validation for user notes so that it checks against the classification code

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -404,10 +404,22 @@
 
       <xsl:choose>
         <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
+          <xsl:variable name="securityConstraints" select="gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]"/>
+          <xsl:variable name="securityClassification" select="util:getCodelistTranslation($securityConstraints/gmd:classification/gmd:MD_ClassificationCode/name(), string($securityConstraints/gmd:classification/gmd:MD_ClassificationCode/@codeListValue), string($isoLangId))"/>
           <Field name="secConstr" string="true" store="true" index="true"/>
-          <Field name="secUserNote" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote/gco:CharacterString}" store="true" index="true"/>
+          <Field name="secUserNote" string="{$securityConstraints/gmd:userNote/gco:CharacterString}" store="true" index="true"/>
           <!-- put secUserNote in MD_SecurityConstraintsUseLimitation so that it can be displayed on the view page -->
-          <Field name="MD_SecurityConstraintsUseLimitation" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote/gco:CharacterString}" store="true" index="true"/>
+
+          <xsl:variable name="securityConstraintsUseLimitation">
+            <xsl:value-of select="$securityClassification"/>
+            <xsl:choose>
+              <xsl:when test="$securityConstraints/gmd:userNote/gco:CharacterString !='' and $securityConstraints/gmd:userNote/gco:CharacterString != $securityClassification">
+                <xsl:value-of select="concat(':', $securityConstraints/gmd:userNote/gco:CharacterString)"/>
+              </xsl:when>
+            </xsl:choose>
+          </xsl:variable>
+
+          <Field name="MD_SecurityConstraintsUseLimitation" string="{$securityConstraintsUseLimitation}" store="true" index="true"/>
         </xsl:when>
         <xsl:otherwise>
           <Field name="secConstr" string="false" store="true" index="true"/>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -414,7 +414,7 @@
             <xsl:value-of select="$securityClassification"/>
             <xsl:choose>
               <xsl:when test="$securityConstraints/gmd:userNote/gco:CharacterString !='' and $securityConstraints/gmd:userNote/gco:CharacterString != $securityClassification">
-                <xsl:value-of select="concat(':', $securityConstraints/gmd:userNote/gco:CharacterString)"/>
+                <xsl:value-of select="concat('; ', $securityConstraints/gmd:userNote/gco:CharacterString)"/>
               </xsl:when>
             </xsl:choose>
           </xsl:variable>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -359,10 +359,22 @@
 
       <xsl:choose>
         <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints">
+          <xsl:variable name="securityConstraints" select="gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]"/>
+          <xsl:variable name="securityClassification" select="util:getCodelistTranslation($securityConstraints/gmd:classification/gmd:MD_ClassificationCode/name(), string($securityConstraints/gmd:classification/gmd:MD_ClassificationCode/@codeListValue), string($langCode_ISO639_2B))"/>
           <Field name="secConstr" string="true" store="true" index="true"/>
-          <Field name="secUserNote" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId]}" store="true" index="true"/>
+          <Field name="secUserNote" string="{$securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId]}" store="true" index="true"/>
           <!-- put secUserNote in MD_SecurityConstraintsUseLimitation so that it can be displayed on the view page -->
-          <Field name="MD_SecurityConstraintsUseLimitation" string="{gmd:resourceConstraints/gmd:MD_SecurityConstraints[1]/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId]}" store="true" index="true"/>
+
+          <xsl:variable name="securityConstraintsUseLimitation">
+            <xsl:value-of select="$securityClassification"/>
+            <xsl:choose>
+              <xsl:when test="$securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId] !='' and $securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId] != $securityClassification">
+                <xsl:value-of select="concat(':', $securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId])"/>
+              </xsl:when>
+            </xsl:choose>
+          </xsl:variable>
+
+          <Field name="MD_SecurityConstraintsUseLimitation" string="{$securityConstraintsUseLimitation}" store="true" index="true"/>
         </xsl:when>
         <xsl:otherwise>
           <Field name="secConstr" string="false" store="true" index="true"/>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -369,7 +369,7 @@
             <xsl:value-of select="$securityClassification"/>
             <xsl:choose>
               <xsl:when test="$securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId] !='' and $securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId] != $securityClassification">
-                <xsl:value-of select="concat(':', $securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId])"/>
+                <xsl:value-of select="concat('; ', $securityConstraints/gmd:userNote//gmd:LocalisedCharacterString[@locale=$langId])"/>
               </xsl:when>
             </xsl:choose>
           </xsl:variable>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -40,6 +40,8 @@
   <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
   <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
+  <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
+  <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>
   <UseLimitation>Value is required for Use Limitation in both languages</UseLimitation>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
@@ -32,6 +32,8 @@
   <Keyword>Keyword is required</Keyword>
 
   <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
+  <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
+  <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>
   <UseLimitation>Value is required for Use Limitation</UseLimitation>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -40,6 +40,8 @@
   <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
+  <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont :</SecurityClassificationUserNote>
+  <SecurityClassificationUserNoteEmpty>Explications sur les restrictions devrait être vide pour la restriction de manipulation</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>Si vous indiquez «Autres restrictions» dans les champs «Contraintes d'accès» ou «Utiliser les contraintes», les autres contraintes d'accès ou d'utilisation de la ressource doivent être expliquées ici.</OtherConstraintsNote>
   <UseLimitation>Limitation d'utilisation est obligatoire dans les deux langues</UseLimitation>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
@@ -32,6 +32,8 @@
   <Keyword>Au moins un mot clé est requis</Keyword>
 
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
+  <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont :</SecurityClassificationUserNote>
+  <SecurityClassificationUserNoteEmpty>Explications sur les restrictions devrait être vide pour la restriction de manipulation</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>L'indication 'Autres restrictions' dans les champs « Contraintes d'accès » ou « Contraintes d'utilisation » permet de décrire ici d’autres contraintes quant à l'accès ou l'utilisation de la ressource.</OtherConstraintsNote>
   <UseLimitation>Limitation d'utilisation est obligatoire</UseLimitation>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -68,6 +68,54 @@
     <xsl:value-of select="$v" />
   </xsl:function>
 
+  <xsl:function xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                name="geonet:checkUserNoteSecurityClassificationCode"
+                as="xs:string">
+    <xsl:param name="securityLevel" as="xs:string"/>
+    <xsl:param name="securityClassificationCodeNode"/>
+
+    <xsl:variable name="locLang2char" select="if ($lang = 'fre') then 'fr' else 'en'"/>
+    <xsl:variable name="security-level-list"
+                   select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+
+    <xsl:variable name="lookup">
+      <table>
+        <row securityClassificationCode="RI_484" securityLevel="unclassified"/> <!-- unclassified/unclassified -->
+        <row securityClassificationCode="RI_485" securityLevel="protectA" />    <!-- restricted/protectA -->
+        <row securityClassificationCode="RI_485" securityLevel="protectB" />    <!-- restricted/protectB -->
+        <row securityClassificationCode="RI_485" securityLevel="protectC"/>     <!-- restricted/protectC -->
+        <row securityClassificationCode="RI_486" securityLevel="confidential"/> <!-- confidential/confidential -->
+        <row securityClassificationCode="RI_489" securityLevel="confidential"/> <!-- sensitive/confidential -->
+        <row securityClassificationCode="RI_487" securityLevel="secret"/>       <!-- secret/secret -->
+        <row securityClassificationCode="RI_488" securityLevel="topSecret"/>    <!-- topSecret/topSecret -->
+      </table>
+    </xsl:variable>
+
+    <xsl:variable name="v">
+      <xsl:choose>
+        <!-- Found so return empty list -->
+        <xsl:when test="$lookup/table/row[@securityLevel = $securityLevel and @securityClassificationCode = $securityClassificationCodeNode/@codeListValue]">
+          <xsl:value-of select="''"/>
+        </xsl:when>
+        <xsl:when test="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]">
+           <xsl:for-each select="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]/@securityLevel">
+              <!--xsl:value-of select="tr:codelist-value-label(tr:create($schema), $securityClassificationCodeNode/local-name(), .)"/-->
+              <xsl:variable name="securityLevelCode" select="concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', .)"/>
+              <xsl:value-of select="$security-level-list//rdf:Description[@rdf:about = $securityLevelCode]/ns2:prefLabel[@xml:lang=$locLang2char]"/>
+              <xsl:if test="position() != last()">, </xsl:if>
+           </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Not Found in table so return NULL to mean that we expect this to be null   -->
+          <xsl:value-of select="'NULL'"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:value-of select="$v"/>
+
+  </xsl:function>
+
   <xsl:function name="geonet:appendLocaleMessage">
     <xsl:param name="localeStringNode"/>
     <xsl:param name="appendText" as="xs:string"/>
@@ -660,9 +708,21 @@
 
       <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityLevel, $securityLevelList)" />
 
-      <sch:assert test="($missingTitle and $missingTitleOtherLang) or
+      <sch:let name="validSecurityLevel" value="($missingTitle and $missingTitleOtherLang) or
                         ($security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel and
-                         $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char]=$securityLevelTranslated)">$locMsg</sch:assert>
+                         $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char]=$securityLevelTranslated)"/>
+
+      <sch:assert test="$validSecurityLevel">$locMsg</sch:assert>
+
+      <sch:let name="securityLevelCode" value="replace($security-level-list//rdf:Description[lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])=lower-case($securityLevel)]/@rdf:about, 'http://geonetwork-opensource.org/EC/GC_Security_Classification#', '')"/>
+
+      <sch:let name="checkUserNoteSecurityClassificationCode" value="geonet:checkUserNoteSecurityClassificationCode($securityLevelCode, ../gmd:classification/gmd:MD_ClassificationCode)" />
+
+      <sch:let name="locSecurityClassificationUserNoteMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityClassificationUserNote, $checkUserNoteSecurityClassificationCode)" />
+
+      <sch:assert test="not($validSecurityLevel) or $checkUserNoteSecurityClassificationCode='NULL' or $checkUserNoteSecurityClassificationCode = ''">$locSecurityClassificationUserNoteMsg</sch:assert>
+
+      <sch:assert test="not($validSecurityLevel) or $checkUserNoteSecurityClassificationCode!='NULL' or $checkUserNoteSecurityClassificationCode = ''">$loc/strings/SecurityClassificationUserNoteEmpty</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -98,12 +98,22 @@
           <xsl:value-of select="''"/>
         </xsl:when>
         <xsl:when test="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]">
-           <xsl:for-each select="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]/@securityLevel">
-              <!--xsl:value-of select="tr:codelist-value-label(tr:create($schema), $securityClassificationCodeNode/local-name(), .)"/-->
-              <xsl:variable name="securityLevelCode" select="concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', .)"/>
+          <xsl:variable name="securityLevelList">
+            <xsl:for-each select="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]/@securityLevel">
+              <xsl:variable name="securityLevelCode"
+                            select="concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', .)"/>
               <xsl:value-of select="$security-level-list//rdf:Description[@rdf:about = $securityLevelCode]/ns2:prefLabel[@xml:lang=$locLang2char]"/>
               <xsl:if test="position() != last()">, </xsl:if>
-           </xsl:for-each>
+            </xsl:for-each>
+          </xsl:variable>
+          <xsl:choose>
+            <xsl:when test="replace($securityLevelList, ', ', '') =''">
+              <xsl:value-of select="'NULL'"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$securityLevelList"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:when>
         <xsl:otherwise>
           <!-- Not Found in table so return NULL to mean that we expect this to be null   -->

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -64,6 +64,53 @@
     <xsl:value-of select="$v" />
   </xsl:function>
 
+  <xsl:function xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                name="geonet:checkUserNoteSecurityClassificationCode"
+                as="xs:string">
+    <xsl:param name="securityLevel" as="xs:string"/>
+    <xsl:param name="securityClassificationCodeNode"/>
+
+    <xsl:variable name="locLang2char" select="if ($lang = 'fre') then 'fr' else 'en'"/>
+    <xsl:variable name="security-level-list"
+                   select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+
+    <xsl:variable name="lookup">
+      <table>
+        <row securityClassificationCode="RI_484" securityLevel="unclassified"/> <!-- unclassified/unclassified -->
+        <row securityClassificationCode="RI_485" securityLevel="protectA" />    <!-- restricted/protectA -->
+        <row securityClassificationCode="RI_485" securityLevel="protectB" />    <!-- restricted/protectB -->
+        <row securityClassificationCode="RI_485" securityLevel="protectC"/>     <!-- restricted/protectC -->
+        <row securityClassificationCode="RI_486" securityLevel="confidential"/> <!-- confidential/confidential -->
+        <row securityClassificationCode="RI_489" securityLevel="confidential"/> <!-- sensitive/confidential -->
+        <row securityClassificationCode="RI_487" securityLevel="secret"/>       <!-- secret/secret -->
+        <row securityClassificationCode="RI_488" securityLevel="topSecret"/>    <!-- topSecret/topSecret -->
+      </table>
+    </xsl:variable>
+
+    <xsl:variable name="v">
+      <xsl:choose>
+        <!-- Found so return empty list -->
+        <xsl:when test="$lookup/table/row[@securityLevel = $securityLevel and @securityClassificationCode = $securityClassificationCodeNode/@codeListValue]">
+          <xsl:value-of select="''"/>
+        </xsl:when>
+        <xsl:when test="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]">
+           <xsl:for-each select="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]/@securityLevel">
+              <!--xsl:value-of select="tr:codelist-value-label(tr:create($schema), $securityClassificationCodeNode/local-name(), .)"/-->
+              <xsl:variable name="securityLevelCode" select="concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', .)"/>
+              <xsl:value-of select="$security-level-list//rdf:Description[@rdf:about = $securityLevelCode]/ns2:prefLabel[@xml:lang=$locLang2char]"/>
+              <xsl:if test="position() != last()">, </xsl:if>
+           </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Not Found in table so return NULL to mean that we expect this to be null   -->
+          <xsl:value-of select="'NULL'"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:value-of select="$v"/>
+
+  </xsl:function>
 
   <xsl:function name="geonet:appendLocaleMessage">
     <xsl:param name="localeStringNode"/>
@@ -362,7 +409,19 @@
       <sch:let name="securityLevelList" value="geonet:securityLevelList($thesaurusDir)" />
       <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityLevel, $securityLevelList)" />
 
-      <sch:assert test="$missingTitle or $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel">$locMsg</sch:assert>
+      <sch:let name="validSecurityLevel" value="$missingTitle or $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel"/>
+
+      <sch:assert test="$validSecurityLevel">$locMsg</sch:assert>
+
+      <sch:let name="securityLevelCode" value="replace($security-level-list//rdf:Description[lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])=lower-case($securityLevel)]/@rdf:about, 'http://geonetwork-opensource.org/EC/GC_Security_Classification#', '')"/>
+
+      <sch:let name="checkUserNoteSecurityClassificationCode" value="geonet:checkUserNoteSecurityClassificationCode($securityLevelCode, ../gmd:classification/gmd:MD_ClassificationCode)" />
+
+      <sch:let name="locSecurityClassificationUserNoteMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityClassificationUserNote, $checkUserNoteSecurityClassificationCode)" />
+
+      <sch:assert test="not($validSecurityLevel) or $checkUserNoteSecurityClassificationCode='NULL' or $checkUserNoteSecurityClassificationCode = ''">$locSecurityClassificationUserNoteMsg</sch:assert>
+
+      <sch:assert test="not($validSecurityLevel) or $checkUserNoteSecurityClassificationCode!='NULL' or $checkUserNoteSecurityClassificationCode = ''">$loc/strings/SecurityClassificationUserNoteEmpty</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -94,12 +94,22 @@
           <xsl:value-of select="''"/>
         </xsl:when>
         <xsl:when test="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]">
-           <xsl:for-each select="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]/@securityLevel">
-              <!--xsl:value-of select="tr:codelist-value-label(tr:create($schema), $securityClassificationCodeNode/local-name(), .)"/-->
-              <xsl:variable name="securityLevelCode" select="concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', .)"/>
+          <xsl:variable name="securityLevelList">
+            <xsl:for-each select="$lookup/table/row[@securityClassificationCode = $securityClassificationCodeNode/@codeListValue]/@securityLevel">
+              <xsl:variable name="securityLevelCode"
+                            select="concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', .)"/>
               <xsl:value-of select="$security-level-list//rdf:Description[@rdf:about = $securityLevelCode]/ns2:prefLabel[@xml:lang=$locLang2char]"/>
               <xsl:if test="position() != last()">, </xsl:if>
-           </xsl:for-each>
+            </xsl:for-each>
+          </xsl:variable>
+          <xsl:choose>
+            <xsl:when test="replace($securityLevelList, ', ', '') =''">
+              <xsl:value-of select="'NULL'"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$securityLevelList"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:when>
         <xsl:otherwise>
           <!-- Not Found in table so return NULL to mean that we expect this to be null   -->


### PR DESCRIPTION
Add validation for user notes so that it checks against the classification code

This will prevent cases where a user specifies "top secret" as the classification code and "protected a" as the user note.

Also updated the index values so that they are set as the "classificationcode:user note" - unless they are both the same.