### PR TITLE
Convert fra to fre (ISO-639.2.B) for multilingual fields.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -125,9 +125,15 @@
 
         <!-- the existing translation -->
         <xsl:for-each select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
+          <xsl:variable name="locale_ISO639_2B">
+            <xsl:choose>
+              <xsl:when test="@locale = '#fra'">#fre</xsl:when>
+              <xsl:otherwise><xsl:value-of select="@locale"/></xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
           <!-- don't put in the default lang if it already has a value -->
-          <xsl:if test="not($hasDefaultValue) or substring-after(@locale, '#') != $metadataLanguage">
-            <value ref="{gn:element/@ref}" lang="{substring-after(@locale, '#')}">
+          <xsl:if test="not($hasDefaultValue) or substring-after($locale_ISO639_2B, '#') != $metadataLanguage">
+            <value ref="{gn:element/@ref}" lang="{substring-after($locale_ISO639_2B, '#')}">
               <xsl:value-of select="."/>
             </value>
           </xsl:if>
@@ -136,9 +142,16 @@
         <!-- and create field for none translated language -->
         <xsl:for-each select="$metadataOtherLanguages/lang">
           <xsl:variable name="currentLanguageId" select="@id"/>
+          <xsl:variable name="currentLanguageId_none_iso">
+            <xsl:choose>
+              <xsl:when test="$currentLanguageId = 'fre'">fra</xsl:when>
+              <xsl:otherwise><xsl:value-of select="$currentLanguageId"/></xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+
           <xsl:if test="count($theElement/
                 gmd:PT_FreeText/gmd:textGroup/
-                gmd:LocalisedCharacterString[@locale = concat('#',$currentLanguageId)]) = 0">
+                gmd:LocalisedCharacterString[@locale = concat('#',$currentLanguageId_none_iso)]) = 0">
             <!--don't put in default language if already there-->
               <xsl:if test="not($hasDefaultValue) or $currentLanguageId != $metadataLanguage ">
                  <value ref="lang_{@id}_{$theElement/gn:element/@ref}"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -142,7 +142,7 @@
         <!-- and create field for none translated language -->
         <xsl:for-each select="$metadataOtherLanguages/lang">
           <xsl:variable name="currentLanguageId" select="@id"/>
-          <xsl:variable name="currentLanguageId_none_iso">
+          <xsl:variable name="currentLanguageId_iso639_2t">
             <xsl:choose>
               <xsl:when test="$currentLanguageId = 'fre'">fra</xsl:when>
               <xsl:otherwise><xsl:value-of select="$currentLanguageId"/></xsl:otherwise>
@@ -151,7 +151,7 @@
 
           <xsl:if test="count($theElement/
                 gmd:PT_FreeText/gmd:textGroup/
-                gmd:LocalisedCharacterString[@locale = concat('#',$currentLanguageId_none_iso)]) = 0">
+                gmd:LocalisedCharacterString[@locale = concat('#',$currentLanguageId_iso639_2t)]) = 0">
             <!--don't put in default language if already there-->
               <xsl:if test="not($hasDefaultValue) or $currentLanguageId != $metadataLanguage ">
                  <value ref="lang_{@id}_{$theElement/gn:element/@ref}"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -231,7 +231,8 @@
           <xsl:for-each select="$metadataOtherLanguages/lang">
             <xsl:variable name="code" select="@code"/>
             <xsl:variable name="currentLanguageId" select="@id"/>
-            <xsl:variable name="currentLanguageId_none_ISO">
+
+            <xsl:variable name="currentLanguageId_iso639_2t">
               <xsl:choose>
                 <xsl:when test="$currentLanguageId = 'fre'">fra</xsl:when>
                 <xsl:otherwise><xsl:value-of select="$currentLanguageId"/></xsl:otherwise>
