### PR TITLE
Support multicombiner directive for online resources description

### DIFF
--- a/src/main/config/codelist/local/thesauri/theme/GC_Resource_ContentTypes.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/GC_Resource_ContentTypes.rdf
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:ns2="http://www.w3.org/2004/02/skos/core#">
+
+    <ns2:ConceptScheme>
+      <dc:title>Resource content type</dc:title>
+       <dc:title xml:lang="en">Resource content type</dc:title>
+       <dc:title xml:lang="fr">Type d'information de la ressource</dc:title>
+      <dc:description></dc:description>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+    </ns2:ConceptScheme>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcecontenttype#Dataset">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+            >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+            >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Données</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Dataset</ns2:prefLabel>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcecontenttype#Web Service">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+            >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+            >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Service Web</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Web Service</ns2:prefLabel>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcecontenttype#API">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+            >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+            >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">API</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">API</ns2:prefLabel>
+    </rdf:Description>
+
+   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcecontenttype#Supporting Document">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+            >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+            >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Document de soutien</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Supporting Document</ns2:prefLabel>
+    </rdf:Description>
+
+   <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcecontenttype#Application">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+            >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+            >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Application</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Application</ns2:prefLabel>
+    </rdf:Description>
+</rdf:RDF>

--- a/src/main/config/codelist/local/thesauri/theme/GC_Resource_Languages.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/GC_Resource_Languages.rdf
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:ns2="http://www.w3.org/2004/02/skos/core#">
+
+    <ns2:ConceptScheme>
+      <dc:title>Resource languages</dc:title>
+       <dc:title xml:lang="en">Resource languages</dc:title>
+       <dc:title xml:lang="fr">Langue de la ressource</dc:title>
+      <dc:description></dc:description>
+      <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+      <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+    </ns2:ConceptScheme>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcelanguage#eng">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+            >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+            >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">eng</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">eng</ns2:prefLabel>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcelanguage#fra">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+        >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+        >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">fra</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">fra</ns2:prefLabel>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcelanguage#eng,fra">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+        >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+        >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">eng,fra</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">eng,fra</ns2:prefLabel>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/resourcelanguage#zxx">
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en"
+        >Definition</ns2:scopeNote>
+        <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr"
+        >Definition</ns2:scopeNote>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">zxx</ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">zxx</ns2:prefLabel>
+    </rdf:Description>
+
+</rdf:RDF>

--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -1,67 +1,91 @@
 {
   "config": {
-    "loadMapCapabilities": "false",
     "display": "radio",
-    "types": [
-      {
-        "label": "addOnlinesrc",
-        "sources": {
-          "filestore": true
-        },
-        "icon": "fa gn-icon-onlinesrc",
-        "process": "onlinesrc-add",
-        "fields": {
-          "protocol": {
-            "value": "WWW:LINK-1.0-http--link",
-            "isMultilingual": false,
-            "required": true,
-            "tooltip": "gmd:protocol"
-          },
-          "url": {
-            "isMultilingual": false,
-            "required": true,
-            "tooltip": "gmd:URL"
-          },
-          "name": {
-            "tooltip": "gmd:name"
-          },
-          "desc": {
-            "tooltip": "gmd:description"
-          },
-          "function": {
-            "isMultilingual": false,
-            "tooltip": "gmd:function"
-          },
-          "applicationProfile": {
-            "isMultilingual": false,
-            "tooltip": "gmd:applicationProfile"
-          }
-        }
+    "loadMapCapabilities": "false",
+    "types": [{
+      "label": "addOnlinesrc",
+      "sources": {
+        "filestore": true
       },
-      {
-        "label": "addThumbnail",
-        "sources": {
-          "filestore": true,
-          "thumbnailMaker": true
+      "icon": "fa gn-icon-onlinesrc",
+      "process": "onlinesrc-add",
+      "fields": {
+        "protocol": {
+          "value": "WWW:LINK-1.0-http--link",
+          "isMultilingual": false,
+          "required": true,
+          "tooltip": "gmd:protocol"
         },
-        "icon": "fa gn-icon-thumbnail",
-        "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
-        "process": "thumbnail-add",
-        "fields": {
-          "url": {
-            "param": "thumbnail_url",
-            "isMultilingual": false,
-            "required": true
-          },
-          "name": {
-            "param": "thumbnail_desc"
+        "url": {
+          "isMultilingual": false,
+          "required": true,
+          "tooltip": "gmd:URL"
+        },
+        "name": {"tooltip": "gmd:name"},
+        "desc": {
+          "tooltip": "gmd:description",
+          "required": true,
+          "directive": "gn-multientry-combiner-online-resources-description",
+          "directiveConfig": {
+            "valueElementId": "multicombinervalue",
+            "fieldName": "desc",
+            "combiner":";",
+            "config":
+            [
+              {
+                "type": "thesaurus",
+                "heading": {
+                  "eng": "Content type",
+                  "fra": "Type d'information"
+                },
+                "thesaurus": "external.theme.GC_Resource_ContentTypes"
+              },
+              {
+                "type": "thesaurus",
+                "heading": {
+                  "eng": "Format",
+                  "fra": "Format"
+                },
+                "thesaurus": "external.theme.GC_Resource_Formats"
+              },
+              {
+                "type": "thesaurus",
+                "heading": {
+                  "eng": "Language",
+                  "fra": "Langue"
+                },
+                "thesaurus": "external.theme.GC_Resource_Languages"
+              }
+            ]
           }
+        },
+        "function": {
+          "isMultilingual": false,
+          "tooltip": "gmd:function"
+        },
+        "applicationProfile": {
+          "isMultilingual": false,
+          "tooltip": "gmd:applicationProfile"
         }
       }
-    ],
-    "multilingualFields": [
-      "name",
-      "desc"
-    ]
+    }, {
+      "label": "addThumbnail",
+      "sources": {
+        "filestore": true,
+        "thumbnailMaker": true
+      },
+      "icon": "fa gn-icon-thumbnail",
+      "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
+      "process": "thumbnail-add",
+      "fields": {
+        "url": {
+          "param": "thumbnail_url",
+          "isMultilingual": false,
+          "required": true
+        },
+        "name": {"param": "thumbnail_desc"}
+      }
+    }],
+    "multilingualFields": ["name", "desc"]
   }
 }


### PR DESCRIPTION
Backport of the multicombiner directive for online resources description, requires these commits from GeoNetwork `3.10.x`:

- https://github.com/geonetwork/core-geonetwork/commit/0206e666400574ce013b5c4b34a53ba0e22fb66c
- https://github.com/geonetwork/core-geonetwork/commit/13deefbe86208595f6e878a5b8a27d5c60fbcafc

This is in effect a backport of https://github.com/metadata101/iso19139.ca.HNAP/pull/213 (reference issue https://github.com/metadata101/iso19139.ca.HNAP/issues/95 )