### PR TITLE
validate for online resource protocol

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -41,7 +41,8 @@
   <DistributionFormatVersion>Value is required for distribution format - File version</DistributionFormatVersion>
   <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
-  <OnlineResourceProtocol>Protocol (HTTP, HTTPS, FTP, ESRI REST: Map Service, OGC:WMS, OGC:WFS) is required for Online Resource: </OnlineResourceProtocol>
+  <OnlineResourceName>Protocol of Online Resource "</OnlineResourceName>
+  <OnlineResourceProtocol>" is not valid. Valid values are: </OnlineResourceProtocol>
 
   <MapResourcesREST>REST Map Resources should be available in english and french</MapResourcesREST>
   <MapResourcesRESTNumber>The number of ESRI REST Map Resources should be at most 2 (one for english and one for french)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -41,6 +41,7 @@
   <DistributionFormatVersion>Value is required for distribution format - File version</DistributionFormatVersion>
   <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
+  <OnlineResourceProtocol>Protocol is required for Online Resource: </OnlineResourceProtocol>
 
   <MapResourcesREST>REST Map Resources should be available in english and french</MapResourcesREST>
   <MapResourcesRESTNumber>The number of ESRI REST Map Resources should be at most 2 (one for english and one for french)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -41,8 +41,7 @@
   <DistributionFormatVersion>Value is required for distribution format - File version</DistributionFormatVersion>
   <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
-  <OnlineResourceName>Protocol of Online Resource "</OnlineResourceName>
-  <OnlineResourceProtocol>" is not valid. Valid values are: </OnlineResourceProtocol>
+  <OnlineResourceProtocol>Protocol of Online Resource is not valid. Valid values are: </OnlineResourceProtocol>
 
   <MapResourcesREST>REST Map Resources should be available in english and french</MapResourcesREST>
   <MapResourcesRESTNumber>The number of ESRI REST Map Resources should be at most 2 (one for english and one for french)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -41,7 +41,7 @@
   <DistributionFormatVersion>Value is required for distribution format - File version</DistributionFormatVersion>
   <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
-  <OnlineResourceProtocol>Protocol is required for Online Resource: </OnlineResourceProtocol>
+  <OnlineResourceProtocol>Protocol (HTTP, HTTPS, FTP, ESRI REST: Map Service, OGC:WMS, OGC:WFS) is required for Online Resource: </OnlineResourceProtocol>
 
   <MapResourcesREST>REST Map Resources should be available in english and french</MapResourcesREST>
   <MapResourcesRESTNumber>The number of ESRI REST Map Resources should be at most 2 (one for english and one for french)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -41,8 +41,7 @@
   <DistributionFormatVersion>Une valeur est nécessaire pour: Version du Format de distribution</DistributionFormatVersion>
   <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
