### PR TITLE
Add validation for srv:SV_ServiceIdentification

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -48,4 +48,6 @@
   <MapResourcesWMS>WMS Map Resources should be available in english and french</MapResourcesWMS>
   <MapResourcesWMSNumber>The number of WMS Map Resources should be at most 2 (one for english and one for french)</MapResourcesWMSNumber>
 
+  <ServiceNamespace>srv:SV_ServiceIdentification is misplaced for gmd:MD_ScopeCode: </ServiceNamespace>
+
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -48,4 +48,6 @@
   <MapResourcesWMS>Les sources de la carte WMS devraient être disponibles en anglais et en français</MapResourcesWMS>
   <MapResourcesWMSNumber>Le nombre de sources de la carte WMS devrait être au plus 2 (une pour l'anglais et une pour le français)</MapResourcesWMSNumber>
 
+  <ServiceNamespace>srv:SV_ServiceIdentification est mal placé pour gmd:MD_ScopeCode: </ServiceNamespace>
+
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -406,6 +406,14 @@
         test="$isValid or $missing"
       >$loc/strings/InvalidUseConstraints</sch:assert>
     </sch:rule>
+
+    <sch:rule context="//gmd:identificationInfo">
+      <sch:let name="serviceLevel" value="string(parent::gmd:MD_Metadata/gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue='RI_631'])"/>
+      <sch:let name="serviceIndNode" value="string( //srv:SV_ServiceIdentification | //*[@gco:isoType='srv:SV_ServiceIdentification'] )"/>
+      <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/ServiceNamespace, $hierarchyLevel)"/>
+
+      <sch:assert test="($serviceLevel and $serviceIndNode) or (not($serviceLevel) and not ($serviceIndNode) )">$locMsg</sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 
@@ -440,7 +448,7 @@
     		<sch:let name="protocolListString" value="geonet:protocolListString($protocolList)"/>
 
         <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/OnlineResourceProtocol, $protocolListString)"/>
-     
+
         <sch:assert test="$isValidProtocol">$locMsg</sch:assert>
 
     </sch:rule>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -408,6 +408,7 @@
     </sch:rule>
 
     <sch:rule context="//gmd:identificationInfo">
+      <sch:let name="hierarchyLevel" value="string(parent::gmd:MD_Metadata/gmd:hierarchyLevel/gmd:MD_ScopeCode)"/>
       <sch:let name="serviceLevel" value="string(parent::gmd:MD_Metadata/gmd:hierarchyLevel/gmd:MD_ScopeCode[@codeListValue='RI_631'])"/>
       <sch:let name="serviceIndNode" value="string( //srv:SV_ServiceIdentification | //*[@gco:isoType='srv:SV_ServiceIdentification'] )"/>
       <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/ServiceNamespace, $hierarchyLevel)"/>


### PR DESCRIPTION
This legacy service type metadata do existed when we imported from other system.

![image](https://user-images.githubusercontent.com/74916635/177215334-d8e395ae-fc63-4a8b-82d9-3a0fb4baf602.png)


The <gmd:MD_DataIdentification> is only for dataset type not service. Service metadata will have srv:SV_ServiceIdentification element name instead. This validation rule just to ensure srv:SV_ServiceIdentification must be presented with gmd:MD_Metadata/gmd:hierarchyLevel/gmd:MD_ScopeCode='service'