### PR TITLE
Fix country and administrative area validations

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -67,6 +67,10 @@
   <CitedResponsiblePartyDeliveryPoint>Cited Responsible Party - Delivery Point should be empty or filled in English and French</CitedResponsiblePartyDeliveryPoint>
   <DistributorDeliveryPoint>Distributor - Delivery Point should be empty or filled in English and French</DistributorDeliveryPoint>
 
+  <ContactAdministrativeArea>Contact - Province/State should be empty or filled in English and French</ContactAdministrativeArea>
+  <CitedResponsiblePartyAdministrativeArea>Cited Responsible Party - Province/State should be empty or filled in English and French</CitedResponsiblePartyAdministrativeArea>
+  <DistributorAdministrativeArea>Distributor - Province/State should be empty or filled in English and French</DistributorAdministrativeArea>
+
   <ContactPhone>Contact - Phone should be empty or filled in English and French</ContactPhone>
   <CitedResponsiblePartyPhone>Cited Responsible Party - Phone should be empty or filled in English and French</CitedResponsiblePartyPhone>
   <DistributorPhone>Distributor - Phone should be empty or filled in English and French</DistributorPhone>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -68,6 +68,10 @@
   <CitedResponsiblePartyDeliveryPoint>Responsable de la ressource - Adresse devrait être vide ou rempli en anglais et en français</CitedResponsiblePartyDeliveryPoint>
   <DistributorDeliveryPoint>Responsable de la distribution - Adresse devrait être vide ou remplie en anglais et en français</DistributorDeliveryPoint>
 
+  <ContactAdministrativeArea>Responsable des métadonnées - Province/État devrait être vide ou remplie en anglais et en français</ContactAdministrativeArea>
+  <CitedResponsiblePartyAdministrativeArea>Responsable de la ressource - Province/État devrait être vide ou remplie en anglais et en français</CitedResponsiblePartyAdministrativeArea>
+  <DistributorAdministrativeArea>Responsable de la distribution - Province/État devrait être vide ou remplie en anglais et en français</DistributorAdministrativeArea>
+
   <ContactPhone>Responsable des métadonnées - Numéro de téléphone devrait être vide ou remplie en anglais et en français</ContactPhone>
   <CitedResponsiblePartyPhone>Responsable de la ressource - Numéro de téléphone devrait être vide ou rempli en anglais et en français</CitedResponsiblePartyPhone>
   <DistributorPhone>Responsable de la distribution - Numéro de téléphone devrait être vide ou rempli en anglais et en français</DistributorPhone>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -302,6 +302,21 @@
 
     </sch:rule>
 
+    <!-- Contact - Administrative area -->
+    <sch:rule context="//gmd:contact//gmd:administrativeArea">
+      <sch:let name="province-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_State_Province.rdf'), '\\', '/')))"/>
+
+      <sch:let name="administrativeArea" value="lower-case(gco:CharacterString)" />
+      <sch:let name="administrativeAreaOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:assert test="((not($administrativeArea) and not($administrativeAreaOtherLang)) or
+          (string($province-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $administrativeArea])
+          and
+          string($province-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $administrativeAreaOtherLang])))"
+      >$loc/strings/ContactAdministrativeArea</sch:assert>
+
+    </sch:rule>
+
 
     <!-- Contact - Delivery point -->
     <sch:rule context="//gmd:contact/*/gmd:contactInfo//gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
@@ -486,6 +501,20 @@
       >$loc/strings/ECCountry</sch:assert>
     </sch:rule>
 
+    <!-- Cited responsible party - Administrative area -->
+    <sch:rule context="//gmd:contact//gmd:administrativeArea">
+      <sch:let name="province-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_State_Province.rdf'), '\\', '/')))"/>
+
+      <sch:let name="administrativeArea" value="lower-case(gco:CharacterString)" />
+      <sch:let name="administrativeAreaOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:assert test="((not($administrativeArea) and not($administrativeAreaOtherLang)) or
+          (string($province-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $administrativeArea])
+          and
+          string($province-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $administrativeAreaOtherLang])))"
+      >$loc/strings/CitedResponsiblePartyAdministrativeArea</sch:assert>
+
+    </sch:rule>
 
     <!-- Cited Responsible Party - Position name -->
     <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:positionName
@@ -869,6 +898,21 @@
       <sch:assert
         test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
       >$loc/strings/DistributorPositionName</sch:assert>
+
+    </sch:rule>
+
+    <!-- Distributor contact - Administrative area -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact//gmd:administrativeArea">
+      <sch:let name="province-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_State_Province.rdf'), '\\', '/')))"/>
+
+      <sch:let name="administrativeArea" value="lower-case(gco:CharacterString)" />
+      <sch:let name="administrativeAreaOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:assert test="((not($administrativeArea) and not($administrativeAreaOtherLang)) or
+          (string($province-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $administrativeArea])
+          and
+          string($province-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $administrativeAreaOtherLang])))"
+      >$loc/strings/DistributorAdministrativeArea</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -294,12 +294,11 @@
       <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
       <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
-      <sch:assert test="(not($countryName) or
-          ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))
+      <sch:assert test="((not($countryName) and not($countryNameOtherLang)) or
+          (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName])
           and
-          (not($countryNameOtherLang) or
-          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))"
-          >$loc/strings/ECCountry</sch:assert>
+          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang])))"
+      >$loc/strings/ECCountry</sch:assert>
 
     </sch:rule>
 
@@ -480,12 +479,11 @@
       <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
       <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
-      <sch:assert test="(not($countryName) or
-          ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))
+      <sch:assert test="((not($countryName) and not($countryNameOtherLang)) or
+          (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName])
           and
-          (not($countryNameOtherLang) or
-          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))"
-          >$loc/strings/ECCountry</sch:assert>
+          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang])))"
+      >$loc/strings/ECCountry</sch:assert>
     </sch:rule>
 
 
@@ -881,12 +879,11 @@
       <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
       <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
-      <sch:assert test="(not($countryName) or
-          ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))
+      <sch:assert test="((not($countryName) and not($countryNameOtherLang)) or
+          (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName])
           and
-          (not($countryNameOtherLang) or
-          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))"
-          >$loc/strings/ECCountry</sch:assert>
+          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang])))"
+      >$loc/strings/ECCountry</sch:assert>
 
     </sch:rule>
 


### PR DESCRIPTION
- Country validation, when one of the language values is missing, it is not reporting the validation error.
- Administrative area validation was missing.