-  <OnlineResourceName>Protocole de ressource en ligne "</OnlineResourceName>
-  <OnlineResourceProtocol>" n'est pas valide. Les valeurs valides sont </OnlineResourceProtocol>
+  <OnlineResourceProtocol>Protocole de ressource en ligne n'est pas valide. Les valeurs valides sont </OnlineResourceProtocol>
 
   <MapResourcesREST>Les sources de la carte REST devraient être disponibles en anglais et en français</MapResourcesREST>
   <MapResourcesRESTNumber>Le nombre de sources de la carte ESRI REST devrait être au plus 2 (une pour l'anglais et une pour le français)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -41,6 +41,7 @@
   <DistributionFormatVersion>Une valeur est nécessaire pour: Version du Format de distribution</DistributionFormatVersion>
   <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
+  <OnlineResourceProtocol>Le protocole est requis pour la ressource en ligne: </OnlineResourceProtocol>
 
   <MapResourcesREST>Les sources de la carte REST devraient être disponibles en anglais et en français</MapResourcesREST>
   <MapResourcesRESTNumber>Le nombre de sources de la carte ESRI REST devrait être au plus 2 (une pour l'anglais et une pour le français)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -41,7 +41,8 @@
   <DistributionFormatVersion>Une valeur est nécessaire pour: Version du Format de distribution</DistributionFormatVersion>
   <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
-  <OnlineResourceProtocol>Le protocole (HTTP, HTTPS, FTP, ESRI REST: Map Service, OGC:WMS, OGC:WFS) est requis pour la ressource en ligne: </OnlineResourceProtocol>
+  <OnlineResourceName>Protocole de ressource en ligne "</OnlineResourceName>
+  <OnlineResourceProtocol>" n'est pas valide. Les valeurs valides sont </OnlineResourceProtocol>
 
   <MapResourcesREST>Les sources de la carte REST devraient être disponibles en anglais et en français</MapResourcesREST>
   <MapResourcesRESTNumber>Le nombre de sources de la carte ESRI REST devrait être au plus 2 (une pour l'anglais et une pour le français)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -41,7 +41,7 @@
   <DistributionFormatVersion>Une valeur est nécessaire pour: Version du Format de distribution</DistributionFormatVersion>
   <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
-  <OnlineResourceProtocol>Le protocole est requis pour la ressource en ligne: </OnlineResourceProtocol>
+  <OnlineResourceProtocol>Le protocole (HTTP, HTTPS, FTP, ESRI REST: Map Service, OGC:WMS, OGC:WFS) est requis pour la ressource en ligne: </OnlineResourceProtocol>
 
   <MapResourcesREST>Les sources de la carte REST devraient être disponibles en anglais et en français</MapResourcesREST>
   <MapResourcesRESTNumber>Le nombre de sources de la carte ESRI REST devrait être au plus 2 (une pour l'anglais et une pour le français)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -31,6 +31,32 @@
   <sch:let name="mainLanguageText" value="if ($mainLanguage = 'fra') then 'French' else 'English'"/>
   <sch:let name="mainLanguage2char" value="if ($mainLanguage = 'fra') then 'fr' else 'en'"/>
 
+  <xsl:function xmlns:sch="http://purl.oclc.org/dsdl/schematron" name="geonet:protocolListString" as="xs:string">
+    <xsl:param name="protocolNode"/>
+
+  	<xsl:variable name="v">
+  	  <xsl:for-each select="$protocolNode">
+        <xsl:sort select="lower-case(.)" order="ascending"/>
+        <xsl:value-of select="."/>
+        <xsl:if test="position() != last()">, </xsl:if>
+       </xsl:for-each>
+    </xsl:variable>
+
+  	<xsl:value-of select="$v"/>
+  </xsl:function>
+
+  <xsl:function xmlns:sch="http://purl.oclc.org/dsdl/schematron" name="geonet:appendLocaleMessage">
+    <xsl:param name="localeStringNode"/>
+    <xsl:param name="appendText" as="xs:string"/>
+
+    <xsl:for-each select="$localeStringNode">
+      <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:value-of select="concat($localeStringNode, $appendText)"/>
+      </xsl:copy>
+    </xsl:for-each>
+  </xsl:function>
+
   <!--- Metadata pattern -->
   <sch:pattern>
     <sch:title>$loc/strings/Metadata</sch:title>
@@ -411,7 +437,12 @@
 
     		<sch:let name="resourceName" value="gmd:name/gco:CharacterString/text()" />
 
-        <sch:assert test="$isValidProtocol">$loc/strings/concat(OnlineResourceProtocol, $resourceName)</sch:assert>
+    		<sch:let name="protocolListString" value="geonet:protocolListString($protocolList)"/>
+    		<sch:let name="resourceNameMsg" value="geonet:appendLocaleMessage($loc/strings/OnlineResourceName, $resourceName)"/>
+    		<sch:let name="protocolListMsg" value="geonet:appendLocaleMessage($loc/strings/OnlineResourceProtocol, $protocolListString)"/>
+    		<sch:let name="locMsg" value="geonet:appendLocaleMessage($resourceNameMsg, $protocolListMsg)"/>
+
+        <sch:assert test="$isValidProtocol">$locMsg</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -404,18 +404,14 @@
     </sch:rule>
 
     <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource">
-        <sch:let name="protocolMissing" value="not(string(gmd:protocol/gco:CharacterString))" />
-    		<sch:let name="isNotPlaceholderProtocol" value="(string(gmd:protocol/gco:CharacterString) != 'WWW:DOWNLOAD-1.0-http--download')"/>
-    		<!--TODO: Pass these values from ./loc/./labels.xml dynamically-->
-    		<sch:let name="isValidProtocol" value="string(gmd:protocol/gco:CharacterString) = 'HTTP'
-        												or string(gmd:protocol/gco:CharacterString) = 'HTTPS'
-        												or string(gmd:protocol/gco:CharacterString) = 'FTP'
-        												or string(gmd:protocol/gco:CharacterString) = 'ESRI REST: Map Service'
-        												or string(gmd:protocol/gco:CharacterString) = 'OGC:WMS'
-        												or string(gmd:protocol/gco:CharacterString) = 'OGC:WFS'"/>
+        <sch:let name="locLabel" value="document(concat('../loc/', $lang, '/labels.xml'))"/>
+        <sch:let name="protocolList" value="$locLabel/labels/element[@name='gmd:protocol']/helper/option"/>
+        <sch:let name="protocol" value="gmd:protocol/gco:CharacterString/text()"/>
+        <sch:let name="isValidProtocol" value="$protocol = $protocolList"/>
+
     		<sch:let name="resourceName" value="gmd:name/gco:CharacterString/text()" />
 
-        <sch:assert test="not($protocolMissing) and $isNotPlaceholderProtocol and $isValidProtocol">$loc/strings/concat(OnlineResourceProtocol, $resourceName)</sch:assert>
+        <sch:assert test="$isValidProtocol">$loc/strings/concat(OnlineResourceProtocol, $resourceName)</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -405,10 +405,17 @@
 
     <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource">
         <sch:let name="protocolMissing" value="not(string(gmd:protocol/gco:CharacterString))" />
-    		<sch:let name="isValidProtocol" value="(string(gmd:protocol/gco:CharacterString) != 'WWW:DOWNLOAD-1.0-http--download')"/>
+    		<sch:let name="isNotPlaceholderProtocol" value="(string(gmd:protocol/gco:CharacterString) != 'WWW:DOWNLOAD-1.0-http--download')"/>
+    		<!--TODO: Pass these values from ./loc/./labels.xml dynamically-->
+    		<sch:let name="isValidProtocol" value="string(gmd:protocol/gco:CharacterString) = 'HTTP'
+        												or string(gmd:protocol/gco:CharacterString) = 'HTTPS'
+        												or string(gmd:protocol/gco:CharacterString) = 'FTP'
+        												or string(gmd:protocol/gco:CharacterString) = 'ESRI REST: Map Service'
+        												or string(gmd:protocol/gco:CharacterString) = 'OGC:WMS'
+        												or string(gmd:protocol/gco:CharacterString) = 'OGC:WFS'"/>
     		<sch:let name="resourceName" value="gmd:name/gco:CharacterString/text()" />
 
-        <sch:assert test="not($protocolMissing) and $isValidProtocol">$loc/strings/concat(OnlineResourceProtocol, $resourceName)</sch:assert>
+        <sch:assert test="not($protocolMissing) and $isNotPlaceholderProtocol and $isValidProtocol">$loc/strings/concat(OnlineResourceProtocol, $resourceName)</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -403,6 +403,14 @@
 
     </sch:rule>
 
+    <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource">
+        <sch:let name="protocolMissing" value="not(string(gmd:protocol/gco:CharacterString))" />
+    		<sch:let name="isValidProtocol" value="(string(gmd:protocol/gco:CharacterString) != 'WWW:DOWNLOAD-1.0-http--download')"/>
+    		<sch:let name="resourceName" value="gmd:name/gco:CharacterString/text()" />
+
+        <sch:assert test="not($protocolMissing) and $isValidProtocol">$loc/strings/concat(OnlineResourceProtocol, $resourceName)</sch:assert>
+
+    </sch:rule>
 
     <!-- Online resource: MapResourcesREST, MapResourcesWMS-->
     <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution">

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -438,7 +438,7 @@
     		<sch:let name="resourceName" value="gmd:name/gco:CharacterString/text()" />
 
     		<sch:let name="protocolListString" value="geonet:protocolListString($protocolList)"/>
-    		<sch:let name="resourceNameMsg" value="geonet:appendLocaleMessage($loc/strings/OnlineResourceName, $resourceName)"/>
+
     		<sch:let name="protocolListMsg" value="geonet:appendLocaleMessage($loc/strings/OnlineResourceProtocol, $protocolListString)"/>
     		<sch:let name="locMsg" value="geonet:appendLocaleMessage($resourceNameMsg, $protocolListMsg)"/>
 


### PR DESCRIPTION
The issue is this field is mandatory and can still be saved as empty from the user input.

![image](https://user-images.githubusercontent.com/74916635/157717525-d6d818ea-0932-4b87-ab80-8c000155d1b8.png)


As result, the protocol will be filled with some default value "WWW:DOWNLOAD-1.0-http--download" which is not correct. There is correct value which is HTTP as quick compare.

![image](https://user-images.githubusercontent.com/74916635/157717656-908628da-52b7-4af6-821a-a4e71e95674c.png)


The validation rule will catch this default incorrect value and output error message as:
![image](https://user-images.githubusercontent.com/74916635/157718075-437682bb-3f49-4944-ba70-7aba23917b47.png)
