### PR TITLE
Fix country validation rules to verify the value in the thesaurus using the element language

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -283,16 +283,11 @@
       <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
       <sch:assert test="(not($countryName) or
-           ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]) or
-           string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryName]))))
-
-           and
-
-           (not($countryNameOtherLang) or
-                       ($countryNameOtherLang and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryNameOtherLang]) or
-                       string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))
-                       ))">$loc/strings/ECCountry</sch:assert>
-
+          ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))
+          and
+          (not($countryNameOtherLang) or
+          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))"
+          >$loc/strings/ECCountry</sch:assert>
 
     </sch:rule>
 
@@ -474,15 +469,11 @@
       <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
       <sch:assert test="(not($countryName) or
-                ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]) or
-                string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryName]))))
-
-                and
-
-                (not($countryNameOtherLang) or
-                            ($countryNameOtherLang and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryNameOtherLang]) or
-                            string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))
-                            ))">$loc/strings/ECCountry</sch:assert>
+          ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))
+          and
+          (not($countryNameOtherLang) or
+          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))"
+          >$loc/strings/ECCountry</sch:assert>
     </sch:rule>
 
 
@@ -875,15 +866,11 @@
       <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
       <sch:assert test="(not($countryName) or
-              ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]) or
-              string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryName]))))
-
-              and
-
-              (not($countryNameOtherLang) or
-                          ($countryNameOtherLang and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryNameOtherLang]) or
-                          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))
-                          ))">$loc/strings/ECCountry</sch:assert>
+          ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))
+          and
+          (not($countryNameOtherLang) or
+          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))"
+          >$loc/strings/ECCountry</sch:assert>
 
     </sch:rule>
 


### PR DESCRIPTION
Previously the values were check in both languages in the thesaurus, causing that this kind of entries (English element with the French value) passed the validation:

```
<gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
    <gco:CharacterString>Canada (le)</gco:CharacterString>
    <gmd:PT_FreeText>
        <gmd:textGroup>
            <gmd:LocalisedCharacterString xmlns="" locale="#fra">Canada (le)</gmd:LocalisedCharacterString>
        </gmd:textGroup>
    </gmd:PT_FreeText>
</gmd:country>
```