### PR TITLE
Update iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP to fix invalid ref system code format when importing data from FGP

### DIFF
--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -2,7 +2,8 @@
 <xsl:stylesheet version="2.0"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <!-- There are some known discrepancies between FGP and HNAP due to misinterpretations of the standards
        This converter is to be used to fix these discrepancies until a resolution is made.
@@ -51,7 +52,33 @@
     match="gmd:country/gco:CharacterString[text()='Canada' and $mainLanguage='fra']/text()|
            gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()='Canada' and @locale=concat('#', $altLanguageId) and $altLanguage='fra']/text()"
     priority="10">
-    <xsl:text>Canada (le)</xsl:text>
+      <xsl:text>Canada (le)</xsl:text>
+  </xsl:template>
+
+  <xsl:template
+    match="gmd:CI_Address/gmd:country[gco:CharacterString[text()='Canada'] and not(gmd:PT_FreeText) and ($mainLanguage='fra' or $mainLanguage='eng')]"
+    priority="10">
+      <xsl:copy>
+        <xsl:attribute name="xsi:type">gmd:PT_FreeText_PropertyType</xsl:attribute>
+        <xsl:apply-templates select="node()|@*"/>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+              <gmd:LocalisedCharacterString>
+                <xsl:attribute name="locale">
+                  <xsl:value-of select="concat('#', $altLanguageId)" />
+                </xsl:attribute>						
+                <xsl:choose>
+                  <xsl:when test="$mainLanguage='eng'">
+                    <xsl:text>Canada (le)</xsl:text>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:text>Canada</xsl:text>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </xsl:copy>
   </xsl:template>
 
   <!-- FGP fix issue where some of the data does not have the correct gmd:metadataStandardName

--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -182,6 +182,15 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- FGP fix issue where Reference System Code is a number but should have the format EPSG:NUMBER. Example: EPSG:4326.  -->
+  <xsl:template
+    match="gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code/gco:CharacterString[string(number(text()))!='NaN' and contains(upper-case(../../gmd:codeSpace/gco:CharacterString/text()), 'EPSG')]"
+    priority="10">
+		<xsl:copy>
+			<xsl:value-of select="concat('EPSG:', text())"/>
+		</xsl:copy>
+  </xsl:template>
+
   <!--Add default unclassified as security constraint if missing from metadata xml-->
   <xsl:template match="gmd:MD_DataIdentification">
     <xsl:copy copy-namespaces="no">

--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -99,6 +99,59 @@
     </xsl:copy>
   </xsl:template>
 
+  <!-- FGP fix issue in gmd:administrativeArea where gco:CharacterString has no text but gmd:PT_FreeText has.  -->
+  <xsl:template
+    match="gmd:administrativeArea[not(gco:CharacterString/text()) and gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString/text()]/gco:CharacterString"
+    priority="10">
+    <xsl:copy>
+        <xsl:value-of select="../gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString/text()"/>
+    </xsl:copy>
+  </xsl:template> 
+
+  <!-- FGP fix issue in gmd:administrativeArea where gmd:PT_FreeText has incorrect provincial name of Québec in English.  -->
+  <xsl:template
+    match="gmd:administrativeArea/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()='Québec' and @locale='#eng']/text()"
+    priority="10">
+        <xsl:text>Quebec</xsl:text>
+  </xsl:template>
+  
+  <!--Add gmd:administrativeArea LocalisedCharacterString if not exists. Special case for Québec in French and Quebec in English -->
+  <xsl:template match="gmd:administrativeArea[gco:CharacterString/text()  and not(gmd:PT_FreeText)]"
+    priority="10">
+    <xsl:copy copy-namespaces="no">
+      <xsl:apply-templates select="node()|@*"/>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <xsl:choose>
+              <xsl:when test="$mainLanguage='eng'">
+                <gmd:LocalisedCharacterString locale="#fra">
+                   <xsl:choose>
+                      <xsl:when test="./gco:CharacterString/text() = 'Quebec'">
+                         <xsl:value-of select="'Québec'"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                         <xsl:value-of select="./gco:CharacterString/text()"/>
+                      </xsl:otherwise>
+                   </xsl:choose>
+                </gmd:LocalisedCharacterString>
+              </xsl:when>
+              <xsl:otherwise>
+                <gmd:LocalisedCharacterString locale="#eng">
+                   <xsl:choose>
+                      <xsl:when test="./gco:CharacterString/text() = 'Québec'">
+                         <xsl:value-of select="'Quebec'"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                         <xsl:value-of select="./gco:CharacterString/text()"/>
+                      </xsl:otherwise>
+                   </xsl:choose>
+                </gmd:LocalisedCharacterString>
+              </xsl:otherwise>
+            </xsl:choose>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+    </xsl:copy>
+  </xsl:template>
 
   <!-- ISO19139 are compatible with HNAP however for to import to process then records as HNAP we need to ensure that the metadataStandardName is set correctly -->
 


### PR DESCRIPTION
it is a fix to issue https://github.com/metadata101/iso19139.ca.HNAP/issues/321