### PR TITLE
Avoid indexing srv:serviceType/gco:LocalName with empty values

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -503,7 +503,7 @@
       <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
       <!--  Fields use to search on Service -->
 
-      <xsl:for-each select="srv:serviceType/gco:LocalName">
+      <xsl:for-each select="srv:serviceType/gco:LocalName[string(.)]">
         <Field name="serviceType" string="{string(.)}" store="true" index="true"/>
         <Field  name="type" string="service-{string(.)}" store="true" index="true"/>
       </xsl:for-each>


### PR DESCRIPTION
Otherwise if the empty value is in a metadata template, the metadata new record page shows an entry `service-` for the template types:


<img width="216" alt="template-type" src="https://user-images.githubusercontent.com/1695003/147253185-42b7423a-10ca-4180-b64e-44c9c8bad917.png">

