### PR TITLE
Keyword validation error message missing.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -592,11 +592,11 @@
 
 
     <!-- Keywords -->
-    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
+      <sch:let name="missing" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gco:CharacterString))
             or (@gco:nilReason)" />
 
-      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingOtherLang" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -319,8 +319,8 @@
     </sch:rule>
 
     <!-- Keywords -->
-    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
+      <sch:let name="missing" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gco:CharacterString))
             or (@gco:nilReason)" />
 
       <sch:assert


### PR DESCRIPTION
After the fix:

![image](https://user-images.githubusercontent.com/74916635/115439718-e4e4a980-a1dc-11eb-8387-383090b41b7c.png)


This PR was spited from https://github.com/metadata101/iso19139.ca.HNAP/pull/194 as sub PR.