### PR TITLE
resource format validation rule update.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -798,8 +798,8 @@
       <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
       <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
 
-      <sch:assert test="string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#', $format)]) and
-                          string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#',$formatTranslated)])">$locMsg</sch:assert>
+      <sch:assert test="$formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($mainLanguage2char)]/text() = $format and
+                          $formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($altLanguage2char)]/text() = $formatTranslated">$locMsg</sch:assert>
 
       <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -498,7 +498,7 @@
       <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
       <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList),  concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
 
-      <sch:assert test="string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#', $format)])">$locMsg</sch:assert>
+      <sch:assert test="$formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($mainLanguage2char)]/text() = $format">$locMsg</sch:assert>
 
       <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
 


### PR DESCRIPTION
Current the validation rule fails when the the Resource Description is different from the actual label value because the label value is passed into the xml document search. Here is an example.

The rdf:about="http://geonetwork-opensource.org/EC/resourceformat#CDED ASCII"

but prefered label is ASCII (CDED).

https://github.com/metadata101/iso19139.ca.HNAP/blob/85aeb8ebb04c40965ba9acf6630fb6d2865b2ae4/src/main/config/codelist/local/thesauri/theme/GC_Resource_Formats.rdf#L37-L43

The metadata looks like:
![image](https://user-images.githubusercontent.com/74916635/153082020-721f1eb1-14a0-4879-8989-189265a09a85.png)

Validation failed:
![image](https://user-images.githubusercontent.com/74916635/153082476-91b23e3e-ffc8-4a4e-b8e9-f04cb43f3ed0.png)


I have updated the validation rule to go find the actual label depends on current main language