@@ -243,7 +244,7 @@
                           select="count($theElement/parent::node()/
                                         gmd:PT_FreeText/*/
                                         gmd:LocalisedCharacterString[
-                                          @locale = concat('#', $currentLanguageId_none_ISO)]) = 0"/>
+                                          @locale = concat('#', $currentLanguageId_iso639_2t)]) = 0"/>
 
 
             <xsl:choose>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -214,8 +214,14 @@
 
           <!-- the existing translation -->
           <xsl:for-each select="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
-            <xsl:if test="not($metadataLanguage = substring-after(@locale, '#'))">
-              <value ref="{gn:element/@ref}" lang="{substring-after(@locale, '#')}">
+            <xsl:variable name="locale_ISO639_2B">
+              <xsl:choose>
+                <xsl:when test="@locale = '#fra'">#fre</xsl:when>
+                <xsl:otherwise><xsl:value-of select="@locale"/></xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:if test="not($metadataLanguage = substring-after($locale_ISO639_2B, '#'))">
+              <value ref="{gn:element/@ref}" lang="{substring-after($locale_ISO639_2B, '#')}">
                 <xsl:value-of select="."/>
               </value>
             </xsl:if>
@@ -225,13 +231,19 @@
           <xsl:for-each select="$metadataOtherLanguages/lang">
             <xsl:variable name="code" select="@code"/>
             <xsl:variable name="currentLanguageId" select="@id"/>
+            <xsl:variable name="currentLanguageId_none_ISO">
+              <xsl:choose>
+                <xsl:when test="$currentLanguageId = 'fre'">fra</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$currentLanguageId"/></xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
 
 
             <xsl:variable name="ptFreeElementDoesNotExist"
                           select="count($theElement/parent::node()/
                                         gmd:PT_FreeText/*/
                                         gmd:LocalisedCharacterString[
-                                          @locale = concat('#', $currentLanguageId)]) = 0"/>
+                                          @locale = concat('#', $currentLanguageId_none_ISO)]) = 0"/>
 
 
             <xsl:choose>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -32,6 +32,7 @@
 
 
   <xsl:import href="../../iso19139/layout/utility-tpl-multilingual.xsl"/>
+  <xsl:include href="../../iso19139.ca.HNAP/convert/functions.xsl"/>
 
 
   <!-- Get the main metadata languages -->
@@ -47,7 +48,11 @@
             <xsl:value-of select="$metadata/gmd:language/gmd:LanguageCode/@codeListValue"/>
           </xsl:when>
           <xsl:when test="contains($metadata/gmd:language/gco:CharacterString,';')">
-            <xsl:variable name="metadataMainLanguage" select="normalize-space(substring-before($metadata/gmd:language/gco:CharacterString,';'))"/>
+            <xsl:variable name="metadataMainLanguage">
+              <xsl:call-template name="langId_from_gmdlanguage19139">
+                <xsl:with-param name="gmdlanguage" select="/root/*/gmd:language"/>
+              </xsl:call-template>
+            </xsl:variable>
             <xsl:choose>
               <xsl:when test=" $metadataMainLanguage = 'fra'">
                 <xsl:value-of>fre</xsl:value-of>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -141,6 +141,9 @@
   </xsl:template>
 
   <!-- Get the list of other languages -->
+  <!--This is copied from iso19139
+   https://github.com/geonetwork/core-geonetwork/blob/2208161d116fb5e0d45b45354d8fdbafe98519f1/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl#L102-L128
+   with language code format converting. -->
   <xsl:template name="get-iso19139.ca.HNAP-other-languages">
     <xsl:variable name="isTemplate" select="$metadata/gn:info[position() = last()]/isTemplate"/>
     <xsl:choose>
@@ -159,6 +162,10 @@
         <xsl:for-each select="$metadata/gmd:locale/gmd:PT_Locale">
           <xsl:variable name="langCode"
                         select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
+          <!--The langCode was in iso639-2t format and it need to be converted to iso639-2b
+          because of Geonetwork's standard. It may be "possible" to make this change to ISO19139
+          https://github.com/geonetwork/core-geonetwork/blob/2208161d116fb5e0d45b45354d8fdbafe98519f1/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl-multilingual.xsl#L118-L119
+          as well. -->
           <xsl:variable name="langCode_ISO639_2B">
             <xsl:choose>
               <xsl:when test="$langCode='fra'">

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -154,16 +154,6 @@
         <xsl:for-each select="$metadata/gmd:locale/gmd:PT_Locale">
           <xsl:variable name="langCode"
                         select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
-          <xsl:variable name="id_ISO639_2B">
-            <xsl:choose>
-              <xsl:when test="@id='fra'">
-                <xsl:value-of select="'fre'"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="@id"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:variable>
           <xsl:variable name="langCode_ISO639_2B">
             <xsl:choose>
               <xsl:when test="$langCode='fra'">
@@ -174,7 +164,7 @@
               </xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
-          <lang id="{$id_ISO639_2B}" code="{$langCode_ISO639_2B}">
+          <lang id="{$langCode_ISO639_2B}" code="{$langCode_ISO639_2B}">
             <xsl:if test="$langCode = $mainLanguage">
               <xsl:attribute name="default" select="''"/>
             </xsl:if>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-tpl-multilingual.xsl
@@ -90,37 +90,44 @@
             <xsl:variable name="mainLanguageId"
                           select="$metadata/gmd:locale/gmd:PT_Locale[
                                 gmd:languageCode/gmd:LanguageCode/@codeListValue = $mainLanguage]/@id"/>
