### PR TITLE
Configure the online resources dialog to display the layer selector for WMS layers and add the layer names in the service url. 

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "display": "radio",
-    "loadMapCapabilities": "false",
+    "loadMapCapabilities": "true",
     "types": [{
       "label": "addOnlinesrc",
       "sources": {
@@ -86,6 +86,9 @@
         "name": {"param": "thumbnail_desc"}
       }
     }],
-    "multilingualFields": ["name", "desc"]
+    "multilingualFields": ["name", "desc"],
+    "wmsResources": {
+      "addLayerNamesMode": "url"
+    }
   }
 }


### PR DESCRIPTION
Related to #6195