### PR TITLE
dataQuality/scope not mandatory

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schema/gmd/dataQuality.xsd
+++ b/src/main/plugin/iso19139.ca.HNAP/schema/gmd/dataQuality.xsd
@@ -502,7 +502,7 @@
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
-					<xs:element name="scope" type="gmd:DQ_Scope_PropertyType"/>
+					<xs:element name="scope" type="gmd:DQ_Scope_PropertyType" minOccurs="0"/>
 					<xs:element name="report" type="gmd:DQ_Element_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="lineage" type="gmd:LI_Lineage_PropertyType" minOccurs="0"/>
 				</xs:sequence>


### PR DESCRIPTION
When adding dataset link

![image](https://user-images.githubusercontent.com/74916635/168286742-695ba010-d1be-4397-8fb6-487f0f9fe870.png)

the dataquality node was added like this:
![image](https://user-images.githubusercontent.com/74916635/168286885-da0a931c-a410-4fc6-bcbf-d769034efe31.png)


The schema validation failed
![image](https://user-images.githubusercontent.com/74916635/168287680-a03b9d02-3fff-4882-a2e0-f35f54cb01db.png)


The xsl which is in ISO19139 has no such gmd:scope related code:
https://github.com/geonetwork/core-geonetwork/blob/29f9f5e3b9bc390d82e23d75efe29d9a757c8e72/schemas/iso19139/src/main/plugin/iso19139/process/source-add.xsl#L73-L83

So I would like to make this gmd:scope not mandatory in its schema.