### PR TITLE
Change gmd:spatialRepresentationType to optional and remove validation rules

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1930,7 +1930,6 @@
     <element name="gmd:spatialRepresentationType" id="37.0">
         <label>Spatial representation type</label>
         <description>Method used to spatially represent geographic information</description>
-        <condition>mandatory</condition>
     </element>
     <element name="gmd:spatialResolution" id="38.0">
         <label>Spatial resolution</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -13,7 +13,6 @@
   <Status>Value is required for status</Status>
   <InvalidStatusCode>Status code is not valid</InvalidStatusCode>
   <TopicCategory>Value is required for Topic Category</TopicCategory>
-  <SpatialRepresentation>Value is required for Spatial representation</SpatialRepresentation>
   <InvalidSpatialRepresentationType>Spatial representation code is not valid</InvalidSpatialRepresentationType>
   <PublicationDate>Value is required for Metadata publication date</PublicationDate>
   <CreationDate>Value is required for Metadata creation date</CreationDate>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2659,7 +2659,6 @@
   <element name="gmd:spatialRepresentationType" id="37.0">
     <label>Type de représentation spatiale</label>
     <description>Méthode utilisée pour représenter spatialement l'information géographique</description>
-    <condition>mandatory</condition>
   </element>
   <element name="gmd:spatialResolution" id="38.0">
     <label>Résolution spatiale</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -13,7 +13,6 @@
   <Status>Une valeur est nécessaire pour: Etat</Status>
   <InvalidStatusCode>Le code d'état n'est pas valide</InvalidStatusCode>
   <TopicCategory>Une valeur est nécessaire pour: Catégorie thématique</TopicCategory>
-  <SpatialRepresentation>Une valeur est nécessaire pour: Type de représentation spatiale</SpatialRepresentation>
   <InvalidSpatialRepresentationType>Le code de fréquence de mise à jour n'est pas valide</InvalidSpatialRepresentationType>
   <PublicationDate>Une valeur est nécessaire pour: Métadonnées date de publication</PublicationDate>
   <CreationDate>>Une valeur est nécessaire pour: Métadonnées date de création</CreationDate>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -162,24 +162,16 @@
                    |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:spatialRepresentationType
                    |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:spatialRepresentationType">
 
-      <sch:let name="missing" value="not(string(gmd:MD_SpatialRepresentationTypeCode/@codeListValue))
-                 or (@gco:nilReason)" />
-
-      <sch:assert
-        test="not($missing)"
-      >$loc/strings/SpatialRepresentation</sch:assert>
-
-
       <sch:let name="spatialRepresentationTypeCodelistLabel"
                value="tr:codelist-value-label(
                             tr:create($schema),
                             gmd:MD_SpatialRepresentationTypeCode/local-name(),
                             gmd:MD_SpatialRepresentationTypeCode/@codeListValue)"/>
 
-      <sch:let name="isValid" value="($spatialRepresentationTypeCodelistLabel != '') and ($spatialRepresentationTypeCodelistLabel != gmd:MD_SpatialRepresentationTypeCode/@codeListValue)"/>
+      <sch:let name="isValid" value="($spatialRepresentationTypeCodelistLabel = '') or ($spatialRepresentationTypeCodelistLabel != gmd:MD_SpatialRepresentationTypeCode/@codeListValue)"/>
 
       <sch:assert
-        test="$isValid or $missing"
+        test="$isValid"
       >$loc/strings/InvalidSpatialRepresentationType</sch:assert>
     </sch:rule>
 


### PR DESCRIPTION
MD_DataIdentification/gmd:spatialRepresentationType is current marked as mandatory. But accordingly to the foot note of related document, it meant to be optional
![image](https://user-images.githubusercontent.com/74916635/125130265-b638e980-e0ce-11eb-89bc-27ab15dc34b3.png)


I have commit the solution to get this fields converted to optional and removing validation rule of missing. Please verify if this is acceptable.