### PR TITLE
Increase the number of suggestions in the thesaurus picker and multicombiner directives, used for country, administrative area (province) and organisation names

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -84,13 +84,13 @@
 <!--    <for name="gmd:country" use="data-gn-country-selector-ec"/>-->
     <for name="gmd:country"
              use="data-gn-keyword-picker">
-          <directiveAttributes data-thesaurus-key="external.theme.ISO_Countries" data-focus-to-input="false"/>
+          <directiveAttributes data-thesaurus-key="external.theme.ISO_Countries" data-focus-to-input="false" data-number-of-suggestions="250"/>
 
     </for>
 
     <for name="gmd:administrativeArea"
          use="data-gn-keyword-picker">
-      <directiveAttributes data-thesaurus-key="external.theme.GC_State_Province" data-focus-to-input="false"/>
+      <directiveAttributes data-thesaurus-key="external.theme.GC_State_Province" data-focus-to-input="false" data-number-of-suggestions="75"/>
 
     </for>
 

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -228,7 +228,8 @@
               "eng": "Department/Agency",
               "fra": "Département/agence"
             },
-            "thesaurus": "external.theme.GC_Departments"
+            "thesaurus": "external.theme.GC_Departments",
+            "numberOfSuggestions": 200
           },
 
           {


### PR DESCRIPTION
Currently the number of default suggestions are limited to 20, update the suggestions for these fields to display all the values as thesaurus are not very big.

Requires to be back ported https://github.com/geonetwork/core-geonetwork/pull/6297