### PR TITLE
Remove default gmd:characterSet utf8 as this field is not mandatory

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
@@ -389,7 +389,7 @@
          </gmd:language>
          <gmd:characterSet>
             <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
-                                     codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+                                     codeListValue=""/>
          </gmd:characterSet>
          <gmd:topicCategory gco:nilReason="missing">
             <gmd:MD_TopicCategoryCode/>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
@@ -389,7 +389,7 @@
          </gmd:language>
          <gmd:characterSet>
             <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
-                                     codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+                                     codeListValue=""/>
          </gmd:characterSet>
          <gmd:topicCategory gco:nilReason="missing">
             <gmd:MD_TopicCategoryCode/>


### PR DESCRIPTION
This Character Set is not mandatory

![image](https://user-images.githubusercontent.com/74916635/224822023-2869715e-05f7-406a-9558-e8e93bbafaa1.png)


So when the user create a metadata from its NHAP template, this should be nullable instead of forcing some default value. If we use UTF8 value, the user will never switch back to null value.