### PR TITLE
Unify the date fields configuration in English and French to be stored in the index

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/default.xsl
@@ -167,7 +167,7 @@
                  index="true"/>
 
           <xsl:if test="$useDateAsTemporalExtent">
-            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
           </xsl:if>
         </xsl:for-each>
 
@@ -184,7 +184,7 @@
                  index="true"/>
 
           <xsl:if test="$useDateAsTemporalExtent">
-            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
           </xsl:if>
         </xsl:for-each>
 
@@ -192,10 +192,10 @@
         <!-- Publication -->
         <xsl:for-each
           select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_367']/gmd:date">
-          <Field name="publicationDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+          <Field name="publicationDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
 
           <xsl:if test="$useDateAsTemporalExtent">
-            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
           </xsl:if>
         </xsl:for-each>
 
@@ -253,9 +253,9 @@
               </xsl:call-template>
             </xsl:variable>
 
-            <Field name="tempExtentBegin" string="{lower-case(substring-before($times,'|'))}" store="false"
+            <Field name="tempExtentBegin" string="{lower-case(substring-before($times,'|'))}" store="true"
                    index="true"/>
-            <Field name="tempExtentEnd" string="{lower-case(substring-after($times,'|'))}" store="false" index="true"/>
+            <Field name="tempExtentEnd" string="{lower-case(substring-after($times,'|'))}" store="true" index="true"/>
           </xsl:for-each>
 
         </xsl:for-each>

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -176,7 +176,7 @@
 
         <xsl:for-each
           select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_368']/gmd:date">
-          <Field name="revisionDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+          <Field name="revisionDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
 
           <Field name="createDateMonth"
                  string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 8)}" store="true"
@@ -186,7 +186,7 @@
                  index="true"/>
 
           <xsl:if test="$useDateAsTemporalExtent">
-            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
           </xsl:if>
         </xsl:for-each>
 
@@ -202,16 +202,16 @@
                  index="true"/>
 
           <xsl:if test="$useDateAsTemporalExtent">
-            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
           </xsl:if>
         </xsl:for-each>
 
         <xsl:for-each
           select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='RI_367']/gmd:date">
-          <Field name="publicationDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+          <Field name="publicationDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
 
           <xsl:if test="$useDateAsTemporalExtent">
-            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="false" index="true"/>
+            <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}" store="true" index="true"/>
           </xsl:if>
         </xsl:for-each>
 


### PR DESCRIPTION
Otherwise the UI does show them or not depending on the UI language:

Dates in metadata displayed in English:

![english-ui](https://user-images.githubusercontent.com/1695003/217853915-5f41cfa9-6a74-43a4-ac4a-073cd7a0ddd6.png)

Dates in metadata displayed in French:

![french-ui](https://user-images.githubusercontent.com/1695003/217854035-156c0c88-11db-4bbe-9852-665e623221d5.png)

