### PR TITLE
Use default version from its parent in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>3.12-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <version>3.12-SNAPSHOT</version>
+
   <artifactId>schema-iso19139.ca.HNAP</artifactId>
   <name>Schema Plugin HNAP ISO19139/119</name>
 


### PR DESCRIPTION
The version is always same as its parent. It's better to remove it and use the default from its parent. Should keep same dependency management mechanism as other major metadata profile (i,.e ISO 19139).