### PR TITLE
Email address format validation

### DIFF
--- a/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
+++ b/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class XslUtilHnap {
@@ -253,5 +255,17 @@ public class XslUtilHnap {
         }
 
         return result;
+    }
+
+    /**
+     * Validate if email format.
+     * See more info: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+     * @param emailAddress
+     * @return boolean
+     */
+    public static boolean isEmailFormat(String emailAddress) {
+        Pattern pattern = Pattern.compile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$");
+        Matcher matcher = pattern.matcher(emailAddress);
+        return matcher.matches();
     }
 }

--- a/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
+++ b/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
@@ -258,12 +258,17 @@ public class XslUtilHnap {
     }
 
     /**
-     * Validate if email format.
+     * Validate if email format. Empty email is allowed based on parameter of allowEmptyEmail.
      * See more info: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
-     * @param emailAddress
+     * @param emailAddress email address to validate the pattern
+     * @param allowEmptyEmail allow empty email input. The empty email was handled within the schematron already. This flag allows to ignore repeat checking.
      * @return boolean
      */
-    public static boolean isEmailFormat(String emailAddress) {
+    public static boolean isEmailFormat(String emailAddress, boolean allowEmptyEmail) {
+        if (allowEmptyEmail && org.apache.commons.lang3.StringUtils.isEmpty(emailAddress)) {
+            return true;
+        }
+
         Pattern pattern = Pattern.compile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$");
         Matcher matcher = pattern.matcher(emailAddress);
         return matcher.matches();

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -83,4 +83,6 @@
   <ECThesaurusOrg>Thesaurus cited responsible party organisation is required</ECThesaurusOrg>
   <ECThesaurusRole>Thesaurus cited responsible party role is required</ECThesaurusRole>
   <ECThesaurusEmail>Thesaurus cited responsible party email is required</ECThesaurusEmail>
+
+  <ElectronicMailFormat>Electronic mail address format is invalid (for example abc@abc.com)</ElectronicMailFormat>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
@@ -56,4 +56,6 @@
   <ResourceDescriptionContentType>Online resource description content type is not valid. Valid values are: Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
   <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
+
+  <ElectronicMailFormat>Electronic mail address format is invalid (for example abc@abc.com)</ElectronicMailFormat>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -84,4 +84,6 @@
   <ECThesaurusOrg>Le nom de l’organisation responsable du thésaurus est requis</ECThesaurusOrg>
   <ECThesaurusRole>Le rôle du responsable du thesaurus est requis</ECThesaurusRole>
   <ECThesaurusEmail>Le courriel du responsable du thésaurus est requis</ECThesaurusEmail>
+
+  <ElectronicMailFormat>Le format de l'adresse électronique n'est pas valide (par exemple abc@abc.com)</ElectronicMailFormat>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
@@ -56,4 +56,6 @@
   <ResourceDescriptionContentType>Le type de contenu dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
   <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
+
+  <ElectronicMailFormat>Le format de l'adresse électronique n'est pas valide (par exemple abc@abc.com)</ElectronicMailFormat>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -357,8 +357,8 @@
 
       <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
-      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang, true())"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
@@ -585,8 +585,8 @@
 
       <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
-      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang, true())"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
@@ -695,8 +695,8 @@
 
       <sch:let name="missingEmailOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
-      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang, true())"/>
 
       <sch:assert
         test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail) and not($missingEmailOtherLang))))"
@@ -1003,8 +1003,8 @@
 
       <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
-   	  <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
+   	  <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang, true())"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -164,18 +164,6 @@
     />
   </xsl:function>
 
-  <!--Check email format-->
-    <xsl:function name="geonet:isEmailAddressFormat" as="xs:boolean">
-      <xsl:param name="inputEmailAdress"/>
-          <xsl:choose>
-              <xsl:when test="matches($inputEmailAdress, '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9._%+-]+\.[a-zA-Z0-9]+$')">
-                  <xsl:value-of select="true()"/>
-              </xsl:when>
-              <xsl:otherwise>
-                  <xsl:value-of select="false()"/>
-              </xsl:otherwise>
-          </xsl:choose>
-    </xsl:function>
 
   <!-- =============================================================
   EC schematron rules for multilingual validation in metadata editor:
