### PR TITLE
Add default security constraint to FGP.19139.HNAP template.

### DIFF
--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -126,17 +126,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <!--Overwrite security constraint to default unclassified if presented in metadata xml-->
-  <!--<xsl:template match="gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:classification">
-    <xsl:element name="gmd:classification">
-      <xsl:element name="gmd:MD_ClassificationCode">
-        <xsl:attribute name="codeList">http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96</xsl:attribute>
-        <xsl:attribute name="codeListValue">RI_484</xsl:attribute>
-        <xsl:text>unclassified; nonClassifié</xsl:text>
-      </xsl:element>
-    </xsl:element>
-  </xsl:template>-->
-
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -102,6 +102,41 @@
     </xsl:copy>
   </xsl:template>
 
+  <!--Add default unclassified as security constraint if missing from metadata xml-->
+  <xsl:template match="gmd:MD_DataIdentification">
+    <xsl:copy copy-namespaces="no">
+      <xsl:choose>
+        <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:classification/gmd:MD_ClassificationCode">
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:element name="gmd:resourceConstraints">
+            <xsl:element name="gmd:MD_SecurityConstraints">
+              <xsl:element name="gmd:classification">
+                <xsl:element name="gmd:MD_ClassificationCode">
+                  <xsl:attribute name="codeList">http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96</xsl:attribute>
+                  <xsl:attribute name="codeListValue">RI_484</xsl:attribute>
+                  <xsl:text>unclassified; nonClassifié</xsl:text>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!--Overwrite security constraint to default unclassified if presented in metadata xml-->
+  <!--<xsl:template match="gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:classification">
+    <xsl:element name="gmd:classification">
+      <xsl:element name="gmd:MD_ClassificationCode">
+        <xsl:attribute name="codeList">http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96</xsl:attribute>
+        <xsl:attribute name="codeListValue">RI_484</xsl:attribute>
+        <xsl:text>unclassified; nonClassifié</xsl:text>
+      </xsl:element>
+    </xsl:element>
+  </xsl:template>-->
+
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -105,23 +105,16 @@
   <!--Add default unclassified as security constraint if missing from metadata xml-->
   <xsl:template match="gmd:MD_DataIdentification">
     <xsl:copy copy-namespaces="no">
-      <xsl:choose>
-        <xsl:when test="gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:classification/gmd:MD_ClassificationCode">
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:element name="gmd:resourceConstraints">
-            <xsl:element name="gmd:MD_SecurityConstraints">
-              <xsl:element name="gmd:classification">
-                <xsl:element name="gmd:MD_ClassificationCode">
-                  <xsl:attribute name="codeList">http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96</xsl:attribute>
-                  <xsl:attribute name="codeListValue">RI_484</xsl:attribute>
-                  <xsl:text>unclassified; nonClassifié</xsl:text>
-                </xsl:element>
-              </xsl:element>
-            </xsl:element>
-          </xsl:element>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:if test="not(gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:classification/gmd:MD_ClassificationCode)">
+        <gmd:resourceConstraints>
+          <gmd:MD_SecurityConstraints>
+            <gmd:classification>
+              <gmd:MD_ClassificationCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96"
+                                         codeListValue="RI_484">unclassified; nonClassifié</gmd:MD_ClassificationCode>
+            </gmd:classification>
+          </gmd:MD_SecurityConstraints>
+        </gmd:resourceConstraints>
+      </xsl:if>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
   </xsl:template>


### PR DESCRIPTION
This is for FGP import template only. It will not impact other import jobs.

Security constraint is added if the xml metadata is lack of. Otherwise, leave as is. The overwrite existing security constraint to default code is added as well but it's been disabled. In the future, we can enable it if it's needed.