### PR TITLE
Disable autofill of layer names in add resources panel

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "display": "radio",
+    "loadMapCapabilities": "false",
     "types": [{
       "label": "addOnlinesrc",
       "sources": {


### PR DESCRIPTION
Set the property `loadMapCapabilities` in the online resource panel configuration so it doesn't try to load the `GetCapabilities` document of the OGC services and doesn't show the layers/features grid in the panel. The user must now fill the Name and Description field by hand.

See https://github.com/geonetwork/core-geonetwork/pull/5763 for more info about this
setting.
Related to #66.

Requires GeoNetwork 3.10.7 or > 3.12.1 to properly work.