### PR TITLE
Update iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl

### DIFF
--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -120,10 +120,9 @@
   </xsl:template>
 
   <!--Add default LocalisedCharacterString to thumbnail -->
-  <xsl:template match="gmd:fileDescription">
+  <xsl:template match="gmd:fileDescription[gco:CharacterString/text() != ''  and not(gmd:PT_FreeText)]">
     <xsl:copy copy-namespaces="no">
-      <xsl:if test="not(gmd:PT_FreeText)">
-        <gco:CharacterString><xsl:value-of select="./gco:CharacterString/text()"/></gco:CharacterString>
+      <xsl:apply-templates select="node()|@*"/>
         <gmd:PT_FreeText>
           <gmd:textGroup>
             <xsl:choose>
@@ -140,8 +139,6 @@
             </xsl:choose>
           </gmd:textGroup>
         </gmd:PT_FreeText>
-      </xsl:if>
-      <xsl:apply-templates select="node()/gco:CharacterString|@*"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -122,23 +122,26 @@
   <!--Add default LocalisedCharacterString to thumbnail -->
   <xsl:template match="gmd:fileDescription">
     <xsl:copy copy-namespaces="no">
-      <gmd:PT_FreeText>
-        <gmd:textGroup>
-          <xsl:choose>
-            <xsl:when test="$mainLanguage='eng'">
-              <gmd:LocalisedCharacterString locale="#fra">
-                <xsl:value-of select="./gco:CharacterString/text()"/>
-              </gmd:LocalisedCharacterString>
-            </xsl:when>
-            <xsl:otherwise>
-              <gmd:LocalisedCharacterString locale="#eng">
-                <xsl:value-of select="/gco:CharacterString"/>
-              </gmd:LocalisedCharacterString>
-            </xsl:otherwise>
-          </xsl:choose>
-        </gmd:textGroup>
-      </gmd:PT_FreeText>
-      <xsl:apply-templates select="node()|@*"/>
+      <xsl:if test="not(gmd:PT_FreeText)">
+        <gco:CharacterString><xsl:value-of select="./gco:CharacterString/text()"/></gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <xsl:choose>
+              <xsl:when test="$mainLanguage='eng'">
+                <gmd:LocalisedCharacterString locale="#fra">
+                  <xsl:value-of select="./gco:CharacterString/text()"/>
+                </gmd:LocalisedCharacterString>
+              </xsl:when>
+              <xsl:otherwise>
+                <gmd:LocalisedCharacterString locale="#eng">
+                  <xsl:value-of select="./gco:CharacterString/text()"/>
+                </gmd:LocalisedCharacterString>
+              </xsl:otherwise>
+            </xsl:choose>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </xsl:if>
+      <xsl:apply-templates select="node()/gco:CharacterString|@*"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -119,6 +119,29 @@
     </xsl:copy>
   </xsl:template>
 
+  <!--Add default LocalisedCharacterString to thumbnail -->
+  <xsl:template match="gmd:fileDescription">
+    <xsl:copy copy-namespaces="no">
+      <gmd:PT_FreeText>
+        <gmd:textGroup>
+          <xsl:choose>
+            <xsl:when test="$mainLanguage='eng'">
+              <gmd:LocalisedCharacterString locale="#fra">
+                <xsl:value-of select="./gco:CharacterString/text()"/>
+              </gmd:LocalisedCharacterString>
+            </xsl:when>
+            <xsl:otherwise>
+              <gmd:LocalisedCharacterString locale="#eng">
+                <xsl:value-of select="/gco:CharacterString"/>
+              </gmd:LocalisedCharacterString>
+            </xsl:otherwise>
+          </xsl:choose>
+        </gmd:textGroup>
+      </gmd:PT_FreeText>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>


### PR DESCRIPTION
During iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP conversion when importing metadata, the resource name in the thumbnail is missing.
![image](https://user-images.githubusercontent.com/74916635/190234650-564fc3d0-9165-4fb0-a407-d2a272dd3562.png)

Therefore, current schematron validation will fail
![image](https://user-images.githubusercontent.com/74916635/190234745-775fc0e5-dc21-4630-8d1c-378ee4fc243d.png)


After the fix, the default name will be added

![image](https://user-images.githubusercontent.com/74916635/190235004-11c02d1a-cb55-4b27-8f69-833c0021531b.png)


No more validation error on thumbnail part.
![image](https://user-images.githubusercontent.com/74916635/190235085-0af939ef-a06f-463a-93bb-6a482ef1c50a.png)
