### PR TITLE
Option to disable OGC Capabilites layer processing in the online resource panel. 

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "display": "radio",
+    "loadMapCapabilities": "false",
     "types": [{
       "label": "addOnlinesrc",
       "sources": {


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/5763, that should be cherry-pick to GeoNetwork opensource `3.12.x` and `3.10.x` branches.

This PR should be cherry-pick to `3.10.x` branch also.