### PR TITLE
Fix display of multilingual French values in the full view formatter

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/formatter/xsl-view/view.xsl
@@ -53,6 +53,8 @@
   <xsl:variable name="editorConfig"
                 select="document('../../layout/config-editor.xml')"/>
 
+  <xsl:variable name="langId" select="gn-fn-iso19139:getLangIdHNAP($metadata, $language)"/>
+
 
   <!-- Override codelist template, to don't use the text value,
        just the codeListValue attribute -->

--- a/src/main/plugin/iso19139.ca.HNAP/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/formatter/xsl-view/view.xsl
@@ -41,6 +41,7 @@
                 exclude-result-prefixes="#all">
   <xsl:import href="../../layout/evaluate.xsl"/>
   <xsl:import href="../../layout/utility-tpl-multilingual.xsl"/>
+  <xsl:import href="../../layout/utility-fn.xsl"/>
   <xsl:import href="../../../iso19139/formatter/xsl-view/view.xsl"/>
 
   <!-- Load the editor configuration to be able
@@ -52,8 +53,8 @@
   <xsl:variable name="editorConfig"
                 select="document('../../layout/config-editor.xml')"/>
 
-  
-  <!-- Override codelist template, to don't use the text value, 
+
+  <!-- Override codelist template, to don't use the text value,
        just the codeListValue attribute -->
   <xsl:template mode="render-field"
                 match="*[*/@codeListValue]"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/utility-fn.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/utility-fn.xsl
@@ -31,5 +31,32 @@
 
   <xsl:import href="../../iso19139/layout/utility-fn.xsl"/>
 
+  <xsl:function name="gn-fn-iso19139:getLangIdHNAP" as="xs:string">
+    <xsl:param name="md"/>
+    <xsl:param name="lang"/>
 
+    <!-- convert ISO 639-2B to_ISO 639-2T - i.e. FRE to FRA -->
+    <xsl:variable name="lang_ISO639_2T">
+      <xsl:choose>
+        <xsl:when test="$lang ='fre'">
+          <xsl:value-of select="'fra'"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$lang"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:choose>
+      <xsl:when
+        test="$md/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $lang_ISO639_2T]/@id">
+        <xsl:value-of
+          select="concat('#', $md/gmd:locale/gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $lang_ISO639_2T]/@id)"
+        />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat('#', upper-case($lang_ISO639_2T))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
 </xsl:stylesheet>


### PR DESCRIPTION
WIthout this change the full view formatter displays in the French UI, English values for multilingual elements, due to the wrong language code used.

<img width="1311" alt="language" src="https://user-images.githubusercontent.com/1695003/149981225-af1599f6-a07a-4e63-b4dd-831a50f9abfe.png">