### PR TITLE
remove gmd:characterSet inflating to utf8

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -116,11 +116,7 @@
       <xsl:apply-templates select="gmd:fileIdentifier" />
       <xsl:apply-templates select="gmd:language" />
       <xsl:apply-templates select="gmd:characterSet" />
-      <xsl:if test="not(gmd:characterSet)">
-        <gmd:characterSet>
-          <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
-        </gmd:characterSet>
-      </xsl:if>
+
 
       <xsl:apply-templates select="gmd:parentIdentifier" />
       <xsl:apply-templates select="gmd:hierarchyLevel" />

--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -116,7 +116,11 @@
       <xsl:apply-templates select="gmd:fileIdentifier" />
       <xsl:apply-templates select="gmd:language" />
       <xsl:apply-templates select="gmd:characterSet" />
-
+      <xsl:if test="not(gmd:MD_Metadata/gmd:characterSet)">
+        <gmd:characterSet>
+          <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+        </gmd:characterSet>
+      </xsl:if>
 
       <xsl:apply-templates select="gmd:parentIdentifier" />
       <xsl:apply-templates select="gmd:hierarchyLevel" />


### PR DESCRIPTION
The characterSet in identification (i.e. gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:characterSet)

![image](https://user-images.githubusercontent.com/74916635/223194715-3049098a-ce3d-46cc-af18-522acec33d67.png)

is not mandatory. Bu the inflator always inflate this field to UTF8. This PR is to disable such inflating mechanism.