@@ -369,8 +357,8 @@
 
       <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
-      <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
@@ -597,8 +585,8 @@
 
       <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
-      <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
@@ -707,8 +695,8 @@
 
       <sch:let name="missingEmailOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
-      <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail) and not($missingEmailOtherLang))))"
@@ -1015,8 +1003,8 @@
 
       <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
 
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
-   	  <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+   	  <sch:let name="isOtherLangEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -164,6 +164,19 @@
     />
   </xsl:function>
 
+  <!--Check email format-->
+    <xsl:function name="geonet:isEmailAddressFormat" as="xs:boolean">
+      <xsl:param name="inputEmailAdress"/>
+          <xsl:choose>
+              <xsl:when test="matches($inputEmailAdress, '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9._%+-]+\.[a-zA-Z0-9]+$')">
+                  <xsl:value-of select="true()"/>
+              </xsl:when>
+              <xsl:otherwise>
+                  <xsl:value-of select="false()"/>
+              </xsl:otherwise>
+          </xsl:choose>
+    </xsl:function>
+
   <!-- =============================================================
   EC schematron rules for multilingual validation in metadata editor:
   ============================================================= -->
@@ -348,17 +361,23 @@
 
     <!-- Contact - Electronic Mail -->
     <sch:rule context="//gmd:contact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+      <sch:let name="emailAddress" value="string(gco:CharacterString)" />
+      <sch:let name="emailAddressOtherLang" value="string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="missing" value="not($emailAddress)
                 or (@gco:nilReason)" />
 
-      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
+
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
 
       >$loc/strings/ContactElectronicMail</sch:assert>
 
+      <sch:assert test="string($isEmailAddressFormat) ='true' and string($isOtherLangEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
     </sch:rule>
 
 
@@ -570,16 +589,23 @@
     <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
                       |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
                       |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+      <sch:let name="emailAddress" value="string(gco:CharacterString)" />
+      <sch:let name="emailAddressOtherLang" value="string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="missing" value="not($emailAddress)
                 or (@gco:nilReason)" />
 
-      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
+
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
 
       >$loc/strings/CitedResponsiblePartyElectronicMail</sch:assert>
+
+      <sch:assert test="string($isEmailAddressFormat) ='true' and string($isOtherLangEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
 
     </sch:rule>
 
@@ -673,14 +699,22 @@
 
       <sch:let name="emailPresent" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress) > 0" />
 
-      <sch:let name="missingEmail" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString))
+      <sch:let name="emailAddress" value="string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString)" />
+      <sch:let name="emailAddressOtherLang" value="string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:let name="missingEmail" value="not($emailAddress)
               or (@gco:nilReason)" />
 
-      <sch:let name="missingEmailOtherLang" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingEmailOtherLang" value="not($emailAddressOtherLang)" />
+
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail) and not($missingEmailOtherLang))))"
       >$loc/strings/ECThesaurusEmail</sch:assert>
+
+      <sch:assert test="string($isEmailAddressFormat) ='true' and string($isOtherLangEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
     </sch:rule>
 
     <!-- Supplemental information -->
@@ -973,16 +1007,23 @@
 
     <!-- Distributor - Electronic Mail -->
     <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+      <sch:let name="emailAddress" value="string(gco:CharacterString)" />
+      <sch:let name="emailAddressOtherLang" value="string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
 
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="missing" value="not($emailAddress)
                 or (@gco:nilReason)" />
 
-      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingOtherLang" value="not($emailAddressOtherLang)" />
+
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+   	  <sch:let name="isOtherLangEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddressOtherLang)"/>
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"
 
       >$loc/strings/DistributorElectronicMail</sch:assert>
