### PR TITLE
Add priority to extract-relations template

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/extract-relations.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/extract-relations.xsl
@@ -42,7 +42,7 @@
 
   <!-- Convert an element gco:CharacterString
   to the GN localized string structure -->
-  <xsl:template mode="get-iso19139-localized-string" match="*">
+  <xsl:template mode="get-iso19139-localized-string" match="*" priority="10">
 
     <xsl:variable name="mainLanguage">
       <xsl:call-template name="langId_from_gmdlanguage19139">


### PR DESCRIPTION
Adding priority to the `get-iso19139-localized-string`.

Unless misunderstanding the xsl spec, using `xsl:import` allows to override templates, but we have identified in some deployments it's not the case. Adding the priority to make sure for HNAP metadata is used the correct template.