### PR TITLE
Update distribution format so that the value stored is the code instead of the English value.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -290,8 +290,8 @@
       <entries>
         <xsl:for-each select="$resourceFormatsTh/rdf:RDF/rdf:Description">
           <entry>
-            <code><xsl:value-of select="ns2:prefLabel[@xml:lang='en']" /></code>
-            <label> <xsl:value-of select="ns2:prefLabel[@xml:lang='en']" /></label>
+            <code><xsl:value-of select="replace(@rdf:about, 'http://geonetwork-opensource.org/EC/resourceformat#', '')" /></code>
+            <label><xsl:value-of select="ns2:prefLabel[@xml:lang=XslUtilHnap:twoCharLangCode($lang)]"/></label>
           </entry>
         </xsl:for-each>
       </entries>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -486,7 +486,7 @@
 
       <sch:let name="distributionFormat" value="gco:CharacterString" />
 
-      <sch:assert test="($missing) or (string($distribution-formats//rdf:Description[normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char]) = $distributionFormat]))">$loc/strings/DistributionFormatInvalid</sch:assert>
+      <sch:assert test="($missing) or (string($distribution-formats//rdf:Description[replace(@rdf:about, 'http://geonetwork-opensource.org/EC/resourceformat#', '') = $distributionFormat]))">$loc/strings/DistributionFormatInvalid</sch:assert>
 
     </sch:rule>
 


### PR DESCRIPTION
Update distribution format so that the value stored is the code instead of the English value.

Fixes issue #319

Output after this fix will be distribution format similar the following

```
         <gmd:distributionFormat>
            <gmd:MD_Format>
               <gmd:name>
                  <gco:CharacterString>CDED ASCII</gco:CharacterString>
               </gmd:name>
               <gmd:version>
                  <gco:CharacterString>test</gco:CharacterString>
               </gmd:version>
            </gmd:MD_Format>
         </gmd:distributionFormat>
```

Also, the record will validate using a record with the main language as French.