+
+      <sch:assert test="string($isEmailAddressFormat) ='true' and string($isOtherLangEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -160,6 +160,19 @@
     />
   </xsl:function>
 
+  <!--Check email format-->
+  <xsl:function name="geonet:isEmailAddressFormat" as="xs:boolean">
+    <xsl:param name="inputEmailAdress"/>
+        <xsl:choose>
+            <xsl:when test="matches($inputEmailAdress, '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9._%+-]+\.[a-zA-Z0-9]+$')">
+                <xsl:value-of select="true()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="false()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+  </xsl:function>
+
   <!-- =============================================================
   EC schematron rules for multilingual validation in metadata editor:
   ============================================================= -->
@@ -220,14 +233,19 @@
 
     <!-- Contact - Electronic Mail -->
     <sch:rule context="//gmd:contact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+      <sch:let name="emailAddress" value="string(gco:CharacterString)" />
 
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="missing" value="not($emailAddress)
                 or (@gco:nilReason)" />
+
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
 
       <sch:assert
         test="not($missing)"
 
       >$loc/strings/ContactElectronicMail</sch:assert>
+
+      <sch:assert test="string($isEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
 
     </sch:rule>
   </sch:pattern>
@@ -318,14 +336,16 @@
                       |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
                       |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
 
-      <sch:let name="missing" value="not(string(gco:CharacterString))
-                or (@gco:nilReason)" />
-
+      <sch:let name="emailAddress" value="string(gco:CharacterString)" />
+      <sch:let name="missing" value="not($emailAddress) or (@gco:nilReason)" />
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
 
       <sch:assert
         test="not($missing)"
 
       >$loc/strings/CitedResponsiblePartyElectronicMail</sch:assert>
+
+      <sch:assert test="string($isEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
 
     </sch:rule>
 
@@ -394,12 +414,17 @@
 
       <sch:let name="emailPresent" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress) > 0" />
 
-      <sch:let name="missingEmail" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString))
+      <sch:let name="emailAddress" value="string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString)" />
+      <sch:let name="missingEmail" value="not($emailAddress)
               or (@gco:nilReason)" />
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
 
       <sch:assert
         test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail))))"
       >$loc/strings/ECThesaurusEmail</sch:assert>
+
+      <sch:assert test="string($isEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
+
     </sch:rule>
 
     <!-- Note (Other constraints) -->
@@ -555,13 +580,18 @@
     <!-- Distributor - Electronic Mail -->
     <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
 
-      <sch:let name="missing" value="not(string(gco:CharacterString))
+      <sch:let name="emailAddress" value="string(gco:CharacterString)" />
+      <sch:let name="missing" value="not($emailAddress)
                   or (@gco:nilReason)" />
+      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
 
       <sch:assert
         test="not($missing)"
 
       >$loc/strings/DistributorElectronicMail</sch:assert>
+
+
+      <sch:assert test="string($isEmailAddressFormat) ='true'">$loc/strings/ElectronicMailFormat</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -160,18 +160,6 @@
     />
   </xsl:function>
 
-  <!--Check email format-->
-  <xsl:function name="geonet:isEmailAddressFormat" as="xs:boolean">
-    <xsl:param name="inputEmailAdress"/>
-        <xsl:choose>
-            <xsl:when test="matches($inputEmailAdress, '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9._%+-]+\.[a-zA-Z0-9]+$')">
-                <xsl:value-of select="true()"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="false()"/>
-            </xsl:otherwise>
-        </xsl:choose>
-  </xsl:function>
 
   <!-- =============================================================
   EC schematron rules for multilingual validation in metadata editor:
@@ -238,7 +226,7 @@
       <sch:let name="missing" value="not($emailAddress)
                 or (@gco:nilReason)" />
 
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
 
       <sch:assert
         test="not($missing)"
