### PR TITLE
Schematron rules xpath fixes, and fixes in xpath in config-editor.xsl…

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -468,7 +468,7 @@
                    in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification"
                    or="resourceConstraints"/>
 
-          <field name="temporalRangeSection" templateModeOnly="true"
+          <field name="temporalRangeSection"
                  xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement"
                  if="count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification) > 0">
             <template>
@@ -505,7 +505,7 @@
             </template>
           </field>
 
-          <field name="temporalRangeSection" templateModeOnly="true"
+          <field name="temporalRangeSection"
                  xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement"
                  if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
             <template>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
@@ -38,7 +38,7 @@
   <ContactOrganisationName>Contact - Organization name is required</ContactOrganisationName>
   <CitedResponsiblePartyOrganisationName>Cited Responsible Party - Organization name is required</CitedResponsiblePartyOrganisationName>
   <DistributorOrganisationName>Distributor - Organization name is required</DistributorOrganisationName>
-  
+
   <ContactElectronicMail>Contact - Electronic mail address is required</ContactElectronicMail>
   <CitedResponsiblePartyElectronicMail>Cited Responsible Party - Electronic mail address is required</CitedResponsiblePartyElectronicMail>
   <DistributorElectronicMail>Distributor - Electronic mail address is required</DistributorElectronicMail>
@@ -50,4 +50,8 @@
   <ECThesaurusOrg>Thesaurus cited responsible party organisation is required</ECThesaurusOrg>
   <ECThesaurusRole>Thesaurus cited responsible party role is required</ECThesaurusRole>
   <ECThesaurusEmail>Thesaurus cited responsible party email is required</ECThesaurusEmail>
+
+  <ResourceDescriptionContentType>Online resource description content type is not valid. Valid values are: Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
+  <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
+  <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
@@ -50,4 +50,8 @@
   <ECThesaurusOrg>Le nom de l’organisation responsable du thésaurus est requis</ECThesaurusOrg>
   <ECThesaurusRole>Le rôle du responsable du thésaurus est requis</ECThesaurusRole>
   <ECThesaurusEmail>Le courriel du responsable du thésaurus est requis</ECThesaurusEmail>
+
+  <ResourceDescriptionContentType>Le type de contenu dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
+  <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
+  <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -238,21 +238,24 @@
     </sch:rule>
 
     <!-- Begin position -->
-    <sch:rule context="//gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent">
-
-      <sch:let name="beginPosition" value="gmd:extent/gml:TimePeriod//gml:beginPosition" />
+    <sch:rule context="//gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:beginPosition">
+      <sch:let name="beginPosition" value="." />
       <sch:let name="missingBeginPosition" value="not(string($beginPosition))" />
 
       <sch:assert test="not($missingBeginPosition)">$loc/strings/BeginDate</sch:assert>
       <sch:assert test="$missingBeginPosition or (XslUtilHnap:verifyDateFormat($beginPosition) &gt; 0)">$loc/strings/BeginPositionFormat</sch:assert>
+    </sch:rule>
 
+    <!-- End position -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod">
+      <sch:let name="beginPosition" value="//gml:beginPosition" />
+      <sch:let name="missingBeginPosition" value="not(string($beginPosition))" />
 
-      <sch:let name="endPosition" value="gmd:extent/gml:TimePeriod//gml:endPosition" />
+      <sch:let name="endPosition" value="//gml:endPosition" />
       <sch:let name="missingEndPosition" value="not(string($endPosition))" />
 
       <sch:assert test="$missingBeginPosition or $missingEndPosition or (XslUtilHnap:compareDates($endPosition, $beginPosition) &gt;= 0)">$loc/strings/EndPosition</sch:assert>
     </sch:rule>
-
 
     <!-- Dataset language -->
     <sch:rule context="//gmd:identificationInfo/*/gmd:language

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -238,16 +238,16 @@
     </sch:rule>
 
     <!-- Begin position -->
-    <sch:rule context="//gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement">
+    <sch:rule context="//gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent">
 
-      <sch:let name="beginPosition" value="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:beginPosition" />
+      <sch:let name="beginPosition" value="gmd:extent/gml:TimePeriod//gml:beginPosition" />
       <sch:let name="missingBeginPosition" value="not(string($beginPosition))" />
 
       <sch:assert test="not($missingBeginPosition)">$loc/strings/BeginDate</sch:assert>
       <sch:assert test="$missingBeginPosition or (XslUtilHnap:verifyDateFormat($beginPosition) &gt; 0)">$loc/strings/BeginPositionFormat</sch:assert>
 
 
-      <sch:let name="endPosition" value="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:endPosition" />
+      <sch:let name="endPosition" value="gmd:extent/gml:TimePeriod//gml:endPosition" />
       <sch:let name="missingEndPosition" value="not(string($endPosition))" />
 
       <sch:assert test="$missingBeginPosition or $missingEndPosition or (XslUtilHnap:compareDates($endPosition, $beginPosition) &gt;= 0)">$loc/strings/EndPosition</sch:assert>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -517,10 +517,10 @@
 
     <!-- Keywords -->
     <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="missing" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gco:CharacterString))
             or (@gco:nilReason)" />
 
-      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingOtherLang" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -516,7 +516,7 @@
 
 
     <!-- Keywords -->
-    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
+    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
       <sch:let name="missing" value="not(string(gco:CharacterString))
             or (@gco:nilReason)" />
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -263,7 +263,7 @@
 
     <!-- Keywords -->
     <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="missing" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gco:CharacterString))
             or (@gco:nilReason)" />
 
       <sch:assert

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -262,7 +262,7 @@
     </sch:rule>
 
     <!-- Keywords -->
-    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
+    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
       <sch:let name="missing" value="not(string(gco:CharacterString))
             or (@gco:nilReason)" />
 


### PR DESCRIPTION
@ianwallen 

These three validation error are not showing. I found some workaround just want to be sure if it's ok.

![image](https://user-images.githubusercontent.com/74916635/111375271-6a23ee00-8674-11eb-8c36-51c3cbcac07f.png)


1) Some adjustment made to gmd:EX_TemporalExtent xpath in the schematron-rules-common.sch. But I am so sure of the change in config-editor.xml. I have to remove templateModeOnly="true"

![image](https://user-images.githubusercontent.com/74916635/111375749-03eb9b00-8675-11eb-8f35-94ee05ce1231.png)

Otherwise I can never got the validation error target to the right field. Here is the result and you will see "Temporal Event" is added with tooltip and the error is attached to this field.
![image](https://user-images.githubusercontent.com/74916635/111375865-2382c380-8675-11eb-9e26-6f40b9869b74.png)

2) I found the keyword error is not showing in both basic and advanced mode. So I basically change the xpath from //gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword to //gmd:identificationInfo/*/gmd:descriptiveKeywords
So I could get it working. Not sure the science behind. Here is the result:
![image](https://user-images.githubusercontent.com/74916635/111376176-807e7980-8675-11eb-8ca0-7a0bb762c38e.png)


3) I also found some strings missing. So I added them, here is the fixed result:
![image](https://user-images.githubusercontent.com/74916635/111376268-a146cf00-8675-11eb-8a31-1f2d0d9efee1.png)


Let me know if the fix are ok or not. Thanks.