### PR TITLE
config data-gn-onlinesrc-list

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -310,7 +310,8 @@
     <view name="default" displayTooltips="true" displayTooltipsMode="icon">
       <sidePanel>
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
-        <directive data-gn-onlinesrc-list=""/>
+        <directive data-gn-onlinesrc-list=""
+                   data-types="onlinesrc|parent|dataset|source|sibling|associated"/>
       </sidePanel>
 
       <tab id="default" default="true" mode="flat">


### PR DESCRIPTION
This PR is to remove "Link to a Service" and "Link to a Feature" from the online src drop down list. 

The original view is 
![image](https://user-images.githubusercontent.com/74916635/208444362-c61e09a0-d440-4768-9ed8-487bc9946c2a.png)

here is the new view:

![image](https://user-images.githubusercontent.com/74916635/208444440-f9a54bad-424d-4806-9a15-d8c6aa41d054.png)
