### PR TITLE
Metadata editor - data identification dates - support only date format

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -751,7 +751,8 @@
              data-label=""
              data-element-name="{name(gco:Date|gco:DateTime)}"
              data-element-ref="{concat('_X', gn:element/@ref)}"
-             data-hide-time="{if ($viewConfig/@hideTimeInCalendar = 'true') then 'true' else 'false'}">
+             data-hide-date-mode="true"
+             data-hide-time="{not(gco:DateTime)}">
         </div>
 
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -18,6 +18,7 @@
   <PublicationDate>Value is required for Metadata publication date</PublicationDate>
   <CreationDate>Value is required for Metadata creation date</CreationDate>
   <MissingDate>Value is required for Date</MissingDate>
+  <InvalidDate>Date format is not valid. Should be: YYYY-MM-DD</InvalidDate>
   <InvalidDateTypeCode>Date type is not valid</InvalidDateTypeCode>
   <BeginDate>Value is required for Begin Date</BeginDate>
   <BeginPositionFormat>Begin position format is not valid value</BeginPositionFormat>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -18,6 +18,7 @@
   <PublicationDate>Une valeur est nécessaire pour: Métadonnées date de publication</PublicationDate>
   <CreationDate>>Une valeur est nécessaire pour: Métadonnées date de création</CreationDate>
   <MissingDate>Une valeur est nécessaire pour la Date</MissingDate>
+  <InvalidDate>Le format de date n'est pas valide. Devrait être: YYYY-MM-DD</InvalidDate>
   <InvalidDateTypeCode>Le code de type de date n'est pas valide</InvalidDateTypeCode>
   <BeginDate>Une valeur est nécessaire pour la Date de début</BeginDate>
   <BeginPositionFormat>Le format de la date de début n’est pas valide</BeginPositionFormat>

--- a/src/main/plugin/iso19139.ca.HNAP/process/fix-date-format.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/fix-date-format.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                  xmlns:gco="http://www.isotc211.org/2005/gco"
+                  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:geonet="http://www.fao.org/geonetwork"
+                  exclude-result-prefixes="#all">
+
+  <xsl:template match="gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date[gco:Date and string-length(gco:Date) != 10]/gco:Date">
+
+    <xsl:variable name="value" select="." />
+
+    <xsl:copy>
+      <xsl:choose>
+        <xsl:when test="matches($value, '^\d{4}$')">
+          <xsl:value-of select="concat($value, '-01-01')"/>
+        </xsl:when>
+        <xsl:when test="matches($value, '^\d{4}-(0[1-9]|1[0-2])$')">
+          <xsl:value-of select="concat($value, '-01')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$value"/>
+        </xsl:otherwise>
+      </xsl:choose>
+
+    </xsl:copy>
+
+  </xsl:template>
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -239,6 +239,14 @@
       <sch:assert
         test="not($missing)"
       >$loc/strings/MissingDate</sch:assert>
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/MissingDate</sch:assert>
+
+      <sch:assert
+        test="($missing) or matches(., '^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
+      >$loc/strings/InvalidDate</sch:assert>
     </sch:rule>
 
 
@@ -440,7 +448,7 @@
     		<sch:let name="protocolListString" value="geonet:protocolListString($protocolList)"/>
 
         <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/OnlineResourceProtocol, $protocolListString)"/>
-     
+
         <sch:assert test="$isValidProtocol">$locMsg</sch:assert>
 
     </sch:rule>


### PR DESCRIPTION
Requires https://github.com/geonetwork/core-geonetwork/pull/6394

HNAP requires date format only for the data identification dates, with this change the fields in the editor display allow to select only dates in the metadata editor and does not allow to change to year/month or year modes.


![datepicker-dateonly](https://user-images.githubusercontent.com/1695003/173804678-41014d2a-7f47-4e72-b117-2914f233c2d7.png)

A validation rule is added also to validate the full date format: `YYYY-MM-DD`:

![validation-rule](https://user-images.githubusercontent.com/1695003/173810254-e1bd408a-afe9-4cf5-8c6e-05cd07c70bcd.png)

