### PR TITLE
support double click error redirect

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -229,11 +229,11 @@
 
     </sch:rule>
 
-    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date
-            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date
-            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date">
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date">
 
-      <sch:let name="missing" value="not(string(gco:Date)) and not(string(gco:DateTime))
+      <sch:let name="missing" value="not(string(gmd:date/gco:Date)) and not(string(gmd:date/gco:DateTime))
                     " />
 
       <sch:assert


### PR DESCRIPTION
It is an ongoing issue that the double click on some validation errors cannot redirect the screen to the web field. This code change will just fix one of them which is creation/publication date in identification section.

![image](https://user-images.githubusercontent.com/74916635/179270828-a6080642-22d8-4386-80ed-0d154870eef9.png)


For rest of the none working double click errors, I will create an issue to summarize them together.