@@ -338,7 +326,7 @@
 
       <sch:let name="emailAddress" value="string(gco:CharacterString)" />
       <sch:let name="missing" value="not($emailAddress) or (@gco:nilReason)" />
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
 
       <sch:assert
         test="not($missing)"
@@ -417,7 +405,7 @@
       <sch:let name="emailAddress" value="string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString)" />
       <sch:let name="missingEmail" value="not($emailAddress)
               or (@gco:nilReason)" />
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
 
       <sch:assert
         test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail))))"
@@ -583,7 +571,7 @@
       <sch:let name="emailAddress" value="string(gco:CharacterString)" />
       <sch:let name="missing" value="not($emailAddress)
                   or (@gco:nilReason)" />
-      <sch:let name="isEmailAddressFormat" value="geonet:isEmailAddressFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
 
       <sch:assert
         test="not($missing)"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -226,7 +226,7 @@
       <sch:let name="missing" value="not($emailAddress)
                 or (@gco:nilReason)" />
 
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
 
       <sch:assert
         test="not($missing)"
@@ -326,7 +326,7 @@
 
       <sch:let name="emailAddress" value="string(gco:CharacterString)" />
       <sch:let name="missing" value="not($emailAddress) or (@gco:nilReason)" />
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
 
       <sch:assert
         test="not($missing)"
@@ -405,7 +405,7 @@
       <sch:let name="emailAddress" value="string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString)" />
       <sch:let name="missingEmail" value="not($emailAddress)
               or (@gco:nilReason)" />
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
 
       <sch:assert
         test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail))))"
@@ -571,7 +571,7 @@
       <sch:let name="emailAddress" value="string(gco:CharacterString)" />
       <sch:let name="missing" value="not($emailAddress)
                   or (@gco:nilReason)" />
-      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress)"/>
+      <sch:let name="isEmailAddressFormat" value="XslUtilHnap:isEmailFormat($emailAddress, true())"/>
 
       <sch:assert
         test="not($missing)"

--- a/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
+++ b/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link XslUtilHnap} class.
@@ -130,6 +132,18 @@ public class XslUtilHnapTest {
         actualResult = XslUtilHnap.removeFromUrl(paramsToRemove, "invalid url");
         assertEquals("invalid url", "invalid url", actualResult);
 
+
+    }
+
+    @Test
+    public void testIsEmailAddress() {
+        assertTrue(XslUtilHnap.isEmailFormat("o'brian.test@localhost"));
+        assertTrue(XslUtilHnap.isEmailFormat("o'brian.test@localhost.com"));
+
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@localhost.com."));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@localhost."));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@"));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test"));
 
     }
 

--- a/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
+++ b/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
@@ -137,13 +137,17 @@ public class XslUtilHnapTest {
 
     @Test
     public void testIsEmailAddress() {
-        assertTrue(XslUtilHnap.isEmailFormat("o'brian.test@localhost"));
-        assertTrue(XslUtilHnap.isEmailFormat("o'brian.test@localhost.com"));
+        assertTrue(XslUtilHnap.isEmailFormat("o'brian.test@localhost", false));
+        assertTrue(XslUtilHnap.isEmailFormat("o'brian.test@localhost.com", false));
 
-        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@localhost.com."));
-        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@localhost."));
-        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@"));
-        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test"));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@localhost.com.", false));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@localhost.", false));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test@", false));
+        assertFalse(XslUtilHnap.isEmailFormat("o'brian.test", false));
+
+        assertFalse(XslUtilHnap.isEmailFormat("",false));
+        assertTrue(XslUtilHnap.isEmailFormat("",true));
+        assertTrue(XslUtilHnap.isEmailFormat(null,true));
 
     }
 


### PR DESCRIPTION
This feature is to validate for all email formatting based on existing schematron validation logic for schematron-rules-multilingual.sch and schematron-rules-non-multilingual.sch

![image](https://user-images.githubusercontent.com/74916635/224054639-a66fcefd-870d-4532-90e1-29d35c97cdfb.png)
