### PR TITLE
Fix indexing of keywords without theusaurus in the metadata alternative language

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -267,17 +267,7 @@
           <xsl:variable name="keywordWithNoThesaurus"
                         select="//gmd:MD_Keywords[
                                   not(gmd:thesaurusName) or gmd:thesaurusName/*/gmd:title/gmd:LocalisedCharacterString[@locale = $langId]/text() = '']/
-                                    gmd:keyword//gmd:LocalisedCharacterString[@locale=$langId][*/text() != '']"/>
-          <xsl:if test="count($keywordWithNoThesaurus) > 0">
-            'keywords': [
-            <xsl:for-each select="$keywordWithNoThesaurus/(gco:CharacterString|gmx:Anchor)">
-              {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>,
-              'link': '<xsl:value-of select="@xlink:href"/>'}
-              <xsl:if test="position() != last()">,</xsl:if>
-            </xsl:for-each>
-            ]
-            <xsl:if test="//gmd:MD_Keywords[gmd:thesaurusName]">,</xsl:if>
-          </xsl:if>
+                                    gmd:keyword[.//gmd:LocalisedCharacterString[@locale=$langId]/text() != '']"/>
           <xsl:for-each-group select="//gmd:MD_Keywords[
                                         gmd:thesaurusName/*/gmd:title//gmd:LocalisedCharacterString[@locale = $langId]/text() != '' and
                                         count(gmd:keyword//gmd:LocalisedCharacterString[@locale = $langId and text() != '']) > 0]"
@@ -292,6 +282,16 @@
             ]
             <xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each-group>
+          <xsl:if test="count($keywordWithNoThesaurus) > 0">
+            <xsl:if test="count(//gmd:MD_Keywords[gmd:thesaurusName/*/gmd:title/*/text() != '']) > 0">,</xsl:if>
+            'otherKeywords': [
+            <xsl:for-each select="$keywordWithNoThesaurus//gmd:LocalisedCharacterString[@locale = $langId and text() != '']">
+              {'value': <xsl:value-of select="concat('''', replace(., '''', '\\'''), '''')"/>,
+              'link': '<xsl:value-of select="@xlink:href"/>'}
+              <xsl:if test="position() != last()">,</xsl:if>
+            </xsl:for-each>
+            ]
+          </xsl:if>
           }
         </xsl:variable>
 


### PR DESCRIPTION
This issue causes that the keywords without a thesaurus are not displayed in the metadata detail page displayed in the UI with metadata alternative language.

![keywords-eng](https://user-images.githubusercontent.com/1695003/141318931-c96cf746-c507-471e-a5bc-7590e0069c97.png)

Keywords without thesaurus - missing in French UI (alternative metadata language):

![keywords-fre](https://user-images.githubusercontent.com/1695003/141318953-4ea29d42-4ebc-47e4-bb87-05fc57f86178.png)


