### PR TITLE
Add attribute xlink:role for map online resources

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -177,10 +177,16 @@ Insert is made in first transferOptions found.
       -->
       <xsl:choose>
         <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
+
+          <xsl:variable name="resourceLang">
+            <xsl:choose>
+              <xsl:when test="ends-with($desc, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+              <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+
           <gmd:onLine>
-            <xsl:if test="$language">
-              <xsl:attribute name="xlink:role" select="$language"/>
-            </xsl:if>
+            <xsl:attribute name="xlink:role" select="$resourceLang"/>
 
             <xsl:if test="$uuidref">
               <xsl:attribute name="uuidref" select="$uuidref"/>
@@ -258,10 +264,10 @@ Insert is made in first transferOptions found.
                         <xsl:variable name="nameValue"
                                       select="substring-after(., '#')"></xsl:variable>
 
-                        <xsl:message>useOnlyPTFreeText: <xsl:value-of select="$useOnlyPTFreeText" /></xsl:message>
+                        <!--<xsl:message>useOnlyPTFreeText: <xsl:value-of select="$useOnlyPTFreeText" /></xsl:message>
                         <xsl:message>ML: <xsl:value-of select="$mainLang" /></xsl:message>
                         <xsl:message>nameLang: <xsl:value-of select="$nameLang" /></xsl:message>
-                        <xsl:message>nameValue: <xsl:value-of select="$nameValue" /></xsl:message>
+                        <xsl:message>nameValue: <xsl:value-of select="$nameValue" /></xsl:message>-->
 
 
                         <xsl:if
@@ -363,8 +369,17 @@ Insert is made in first transferOptions found.
           <!-- ... the name is simply added in the newly
           created online element. -->
           <gmd:onLine>
-            <xsl:if test="$language">
-              <xsl:attribute name="xlink:role" select="$language"/>
+            <xsl:variable name="isMapProtocol" select="starts-with($protocol, 'ESRI REST:') or starts-with($protocol, 'OGC:')" />
+
+            <xsl:variable name="resourceLang">
+              <xsl:choose>
+                <xsl:when test="ends-with($desc, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+                <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+
+            <xsl:if test="$isMapProtocol">
+              <xsl:attribute name="xlink:role" select="$resourceLang"/>
             </xsl:if>
 
             <xsl:if test="$uuidref">
@@ -446,10 +461,10 @@ Insert is made in first transferOptions found.
                         <xsl:variable name="nameValue"
                                       select="substring-after(., '#')"></xsl:variable>
 
-                        <xsl:message>useOnlyPTFreeText: <xsl:value-of select="$useOnlyPTFreeText" /></xsl:message>
+                        <!--<xsl:message>useOnlyPTFreeText: <xsl:value-of select="$useOnlyPTFreeText" /></xsl:message>
                         <xsl:message>ML: <xsl:value-of select="$mainLang" /></xsl:message>
                         <xsl:message>nameLang: <xsl:value-of select="$nameLang" /></xsl:message>
-                        <xsl:message>nameValue: <xsl:value-of select="$nameValue" /></xsl:message>
+                        <xsl:message>nameValue: <xsl:value-of select="$nameValue" /></xsl:message>-->
 
 
                         <xsl:if

--- a/src/main/plugin/iso19139.ca.HNAP/process/upgrade-mapresources-lang.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/upgrade-mapresources-lang.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:exsl="http://exslt.org/common"
+                xmlns:geonet="http://www.fao.org/geonetwork" exclude-result-prefixes="#all" version="2.0">
+
+    <!-- ================================================================= -->
+
+    <xsl:template match="gmd:MD_Metadata">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+
+    <!-- ================================================================= -->
+
+    <xsl:template match="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[not(@xlink:role) and
+        (gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString = 'OGC:WMS' or starts-with(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, 'ESRI REST:'))]">
+
+        <xsl:variable name="resourceLang">
+            <xsl:choose>
+                <xsl:when test="ends-with(gmd:CI_OnlineResource/gmd:description/gco:CharacterString, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+                <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:copy>
+            <xsl:attribute name="xlink:role"><xsl:value-of select="$resourceLang" /></xsl:attribute>
+            <xsl:copy-of select="@*" />
+
+            <xsl:apply-templates select="*" />
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- ================================================================= -->
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- ================================================================= -->
+
+    <!-- Remove geonet:* elements. -->
+    <xsl:template match="geonet:*" priority="2"/>
+    <xsl:template match="@geonet:*" priority="2"/>
+</xsl:stylesheet>


### PR DESCRIPTION
- if the description ends with fra add in xlink:role='urn:xml:lang:fra-CAN'
- if not (ie eng for fra-eng) add in xlink:role='urn:xml:lang:eng-CAN'

Add also a batch process to update the existing metadata.

Replaces https://github.com/metadata101/iso19139.ca.HNAP/pull/219