### PR TITLE
Make online resource name mandatory and add validation rule

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -21,7 +21,7 @@
           "required": true,
           "tooltip": "gmd:URL"
         },
-        "name": {"tooltip": "gmd:name"},
+        "name": {"tooltip": "gmd:name", "required": true},
         "desc": {
           "tooltip": "gmd:description",
           "required": true,

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -35,6 +35,7 @@
 
   <OtherConstraintsNote2>Note (Other Constraints) is required in both languages</OtherConstraintsNote2>
 
+  <ResourceName>Online resource name is required in both language</ResourceName>
   <ResourceDescription>Online resource description is not valid. The format should be: ContentType;Format;Lang</ResourceDescription>
   <ResourceDescriptionContentType>Online resource description content type is not valid. Valid values are: Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
   <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -35,6 +35,7 @@
 
   <OtherConstraintsNote2>Autres contraintes devrait être vide ou rempli en anglais et en français</OtherConstraintsNote2>
 
+  <ResourceName>Le nom des ressources en ligne est obligatoire dans les deux langues</ResourceName>
   <ResourceDescription>La description des ressources en ligne n'est pas valide. Le format devrait être : TypeContenu;Format;Lang</ResourceDescription>
   <ResourceDescriptionContentType>Le type de contenu dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
   <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -791,6 +791,16 @@
         test="not($missingLanguageForMapService)"
       >$loc/strings/MapServicesLanguage</sch:assert>
 
+      <!-- Resource name -->
+      <sch:let name="missingResourceName" value="not(string(gmd:CI_OnlineResource/gmd:name/gco:CharacterString))" />
+
+      <sch:let name="missingResourceNameOtherLang" value="not(string(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:let name="locMsgResourceName" value="geonet:prependLocaleMessage($loc/strings/ResourceName, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+
+      <sch:assert
+        test="not($missingResourceName) and not($missingResourceNameOtherLang)"
+      >$locMsgResourceName</sch:assert>
 
       <!-- ResourceDescription -->
       <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />


### PR DESCRIPTION
This change displays the resource name field in the online resources panel as a mandatory field and adds a validation rule to verify that the value is filled in both languages.