### PR TITLE
update tooltip for protocal in online resource.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1746,7 +1746,7 @@
     </element>
     <element name="gmd:protocol" id="398.0" alias="protocol">
         <label>Protocol</label>
-        <description>Select the appropriate protocol from the drop down list. If your dataset is available online, select 'web address (URL)'</description>
+        <description>Select the appropriate protocol from the drop down list. If your dataset is available online, then enter its web address in the URL text box.</description>
       <helper sort="true">
         <option value="HTTP">HTTP</option>
         <option value="HTTPS">HTTPS</option>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2417,7 +2417,7 @@
   </element>
   <element name="gmd:protocol" id="398.0" alias="protocol">
     <label>Protocole</label>
-    <description>Sélectionner le bon protocole de la liste déroulante. Si l'ensemble de données est disponible en ligne, sélectionner « Adresse Web (URL) ».</description>
+    <description>Sélectionnez le protocole approprié dans la liste déroulante. Si vos données sont disponibles en ligne, entrez leur location Web dans la zone de texte URL.</description>
     <helper sort="true">
       <option value="HTTP">HTTP</option>
       <option value="HTTPS">HTTPS</option>


### PR DESCRIPTION
The text in tooltip of protocol has no obvious indication of which input field web address (URL) is referring to.

![image](https://user-images.githubusercontent.com/74916635/156210900-bc007fec-bd53-4b1d-8371-e02ba99af322.png)

The updated text will make it more clear which field that web address url is referring to. Here is the updated English text:

"
Select the appropriate protocol from the drop down list. If your dataset is available online, then enter its web address in the URL text box
"

