### PR TITLE
Add missing alias attribute to codelists

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/codelists.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/codelists.xml
@@ -77,7 +77,7 @@
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:CI_OnLineFunctionCode">
+	<codelist name="gmd:CI_OnLineFunctionCode" alias="function">
 		<entry>
 			<code>RI_375</code>
       <value>download; téléchargement</value>
@@ -315,7 +315,7 @@
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:CI_RoleCode">
+	<codelist name="gmd:CI_RoleCode" alias="roleCode">
 		<entry>
 			<code>RI_408</code>
       <value>resourceProvider; fournisseurRessource</value>
@@ -466,7 +466,7 @@
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:DS_AssociationTypeCode">
+	<codelist name="gmd:DS_AssociationTypeCode" alias="associationType">
 		<entry>
       <code>RI_428</code>
 			<value>crossReference; référenceCroisée</value>
@@ -513,7 +513,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:DS_InitiativeTypeCode">
+	<codelist name="gmd:DS_InitiativeTypeCode" alias="initiativeType">
 		<entry>
       <code>RI_435</code>
 			<value>campaign; campagne</value>
@@ -2115,7 +2115,7 @@
 		</entry>-->
 	</codelist>
 	<!-- ==================================================== -->
-  <codelist name="gmd:MD_TopicCategoryCode">
+  <codelist name="gmd:MD_TopicCategoryCode" alias="topicCategory">
     <entry>
       <code>farming</code>
       <label>Farming</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml
@@ -61,7 +61,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-  <codelist name="gmd:CI_OnLineFunctionCode">
+  <codelist name="gmd:CI_OnLineFunctionCode" alias="function">
     <entry>
       <code>RI_375</code>
       <value>download; téléchargement</value>
@@ -283,7 +283,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:CI_RoleCode">
+	<codelist name="gmd:CI_RoleCode" alias="roleCode">
 		<entry>
       <code>RI_408</code>
       <value>resourceProvider; fournisseurRessource</value>
@@ -425,7 +425,7 @@
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:DS_AssociationTypeCode">
+	<codelist name="gmd:DS_AssociationTypeCode" alias="associationType">
 		<entry>
       <code>RI_428</code>
       <value>crossReference; référenceCroisée</value>
@@ -470,7 +470,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>
 	<!-- ==================================================== -->
-	<codelist name="gmd:DS_InitiativeTypeCode">
+	<codelist name="gmd:DS_InitiativeTypeCode" alias="initiativeType">
 		<entry>
       <code>RI_435</code>
       <value>campaign; campagne</value>
@@ -2035,7 +2035,7 @@
 		</entry>-->
 	</codelist>
 	<!-- ==================================================== -->
-  <codelist name="gmd:MD_TopicCategoryCode">
+  <codelist name="gmd:MD_TopicCategoryCode" alias="topicCategory">
     <entry>
       <code>farming</code>
       <label>Agriculture</label>


### PR DESCRIPTION
Some UI angularjs directives like the directory entry selector to add contacts in the metadata editor, use the `alias` attribute from the codelist file to retrieve the values, instead of using the element name, probably to make them more generic to work with other schemas like `iso19115-3` that use different element names.

The `alias` attribute was missing in HNAP, causing that the values default to the ones from `iso19139`, but the codes in HNAP use a different format, causing that the elements ended with the codes from `iso19139` instead of the HNAP ones.

Test case:

1) Import both iso19139 and HNAP templates

2) Create a contact directory entry

3) Create an HNAP metadata and select the contact from the directory list, selecting a role

Without this fix, the role ends with the iso19139 code value, for example `owner`. WIth the fix, for the owner role it's assigned the code from HNAP `RI_410`.