### PR TITLE
index change for  multilingual graphicOverview/fileDescription

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -428,18 +428,24 @@
       <xsl:for-each select="gmd:graphicOverview/gmd:MD_BrowseGraphic">
         <xsl:variable name="fileName" select="gmd:fileName/gco:CharacterString"/>
         <xsl:if test="$fileName != ''">
-          <xsl:variable name="fileDescr" select="gmd:fileDescription/gco:CharacterString"/>
-          <xsl:choose>
-            <xsl:when test="contains($fileName ,'://')">
-              <Field name="image" string="{concat('unknown|', $fileName)}" store="true" index="false"/>
-            </xsl:when>
-            <xsl:when test="string($fileDescr)='thumbnail'">
-              <!-- FIXME : relative path -->
-              <Field name="image"
-                     string="{concat($fileDescr, '|', '../../srv/eng/resources.get?uuid=', //gmd:fileIdentifier/gco:CharacterString, '&amp;fname=', $fileName, '&amp;access=public')}"
-                     store="true" index="false"/>
-            </xsl:when>
-          </xsl:choose>
+
+          <xsl:variable name="thumbnailType" select="if (position() = 1) then 'thumbnail' else 'overview'"/>
+
+          <!-- choose the best language text.  Use the  LocalisedCharacterString (if available) otherwise use the main-language (CharacterString) -->
+          <xsl:variable name="fileDescrMainLang" select="normalize-space(gmd:fileDescription/gco:CharacterString)"/>
+          <xsl:variable name="fileDescrAltLang" select="normalize-space(gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=$langId])"/>
+
+          <xsl:variable name="fileDescr">
+            <xsl:choose>
+              <xsl:when test="$fileDescrAltLang"><xsl:value-of select="$fileDescrAltLang"/></xsl:when>
+              <xsl:otherwise><xsl:value-of select="$fileDescrMainLang"/></xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+
+          <Field name="image"
+                 string="{concat($thumbnailType, '|', $fileName, '|', $fileDescr)}"
+                 store="true" index="false"/>
+
         </xsl:if>
       </xsl:for-each>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -49,6 +49,8 @@
   <CitedResponsiblePartyOrganisationName>Cited Responsible Party - Organization name is required in both languages</CitedResponsiblePartyOrganisationName>
   <DistributorOrganisationName>Distributor - Organization name is required in both languages</DistributorOrganisationName>
 
+  <FileDescription>GraphicOverlay (thumbnail) - File Description should be empty or filled in English and French</FileDescription>
+
   <ContactPositionName>Contact - Position Name should be empty or filled in English and French</ContactPositionName>
   <CitedResponsiblePartyPositionName>Cited Responsible Party - Position Name should be empty or filled in English and French</CitedResponsiblePartyPositionName>
   <DistributorPositionName>Distributor - Position Name should be empty or filled in English and French</DistributorPositionName>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -49,6 +49,9 @@
   <CitedResponsiblePartyOrganisationName>Partie responsable citée - Nom de l'organisation est obligatoire dans les deux langues</CitedResponsiblePartyOrganisationName>
   <DistributorOrganisationName>Distributeur - Nom de l'organisation est obligatoire dans les deux langues</DistributorOrganisationName>
 
+  <FileDescription>Superposition Graphique (vignette) - Description du Fichier devrait être vide ou rempli en anglais et en français</FileDescription>
+
+
   <ContactPositionName>Responsable des métadonnées - Position devrait être vide ou rempli en anglais et en français</ContactPositionName>
   <CitedResponsiblePartyPositionName>Responsable de la ressource - Position devrait être vide ou rempli en anglais et en français</CitedResponsiblePartyPositionName>
   <DistributorPositionName>Distributeur - Position devrait être vide ou rempli en anglais et en français</DistributorPositionName>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -176,6 +176,24 @@
     </sch:rule>
 
 
+
+    <!-- graphicOverlay - fileDescription -->
+    <sch:rule context="//gmd:graphicOverview/gmd:MD_BrowseGraphic/gmd:fileDescription">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/FileDescription</sch:assert>
+
+    </sch:rule>
+
+
+
+
     <!-- Contact - Organisation Name -->
     <sch:rule context="//gmd:contact/*/gmd:organisationName">
 


### PR DESCRIPTION
I noticed a difference between the main-language index (index-fields/default.xsl) and multilingual indexing (index-fields/language-default.xsl) for graphicOverview/fileDescription.

Example for main-language (eng);
http://localhost:8080/geonetwork/srv/eng/q?_content_type=json&_draft=y+or+n+or+e&_isTemplate=y+or+n&fast=index&uuid=7c6640de-2cab-448f-b39a-3187464ac46d
```
"image":     [
      "thumbnail|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox_s_fre.png|ENG: nox_s_fre.png",
      "overview|nox.png|noxy_543.png",
      "overview|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox_s.png|thumbnail",
      "overview|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox.png|large_thumbnail"
    ],
```


Example (incorrect) for secondary language;
http://localhost:8080/geonetwork/srv/fre/q?_content_type=json&_draft=y+or+n+or+e&_isTemplate=y+or+n&fast=index&uuid=7c6640de-2cab-448f-b39a-3187464ac46d
```
"image":     [
      "unknown|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox_s_fre.png",
      "unknown|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox_s.png",
      "unknown|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox.png"
    ],
```

NOTICE:
    a) all are marked as "unknown"
    b) there is no text at the end of the line for the fileDescription

This PR changes the indexing so you will get this for the fre;
```
"image":     [
      "thumbnail|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox_s_fre.png|FRA: nox_s_fre.png",
      "overview|nox.png|noxy_543.png",
      "overview|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox_s.png|vignette",
      "overview|http://localhost:8080/geonetwork/srv/api/records/fd4573c5-1d38-448c-8761-cdfcb3c5695b/attachments/nox.png|grande_vignette"
    ],
```

NOTICE:
   a) it starts with "thumbnail/overview" at the start (as per `eng`)
   b) translated titles are sent back (i.e. "grande_vignette")