### PR TITLE
Support for a process to update the metadata content when creating a duplicate

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/duplicate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/duplicate-metadata.xsl
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                  xmlns:gco="http://www.isotc211.org/2005/gco"
+                  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  xmlns:xlink="http://www.w3.org/1999/xlink"
+                  exclude-result-prefixes="#all">
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:variable name="doiName"
+                select="'Digital Object Identifier (DOI)'"/>
+
+  <xsl:template match="/root">
+    <xsl:apply-templates select="*[1]"/>
+  </xsl:template>
+
+
+  <!-- Remove DOI identifiers -->
+  <xsl:template match="gmd:identifier[
+                                contains(*/gmd:code/*/text(), 'datacite.org/doi/')
+                                or contains(*/gmd:code/*/text(), 'doi.org')
+                                or contains(*/gmd:code/*/@xlink:href, 'doi.org')]" />
+
+  <!-- Remove DOI links -->
+  <xsl:template match="gmd:onLine[*/gmd:name/gco:CharacterString = $doiName]" />
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.ca.HNAP/duplicate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/duplicate-metadata.xsl
@@ -30,6 +30,12 @@
 
   <xsl:output method="xml" indent="yes"/>
 
+  <!-- ISO19139 uses the protocol with value 'DOI' to match the online resource, but
+       HNAP uses for DOI resources the protocol value 'HTTP' that is used for other type
+       of online resources. 
+       
+       Changed in HNAP to use the online resource name.   
+  -->     
   <xsl:variable name="doiName"
                 select="'Digital Object Identifier (DOI)'"/>
 


### PR DESCRIPTION
This change requires https://github.com/geonetwork/core-geonetwork/pull/6507 to be back ported to `3.12.x` branch.

Currently, it is used to remove DOI information when duplicating or creating a child from a metadata, but can be extended with additional use cases if needed.