+            <xsl:variable name="mainLanguageCode"
+                          select="$metadata/gmd:locale/gmd:PT_Locale[
+                                gmd:languageCode/gmd:LanguageCode/@codeListValue = $mainLanguage]/gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
+
             <xsl:variable name="lang_ISO639_2B">
-               <xsl:choose>
-                  <xsl:when test="$mainLanguage = 'fra'">fre</xsl:when>
-                  <xsl:otherwise><xsl:value-of select="$mainLanguage"/></xsl:otherwise>
-               </xsl:choose>
-            </xsl:variable>
-            <xsl:variable name="mainLanguageId_ISO639_2B">
               <xsl:choose>
-                <xsl:when test="$mainLanguageId[1] = 'fra'">fre</xsl:when>
+                <xsl:when test="$mainLanguage = 'fra'">fre</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$mainLanguage"/></xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="mainLanguageCode_ISO639_2B">
+              <xsl:choose>
+                <xsl:when test="$mainLanguageCode[1] = 'fra'">fre</xsl:when>
                 <xsl:otherwise><xsl:value-of select="$mainLanguageId[1]"/></xsl:otherwise>
               </xsl:choose>
             </xsl:variable>
 
-            <lang><xsl:value-of select="concat('&quot;', $lang_ISO639_2B, '&quot;:&quot;#', $mainLanguageId_ISO639_2B, '&quot;')"/></lang>
+
+            <lang><xsl:value-of select="concat('&quot;', $lang_ISO639_2B, '&quot;:&quot;#', $mainLanguageCode_ISO639_2B, '&quot;')"/></lang>
           </xsl:if>
 
           <xsl:for-each
             select="$metadata/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue != $mainLanguage]">
             <xsl:variable name="lang_ISO639_2B">
-               <xsl:choose>
-                  <xsl:when test="gmd:languageCode/gmd:LanguageCode/@codeListValue = 'fra'">fre</xsl:when>
-                  <xsl:otherwise><xsl:value-of select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/></xsl:otherwise>
-               </xsl:choose>
-            </xsl:variable>
-            <xsl:variable name="id_ISO639_2B">
               <xsl:choose>
-                <xsl:when test="@id = 'fra'">fre</xsl:when>
-                <xsl:otherwise><xsl:value-of select="@id"/></xsl:otherwise>
+                <xsl:when test="gmd:languageCode/gmd:LanguageCode/@codeListValue = 'fra'">fre</xsl:when>
+                <xsl:otherwise><xsl:value-of select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/></xsl:otherwise>
               </xsl:choose>
             </xsl:variable>
-            <lang><xsl:value-of select="concat('&quot;', $lang_ISO639_2B, '&quot;:&quot;#', $id_ISO639_2B, '&quot;')"/></lang>
+
+            <xsl:variable name="lang_code_ISO639_2B">
+              <xsl:choose>
+                <xsl:when test="gmd:languageCode/gmd:LanguageCode/@codeListValue = 'fra'">fre</xsl:when>
+                <xsl:otherwise><xsl:value-of select="gmd:languageCode/gmd:LanguageCode/@codeListValue"/></xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+
+            <lang><xsl:value-of select="concat('&quot;', $lang_ISO639_2B, '&quot;:&quot;#', $lang_code_ISO639_2B, '&quot;')"/></lang>
           </xsl:for-each>
         </xsl:otherwise>
       </xsl:choose>


### PR DESCRIPTION
The issue is Geonetwork uses language code "fre" which is ISO-639.2.B standard. NHAP uses "fra" as language code which is not fully supported by multilingual angular module in Geonetwork. There will be conversion needed within xsl.

Issue:
When the user select French NHAP profile to make metadata:
![image](https://user-images.githubusercontent.com/74916635/123684047-f8367580-d81a-11eb-9df7-47a0d0d01435.png)

the system uses "eng" as default the multilingual field (for every single of them)
![image](https://user-images.githubusercontent.com/74916635/123684083-06849180-d81b-11eb-8bdb-7d933c14bb68.png)

Problem is the language code is not consistent. It's mixed of ISO 6392T and ISO 6392B (fra and fre). This angular widget only support 6392B which is fre. 
![image](https://user-images.githubusercontent.com/74916635/123683617-6cbce480-d81a-11eb-827a-cfab1f010d8f.png)


So both main language and JSON needs to be consistent like the following.
![image](https://user-images.githubusercontent.com/74916635/123684549-9d514e00-d81b-11eb-8d56-041e772d9e6d.png)


