### PR TITLE
Add xlink:role attribute to gmd:online tag.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -178,9 +178,19 @@ Insert is made in first transferOptions found.
       <xsl:choose>
         <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
           <gmd:onLine>
-            <xsl:if test="$language">
-              <xsl:attribute name="xlink:role" select="$language"/>
-            </xsl:if>
+            <xsl:choose>
+              <xsl:when test="$language">
+                <xsl:attribute name="xlink:role" select="$language"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:if test="contains($mainLang, 'eng')">
+                  <xsl:attribute name="xlink:role">urn:xml:lang:eng-CAN</xsl:attribute>
+                </xsl:if>
+                <xsl:if test="contains($mainLang, 'fre')">
+                  <xsl:attribute name="xlink:role">urn:xml:lang:fra-CAN</xsl:attribute>
+                </xsl:if>
+              </xsl:otherwise>
+            </xsl:choose>
 
             <xsl:if test="$uuidref">
               <xsl:attribute name="uuidref" select="$uuidref"/>

--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -178,19 +178,9 @@ Insert is made in first transferOptions found.
       <xsl:choose>
         <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
           <gmd:onLine>
-            <xsl:choose>
-              <xsl:when test="$language">
-                <xsl:attribute name="xlink:role" select="$language"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:if test="contains($mainLang, 'eng')">
-                  <xsl:attribute name="xlink:role">urn:xml:lang:eng-CAN</xsl:attribute>
-                </xsl:if>
-                <xsl:if test="contains($mainLang, 'fra')">
-                  <xsl:attribute name="xlink:role">urn:xml:lang:fra-CAN</xsl:attribute>
-                </xsl:if>
-              </xsl:otherwise>
-            </xsl:choose>
+            <xsl:if test="$language">
+              <xsl:attribute name="xlink:role" select="$language"/>
+            </xsl:if>
 
             <xsl:if test="$uuidref">
               <xsl:attribute name="uuidref" select="$uuidref"/>

--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -186,7 +186,7 @@ Insert is made in first transferOptions found.
                 <xsl:if test="contains($mainLang, 'eng')">
                   <xsl:attribute name="xlink:role">urn:xml:lang:eng-CAN</xsl:attribute>
                 </xsl:if>
-                <xsl:if test="contains($mainLang, 'fre')">
+                <xsl:if test="contains($mainLang, 'fra')">
                   <xsl:attribute name="xlink:role">urn:xml:lang:fra-CAN</xsl:attribute>
                 </xsl:if>
               </xsl:otherwise>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -777,13 +777,6 @@
     <!-- Distribution - Resources -->
     <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine">
 
-      <sch:let name="missingLanguageForMapService" value="not(string(@xlink:role)) and (lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'ogc:wms' or lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'esri rest: map service')" />
-
-      <sch:assert
-        test="not($missingLanguageForMapService)"
-      >$loc/strings/MapServicesLanguage</sch:assert>
-
-
       <!-- ResourceDescription -->
       <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
       <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -457,13 +457,6 @@
     <!-- Distribution - Resources -->
     <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine">
 
-      <sch:let name="missingLanguageForMapService" value="not(string(@xlink:role)) and (lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'ogc:wms' or lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'esri rest: map service')" />
-
-      <sch:assert
-        test="not($missingLanguageForMapService)"
-      >$loc/strings/MapServicesLanguage</sch:assert>
-
-
       <!-- ResourceDescription -->
       <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
       <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />


### PR DESCRIPTION
The validation was giving such error:
![image](https://user-images.githubusercontent.com/74916635/119890484-e4d77800-bf05-11eb-8ce8-dacb981facc2.png)


The issue is xlink:role attribute was missing from gmd:online tag. So after the fix. The xlink:role will be added if no $language parameter passed into the xsl, we use root/language to determine what that language is. Here is the result transformed XML:

![image](https://user-images.githubusercontent.com/74916635/119890810-44ce1e80-bf06-11eb-8135-7c60f067589e.png)
