### PR TITLE
Remove role validation from multiligual rules

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -353,30 +353,6 @@
       >$loc/strings/ContactHoursOfService</sch:assert>
     </sch:rule>
 
-
-    <!-- Contact - Role -->
-    <sch:rule context="//gmd:contact/*/gmd:role">
-
-      <sch:let name="roleCodelistLabel"
-                     value="tr:codelist-value-label(
-                            tr:create($schema),
-                            gmd:CI_RoleCode/local-name(),
-                            gmd:CI_RoleCode/@codeListValue)"/>
-
-      <sch:let name="missing" value="not(string(gmd:CI_RoleCode/@codeListValue))
-                 or (@gco:nilReason)" />
-
-      <sch:assert
-        test="not($missing)"
-      >$loc/strings/MissingContactRole</sch:assert>
-
-      <sch:let name="isValid" value="($roleCodelistLabel != '') and ($roleCodelistLabel != gmd:CI_RoleCode/@codeListValue)"/>
-
-      <sch:assert
-        test="$isValid or $missing"
-      >$loc/strings/InvalidContactRole</sch:assert>
-
-    </sch:rule>
   </sch:pattern>
 
 


### PR DESCRIPTION
The validation is defined in the common rules and was reporting an empty error message for the multilingual rules:

![validation](https://user-images.githubusercontent.com/1695003/147953240-149e4d2a-a7ea-4367-b843-48b90061b517.png)

