### PR TITLE
Change label "systems" to "system" in singular word.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1783,7 +1783,7 @@
     <element name="gmd:referenceSystemInfo" id="13.0">
         <label>Reference System Information</label>
         <btnLabel>Add Reference System Information</btnLabel>
-        <description>Description of the spatial and temporal reference systems used in the
+        <description>Description of the spatial and temporal reference system used in the
             dataset</description>
     </element>
     <element name="gmd:report" id="80.0">

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/strings.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/strings.xml
@@ -265,7 +265,7 @@
   <addFreeTextKeywords>Add free-text keywords</addFreeTextKeywords>
   <addDate>Add date</addDate>
   <addCharacterSet>Add character set</addCharacterSet>
-  <referenceSystemInfo>Reference Systems</referenceSystemInfo>
+  <referenceSystemInfo>Reference System</referenceSystemInfo>
 
   <trueValue>Yes</trueValue>
   <falseValue>No</falseValue>


### PR DESCRIPTION
The issue was the label for reference system. There is only one single system input but the "systems" word is multiplier.

![image](https://user-images.githubusercontent.com/74916635/151860592-4aa2585d-dcfc-4e65-bd22-c772253afc7a.png)


It's better to change to singular word.

![image](https://user-images.githubusercontent.com/74916635/151860725-bf5dbf99-1143-4805-8972-e796409de140.png)
