### PR TITLE
Add distribution format

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -502,6 +502,24 @@
                    or="distributionFormat"/>
           </section>
 
+          <action type="add" name="distributionFormat" or="distributionFormat"
+                  in="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution">
+            <template>
+              <snippet>
+                <gmd:distributionFormat>
+                  <gmd:MD_Format>
+                    <gmd:name>
+                      <gco:CharacterString>DOC</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="missing">
+                      <gco:CharacterString/>
+                    </gmd:version>
+                  </gmd:MD_Format>
+                </gmd:distributionFormat>
+              </snippet>
+            </template>
+          </action>
+
 
           <field xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact"
                  in="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -509,7 +509,7 @@
                 <gmd:distributionFormat>
                   <gmd:MD_Format>
                     <gmd:name>
-                      <gco:CharacterString>DOC</gco:CharacterString>
+                      <gco:CharacterString></gco:CharacterString>
                     </gmd:name>
                     <gmd:version gco:nilReason="missing">
                       <gco:CharacterString/>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -509,7 +509,7 @@
                 <gmd:distributionFormat>
                   <gmd:MD_Format>
                     <gmd:name>
-                      <gco:CharacterString></gco:CharacterString>
+                      <gco:CharacterString/>
                     </gmd:name>
                     <gmd:version gco:nilReason="missing">
                       <gco:CharacterString/>


### PR DESCRIPTION
Solution for this issue https://github.com/metadata101/iso19139.ca.HNAP/issues/285
This change gives the "add distribution format" button visible.
![image](https://user-images.githubusercontent.com/74916635/210925652-09852b02-bb97-40fc-a3f8-211c6c151345.png)

Upon clicking the button, this section/template/snippet will be duplicated to multiple

![image](https://user-images.githubusercontent.com/74916635/210925789-9f4a4833-4e97-4d31-b3c9-5fc1adb348c2.png)
