### PR TITLE
Fix typo

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/services-remove.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/services-remove.xsl
@@ -23,5 +23,5 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="../../iso19139/process/service-remove.xsl"/>
+  <xsl:import href="../../iso19139/process/services-remove.xsl"/>
 </xsl:stylesheet>


### PR DESCRIPTION
There is a typo in services-remove.xsl filename.

![image](https://user-images.githubusercontent.com/74916635/176027007-d14a4f2c-490e-4412-b462-e9992521eb87.png)

Therefore the process is not found by Geonetwork. Also there the base xsl is named services.xml https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19139/src/main/plugin/iso19139/process/services-remove.xsl