### PR TITLE
Fix indexing of the online resources protocol in the alternative language - protocol is not multilingual

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -530,7 +530,7 @@
         <xsl:variable name="linkage" select="gmd:linkage/gmd:URL"/>
         <xsl:variable name="title" select="normalize-space(gmd:name//gmd:LocalisedCharacterString[@locale=$langId]|gmd:name/gmx:MimeFileType)"/>
         <xsl:variable name="desc" select="normalize-space(gmd:description//gmd:LocalisedCharacterString[@locale=$langId])"/>
-        <xsl:variable name="protocol" select="normalize-space(gmd:protocol//gmd:LocalisedCharacterString[@locale=$langId])"/>
+        <xsl:variable name="protocol" select="normalize-space(gmd:protocol/gco:CharacterString)"/>
         <xsl:variable name="mimetype"
                       select="geonet:protocolMimeType($linkage, $protocol, gmd:name/gmx:MimeFileType/@type)"/>
 


### PR DESCRIPTION
This causes in the search results that the links to add layers to the map are not displaying the metadata in UI for the metadata alternative language.