### PR TITLE
[4.2.x] Transition to schemas.metadata.geo.ca

### DIFF
--- a/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
+++ b/src/main/config/conversion/import/iso19139.ca.HNAP.FGP-to-iso19139.ca.HNAP.xsl
@@ -189,7 +189,7 @@
         <gmd:resourceConstraints>
           <gmd:MD_SecurityConstraints>
             <gmd:classification>
-              <gmd:MD_ClassificationCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96"
+              <gmd:MD_ClassificationCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_96"
                                          codeListValue="RI_484">unclassified; nonClassifié</gmd:MD_ClassificationCode>
             </gmd:classification>
           </gmd:MD_SecurityConstraints>

--- a/src/main/plugin/iso19139.ca.HNAP/convert/thesaurus-transformation.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/convert/thesaurus-transformation.xsl
@@ -370,7 +370,7 @@
                       </xsl:choose>
                     </gmd:date>
                     <gmd:dateType>
-                      <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                      <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                     </gmd:dateType>
                   </gmd:CI_Date>
                 </gmd:date>
@@ -393,7 +393,7 @@
                     </gmd:date>
                     <gmd:dateType>
                       <gmd:CI_DateTypeCode codeListValue="RI_366"
-                                           codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
+                                           codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
                     </gmd:dateType>
                   </gmd:CI_Date>
                 </gmd:date>
@@ -435,7 +435,7 @@
               </xsl:choose>
 
               <gmd:role>
-                <gmd:CI_RoleCode codeListValue="RI_409" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
+                <gmd:CI_RoleCode codeListValue="RI_409" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
               </gmd:role>
             </gmd:CI_ResponsibleParty>
           </gmd:citedResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -118,7 +118,7 @@
       <xsl:apply-templates select="gmd:characterSet" />
       <xsl:if test="not(gmd:characterSet)">
         <gmd:characterSet>
-          <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+          <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
         </gmd:characterSet>
       </xsl:if>
 
@@ -126,7 +126,7 @@
       <xsl:apply-templates select="gmd:hierarchyLevel" />
       <xsl:if test="not(gmd:hierarchyLevel)">
         <gmd:hierarchyLevel>
-          <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
+          <gmd:MD_ScopeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
         </gmd:hierarchyLevel>
       </xsl:if>
 
@@ -172,7 +172,7 @@
         <gmd:locale>
           <gmd:PT_Locale id="{$mainLanguageId}">
             <gmd:languageCode>
-              <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116"
+              <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116"
                                 codeListValue="{$mainLanguage}">
                 <xsl:choose>
                   <xsl:when test="normalize-space($mainLanguage) = 'fra'">French; Français</xsl:when>
@@ -186,11 +186,11 @@
                 <gmd:country>
                   <xsl:choose>
                     <xsl:when test="upper-case($mainLanguageCountryId) = 'CAN'">
-                      <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117"
+                      <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117"
                                    codeListValue="CAN">Canada; Canada</gmd:Country>
                     </xsl:when>
                     <xsl:otherwise>
-                      <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117"
+                      <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117"
                                    codeListValue="$mainLanguageCountryId"></gmd:Country>
                     </xsl:otherwise>
                   </xsl:choose>
@@ -198,7 +198,7 @@
               </xsl:when>
             </xsl:choose>
             <gmd:characterEncoding>
-              <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+              <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                        codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
             </gmd:characterEncoding>
           </gmd:PT_Locale>
@@ -264,7 +264,7 @@
                       <gco:Date></gco:Date>
                     </gmd:date>
                     <gmd:dateType>
-                      <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                      <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                            codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
                     </gmd:dateType>
                   </gmd:CI_Date>
@@ -278,7 +278,7 @@
                       <gco:Date></gco:Date>
                     </gmd:date>
                     <gmd:dateType>
-                      <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                      <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                            codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                     </gmd:dateType>
                   </gmd:CI_Date>
@@ -307,7 +307,7 @@
       <xsl:apply-templates select="gmd:status" />
       <xsl:if test="not(gmd:status)">
         <gmd:status>
-          <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
+          <gmd:MD_ProgressCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
         </gmd:status>
       </xsl:if>
 
@@ -317,7 +317,7 @@
         <gmd:resourceMaintenance>
           <gmd:MD_MaintenanceInformation>
             <gmd:maintenanceAndUpdateFrequency>
-              <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
+              <gmd:MD_MaintenanceFrequencyCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
             </gmd:maintenanceAndUpdateFrequency>
           </gmd:MD_MaintenanceInformation>
         </gmd:resourceMaintenance>
@@ -354,10 +354,10 @@
               </gmd:PT_FreeText>
             </gmd:useLimitation>
             <gmd:accessConstraints>
-              <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+              <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
             </gmd:accessConstraints>
             <gmd:useConstraints>
-              <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+              <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
             </gmd:useConstraints>
             <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
               <gco:CharacterString/>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -359,7 +359,7 @@
                     </gmd:date>
                     <gmd:dateType>
                       <gmd:CI_DateTypeCode
-                        codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                        codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                         codeListValue=""/>
                     </gmd:dateType>
                   </gmd:CI_Date>
@@ -428,7 +428,7 @@
                     </gmd:date>
                     <gmd:dateType>
                       <gmd:CI_DateTypeCode
-                              codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                              codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                               codeListValue=""/>
                     </gmd:dateType>
                   </gmd:CI_Date>
@@ -459,7 +459,7 @@
             <template>
               <snippet>
                 <gmd:spatialRepresentationType>
-                  <gmd:MD_SpatialRepresentationTypeCode codeListValue="" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_109"/>
+                  <gmd:MD_SpatialRepresentationTypeCode codeListValue="" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_109"/>
                 </gmd:spatialRepresentationType>
               </snippet>
             </template>

--- a/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
@@ -35,7 +35,7 @@
 	<title xml:lang="fr">ISO Profil nord-américain harmonisé (HNAP)</title>
 
 	<depends>iso19139</depends>
-	<schemaLocation>http://www.isotc211.org/2005/gmd http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/napm/napm.xsd</schemaLocation>
+	<schemaLocation>http://www.isotc211.org/2005/gmd https://schemas.metadata.geo.ca/2009/gmd/gmd.xsd http://www.isotc211.org/2005/srv https://schemas.metadata.geo.ca/2009/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm https://schemas.metadata.geo.ca/2009/napm/napm.xsd</schemaLocation>
 
 	<autodetect xmlns:gmd="http://www.isotc211.org/2005/gmd"
               xmlns:gco="http://www.isotc211.org/2005/gco">

--- a/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/schema-ident.xml
@@ -35,7 +35,7 @@
 	<title xml:lang="fr">ISO Profil nord-américain harmonisé (HNAP)</title>
 
 	<depends>iso19139</depends>
-	<schemaLocation>http://www.isotc211.org/2005/gmd https://schemas.metadata.geo.ca/2009/gmd/gmd.xsd http://www.isotc211.org/2005/srv https://schemas.metadata.geo.ca/2009/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm https://schemas.metadata.geo.ca/2009/napm/napm.xsd</schemaLocation>
+	<schemaLocation>http://www.isotc211.org/2005/gmx https://schemas.metadata.geo.ca/2009/gmx/gmx.xsd http://www.isotc211.org/2005/gmd https://schemas.metadata.geo.ca/2009/gmd/gmd.xsd http://www.isotc211.org/2005/srv https://schemas.metadata.geo.ca/2009/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm https://schemas.metadata.geo.ca/2009/napm/napm.xsd</schemaLocation>
 
 	<autodetect xmlns:gmd="http://www.isotc211.org/2005/gmd"
               xmlns:gco="http://www.isotc211.org/2005/gco">

--- a/src/main/plugin/iso19139.ca.HNAP/set-template-language.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/set-template-language.xsl
@@ -39,26 +39,26 @@
       <xsl:when test="$lang = 'fre'">
         <gmd:PT_Locale id="eng">
           <gmd:languageCode>
-            <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116" codeListValue="eng">English; Anglais</gmd:LanguageCode>
+            <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116" codeListValue="eng">English; Anglais</gmd:LanguageCode>
           </gmd:languageCode>
           <gmd:country>
-            <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
+            <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
           </gmd:country>
           <gmd:characterEncoding>
-            <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+            <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
           </gmd:characterEncoding>
         </gmd:PT_Locale>
       </xsl:when>
       <xsl:otherwise>
         <gmd:PT_Locale id="fra">
           <gmd:languageCode>
-            <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
+            <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
           </gmd:languageCode>
           <gmd:country>
-            <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
+            <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
           </gmd:country>
           <gmd:characterEncoding>
-            <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+            <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
           </gmd:characterEncoding>
         </gmd:PT_Locale>
       </xsl:otherwise>

--- a/src/main/plugin/iso19139.ca.HNAP/set-thumbnail.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/set-thumbnail.xsl
@@ -152,21 +152,21 @@
         <xsl:choose>
           <xsl:when test="/root/env/ext = 'png'">
             <gmd:fileType xmlns:napm="http://www.geconnections.org/nap/napMetadataTools/napXsd/napm" xsi:type="napm:napMD_FileFormatCode_PropertyType"
-													codeList="http://nap.geogratis.gc.ca/metadata/register/registerItemClasses-eng.html#IC_115"
+													codeList="https://schemas.metadata.geo.ca/register/registerItemClasses-eng.html#IC_115"
                           codeListValue="RI_716">
               <gco:CharacterString>png; png</gco:CharacterString>
             </gmd:fileType>
           </xsl:when>
           <xsl:when test="/root/env/ext = 'gif'">
             <gmd:fileType xmlns:napm="http://www.geconnections.org/nap/napMetadataTools/napXsd/napm" xsi:type="napm:napMD_FileFormatCode_PropertyType"
-													codeList="http://nap.geogratis.gc.ca/metadata/register/registerItemClasses-eng.html#IC_115"
+													codeList="https://schemas.metadata.geo.ca/register/registerItemClasses-eng.html#IC_115"
                           codeListValue="RI_706">
               <gco:CharacterString>gif; gif</gco:CharacterString>
             </gmd:fileType>
           </xsl:when>
           <xsl:when test="/root/env/ext = 'jpg'">
             <gmd:fileType xmlns:napm="http://www.geconnections.org/nap/napMetadataTools/napXsd/napm" xsi:type="napm:napMD_FileFormatCode_PropertyType"
-													codeList="http://nap.geogratis.gc.ca/metadata/register/registerItemClasses-eng.html#IC_115"
+													codeList="https://schemas.metadata.geo.ca/register/registerItemClasses-eng.html#IC_115"
                           codeListValue="RI_711">
               <gco:CharacterString>jpg; jpg</gco:CharacterString>
             </gmd:fileType>
@@ -177,13 +177,12 @@
   </xsl:template>
 	
 	<!-- ================================================================= -->
-
 	<xsl:template match="@*|node()">
 		 <xsl:copy>
 			  <xsl:apply-templates select="@*|node()"/>
+
 		 </xsl:copy>
 	</xsl:template>
-
 	<!-- ================================================================= -->
 	
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
@@ -16,11 +16,11 @@
       <gco:CharacterString>eng; CAN</gco:CharacterString>
    </gmd:language>
    <gmd:characterSet>
-      <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+      <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
   </gmd:characterSet>
    <gmd:hierarchyLevel>
-      <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108"
+      <gmd:MD_ScopeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_108"
                         codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
    </gmd:hierarchyLevel>
    <gmd:contact>
@@ -119,7 +119,7 @@
             </gmd:CI_Contact>
          </gmd:contactInfo>
          <gmd:role>
-            <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+            <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                              codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
          </gmd:role>
       </gmd:CI_ResponsibleParty>
@@ -144,15 +144,15 @@
    <gmd:locale>
       <gmd:PT_Locale id="fra">
          <gmd:languageCode>
-            <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116"
+            <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116"
                               codeListValue="fra">French; Français</gmd:LanguageCode>
          </gmd:languageCode>
          <gmd:country>
-            <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117"
+            <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117"
                          codeListValue="CAN">Canada; Canada</gmd:Country>
          </gmd:country>
          <gmd:characterEncoding>
-            <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+            <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                      codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
          </gmd:characterEncoding>
       </gmd:PT_Locale>
@@ -192,7 +192,7 @@
                         <gco:Date/>
                      </gmd:date>
                      <gmd:dateType>
-                        <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                        <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                              codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                      </gmd:dateType>
                   </gmd:CI_Date>
@@ -203,7 +203,7 @@
                         <gco:Date/>
                      </gmd:date>
                      <gmd:dateType>
-                        <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                        <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                              codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
                      </gmd:dateType>
                   </gmd:CI_Date>
@@ -304,7 +304,7 @@
                         </gmd:CI_Contact>
                      </gmd:contactInfo>
                      <gmd:role>
-                        <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                        <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                          codeListValue="RI_415">principalInvestigator; chercheurPrincipal</gmd:CI_RoleCode>
                      </gmd:role>
                   </gmd:CI_ResponsibleParty>
@@ -320,13 +320,13 @@
             </gmd:PT_FreeText>
          </gmd:abstract>
          <gmd:status>
-            <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106"
+            <gmd:MD_ProgressCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_106"
                                  codeListValue=""/>
          </gmd:status>
          <gmd:resourceMaintenance>
             <gmd:MD_MaintenanceInformation>
                <gmd:maintenanceAndUpdateFrequency>
-                  <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102"
+                  <gmd:MD_MaintenanceFrequencyCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_102"
                                                    codeListValue=""/>
                </gmd:maintenanceAndUpdateFrequency>
             </gmd:MD_MaintenanceInformation>
@@ -342,8 +342,8 @@
                   </gmd:PT_FreeText>
                </gmd:keyword>
                <gmd:type>
-                  <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101"
-                                           codeListValue="theme" />
+                  <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101"
+                                          codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
                </gmd:type>
                <gmd:thesaurusName>
                   <gmd:CI_Citation>
@@ -361,8 +361,8 @@
                               <gco:Date>2004</gco:Date>
                            </gmd:date>
                            <gmd:dateType>
-                              <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
-                                                   codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                              <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
+							                       codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                            </gmd:dateType>
                         </gmd:CI_Date>
                      </gmd:date>
@@ -372,7 +372,7 @@
                               <gco:Date>2016-07-04</gco:Date>
                            </gmd:date>
                            <gmd:dateType>
-                              <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                              <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                                    codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
                            </gmd:dateType>
                         </gmd:CI_Date>
@@ -388,7 +388,7 @@
                               </gmd:PT_FreeText>
                            </gmd:organisationName>
                            <gmd:role>
-                              <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                              <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                                codeListValue="RI_409">custodian; conservateur</gmd:CI_RoleCode>
                            </gmd:role>
                         </gmd:CI_ResponsibleParty>
@@ -408,11 +408,11 @@
                   </gmd:PT_FreeText>
                </gmd:useLimitation>
                <gmd:accessConstraints>
-                  <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107"
+                  <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107"
                                           codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
                </gmd:accessConstraints>
                <gmd:useConstraints>
-                  <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107"
+                  <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107"
                                           codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
                </gmd:useConstraints>
                <gmd:otherConstraints gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
@@ -428,7 +428,7 @@
          <gmd:resourceConstraints>
             <gmd:MD_SecurityConstraints>
                <gmd:classification>
-                  <gmd:MD_ClassificationCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96"
+                  <gmd:MD_ClassificationCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_96"
                                              codeListValue="RI_484">unclassified; nonClassifié</gmd:MD_ClassificationCode>
                </gmd:classification>
                <gmd:userNote gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
@@ -437,14 +437,14 @@
             </gmd:MD_SecurityConstraints>
          </gmd:resourceConstraints>
          <gmd:spatialRepresentationType>
-            <gmd:MD_SpatialRepresentationTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_109"
+            <gmd:MD_SpatialRepresentationTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_109"
                                                   codeListValue=""/>
          </gmd:spatialRepresentationType>
          <gmd:language>
             <gco:CharacterString>eng; CAN</gco:CharacterString>
          </gmd:language>
          <gmd:characterSet>
-            <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+            <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                      codeListValue=""/>
          </gmd:characterSet>
          <gmd:topicCategory gco:nilReason="missing">
@@ -610,7 +610,7 @@
                         </gmd:CI_Contact>
                      </gmd:contactInfo>
                      <gmd:role>
-                        <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                        <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                          codeListValue="RI_412">distributor; distributeur</gmd:CI_RoleCode>
                      </gmd:role>
                   </gmd:CI_ResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
@@ -16,11 +16,11 @@
       <gco:CharacterString>fra; CAN</gco:CharacterString>
    </gmd:language>
    <gmd:characterSet>
-      <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+      <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
   </gmd:characterSet>
    <gmd:hierarchyLevel>
-      <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108"
+      <gmd:MD_ScopeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_108"
                         codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
    </gmd:hierarchyLevel>
    <gmd:contact>
@@ -119,7 +119,7 @@
             </gmd:CI_Contact>
          </gmd:contactInfo>
          <gmd:role>
-            <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+            <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                              codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
          </gmd:role>
       </gmd:CI_ResponsibleParty>
@@ -144,15 +144,15 @@
    <gmd:locale>
       <gmd:PT_Locale id="eng">
          <gmd:languageCode>
-            <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116"
+            <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116"
                               codeListValue="eng">English; Anglais</gmd:LanguageCode>
          </gmd:languageCode>
          <gmd:country>
-            <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117"
+            <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117"
                          codeListValue="CAN">Canada; Canada</gmd:Country>
          </gmd:country>
          <gmd:characterEncoding>
-            <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+            <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                      codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
          </gmd:characterEncoding>
       </gmd:PT_Locale>
@@ -192,7 +192,7 @@
                         <gco:Date/>
                      </gmd:date>
                      <gmd:dateType>
-                        <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                        <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                              codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                      </gmd:dateType>
                   </gmd:CI_Date>
@@ -203,7 +203,7 @@
                         <gco:Date/>
                      </gmd:date>
                      <gmd:dateType>
-                        <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                        <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                              codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
                      </gmd:dateType>
                   </gmd:CI_Date>
@@ -304,7 +304,7 @@
                         </gmd:CI_Contact>
                      </gmd:contactInfo>
                      <gmd:role>
-                        <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                        <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                          codeListValue="RI_415">principalInvestigator; chercheurPrincipal</gmd:CI_RoleCode>
                      </gmd:role>
                   </gmd:CI_ResponsibleParty>
@@ -320,13 +320,13 @@
             </gmd:PT_FreeText>
          </gmd:abstract>
          <gmd:status>
-            <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106"
+            <gmd:MD_ProgressCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_106"
                                  codeListValue=""/>
          </gmd:status>
          <gmd:resourceMaintenance>
             <gmd:MD_MaintenanceInformation>
                <gmd:maintenanceAndUpdateFrequency>
-                  <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102"
+                  <gmd:MD_MaintenanceFrequencyCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_102"
                                                    codeListValue=""/>
                </gmd:maintenanceAndUpdateFrequency>
             </gmd:MD_MaintenanceInformation>
@@ -342,8 +342,8 @@
                   </gmd:PT_FreeText>
                </gmd:keyword>
                <gmd:type>
-                  <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101"
-                                           codeListValue="theme" />
+                  <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101"
+                                          codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
                </gmd:type>
                <gmd:thesaurusName>
                   <gmd:CI_Citation>
@@ -361,8 +361,9 @@
                               <gco:Date>2004</gco:Date>
                            </gmd:date>
                            <gmd:dateType>
-                              <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                              <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                                    codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+
                            </gmd:dateType>
                         </gmd:CI_Date>
                      </gmd:date>
@@ -372,7 +373,7 @@
                               <gco:Date>2016-07-04</gco:Date>
                            </gmd:date>
                            <gmd:dateType>
-                              <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87"
+                              <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                                    codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
                            </gmd:dateType>
                         </gmd:CI_Date>
@@ -388,7 +389,7 @@
                               </gmd:PT_FreeText>
                            </gmd:organisationName>
                            <gmd:role>
-                              <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                              <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                                codeListValue="RI_409">custodian; conservateur</gmd:CI_RoleCode>
                            </gmd:role>
                         </gmd:CI_ResponsibleParty>
@@ -408,11 +409,11 @@
                   </gmd:PT_FreeText>
                </gmd:useLimitation>
                <gmd:accessConstraints>
-                  <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107"
+                  <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107"
                                           codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
                </gmd:accessConstraints>
                <gmd:useConstraints>
-                  <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107"
+                  <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107"
                                           codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
                </gmd:useConstraints>
                <gmd:otherConstraints gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
@@ -428,7 +429,7 @@
          <gmd:resourceConstraints>
             <gmd:MD_SecurityConstraints>
                <gmd:classification>
-                  <gmd:MD_ClassificationCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_96"
+                  <gmd:MD_ClassificationCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_96"
                                              codeListValue="RI_484">unclassified; nonClassifié</gmd:MD_ClassificationCode>
                </gmd:classification>
                <gmd:userNote gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
@@ -437,14 +438,14 @@
             </gmd:MD_SecurityConstraints>
          </gmd:resourceConstraints>
          <gmd:spatialRepresentationType>
-            <gmd:MD_SpatialRepresentationTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_109"
+            <gmd:MD_SpatialRepresentationTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_109"
                                                   codeListValue=""/>
          </gmd:spatialRepresentationType>
          <gmd:language>
             <gco:CharacterString>fra; CAN</gco:CharacterString>
          </gmd:language>
          <gmd:characterSet>
-            <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+            <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                      codeListValue=""/>
          </gmd:characterSet>
          <gmd:topicCategory gco:nilReason="missing">
@@ -610,7 +611,7 @@
                         </gmd:CI_Contact>
                      </gmd:contactInfo>
                      <gmd:role>
-                        <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                        <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                          codeListValue="RI_412">distributor; distributeur</gmd:CI_RoleCode>
                      </gmd:role>
                   </gmd:CI_ResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
@@ -12,7 +12,7 @@
                  xmlns:gss="http://www.isotc211.org/2005/gss"
                  xmlns:gts="http://www.isotc211.org/2005/gts"
                  xmlns:srv="http://www.isotc211.org/2005/srv"
-                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/napm/napm.xsd"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd https://schemas.metadata.geo.ca/2009/gmd/gmd.xsd http://www.isotc211.org/2005/srv https://schemas.metadata.geo.ca/2009/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm https://schemas.metadata.geo.ca/2009/napm/napm.xsd"
   >
     <gmd:fileIdentifier>
         <gco:CharacterString/>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gmd:MD_Metadata xmlns="http://www.isotc211.org/2005/gmd"
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<gmd:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:gco="http://www.isotc211.org/2005/gco"
                  xmlns:gfc="http://www.isotc211.org/2005/gfc"
                  xmlns:gmd="http://www.isotc211.org/2005/gmd"

--- a/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
@@ -11,7 +11,7 @@
                  xmlns:gss="http://www.isotc211.org/2005/gss"
                  xmlns:gts="http://www.isotc211.org/2005/gts"
                  xmlns:srv="http://www.isotc211.org/2005/srv"
-                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd https://schemas.metadata.geo.ca/2009/gmd/gmd.xsd http://www.isotc211.org/2005/srv https://schemas.metadata.geo.ca/2009/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm https://schemas.metadata.geo.ca/2009/napm/napm.xsd"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmx https://schemas.metadata.geo.ca/2009/gmx/gmx.xsdhttp://www.isotc211.org/2005/gmd https://schemas.metadata.geo.ca/2009/gmd/gmd.xsd http://www.isotc211.org/2005/srv https://schemas.metadata.geo.ca/2009/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm https://schemas.metadata.geo.ca/2009/napm/napm.xsd"
   >
     <gmd:fileIdentifier>
         <gco:CharacterString/>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
@@ -21,10 +21,10 @@
         <gco:CharacterString>eng; CAN</gco:CharacterString>
     </gmd:language>
     <gmd:characterSet>
-        <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+        <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
     </gmd:characterSet>
     <gmd:hierarchyLevel>
-        <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108" codeListValue="RI_631">service; service</gmd:MD_ScopeCode>
+        <gmd:MD_ScopeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_108" codeListValue="RI_631">service; service</gmd:MD_ScopeCode>
     </gmd:hierarchyLevel>
     <gmd:contact>
         <gmd:CI_ResponsibleParty>
@@ -115,7 +115,7 @@
                 </gmd:CI_Contact>
             </gmd:contactInfo>
           <gmd:role>
-            <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+            <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                              codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
           </gmd:role>
         </gmd:CI_ResponsibleParty>
@@ -140,13 +140,13 @@
     <gmd:locale>
         <gmd:PT_Locale id="fra">
             <gmd:languageCode>
-                <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
+                <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
             </gmd:languageCode>
             <gmd:country>
-                <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
+                <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
             </gmd:country>
             <gmd:characterEncoding>
-                <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+                <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
             </gmd:characterEncoding>
         </gmd:PT_Locale>
     </gmd:locale>
@@ -187,7 +187,7 @@
                                 <gco:Date/>
                             </gmd:date>
                             <gmd:dateType>
-                                <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                                <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                             </gmd:dateType>
                         </gmd:CI_Date>
                     </gmd:date>
@@ -197,7 +197,7 @@
                                 <gco:Date/>
                             </gmd:date>
                             <gmd:dateType>
-                                <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
+                                <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
                             </gmd:dateType>
                         </gmd:CI_Date>
                     </gmd:date>
@@ -295,7 +295,7 @@
                                 </gmd:CI_Contact>
                             </gmd:contactInfo>
                           <gmd:role>
-                            <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                            <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                              codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
                           </gmd:role>
                         </gmd:CI_ResponsibleParty>
@@ -314,12 +314,12 @@
                 <gmd:MD_ProgressCode codeListValue="completed" codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ProgressCode"/>
             </gmd:status>
             <gmd:status>
-                <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
+                <gmd:MD_ProgressCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
             </gmd:status>
             <gmd:resourceMaintenance>
                 <gmd:MD_MaintenanceInformation>
                     <gmd:maintenanceAndUpdateFrequency>
-                        <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
+                        <gmd:MD_MaintenanceFrequencyCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
                     </gmd:maintenanceAndUpdateFrequency>
                 </gmd:MD_MaintenanceInformation>
             </gmd:resourceMaintenance>
@@ -334,7 +334,7 @@
                         </gmd:PT_FreeText>
                     </gmd:keyword>
                     <gmd:type>
-                        <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
+                        <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
                     </gmd:type>
                     <gmd:thesaurusName>
                         <gmd:CI_Citation>
@@ -353,7 +353,7 @@
                                     </gmd:date>
                                     <gmd:dateType>
                                         <gmd:CI_DateTypeCode codeListValue="RI_366"
-                                                             codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
+                                                             codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
                                     </gmd:dateType>
                                 </gmd:CI_Date>
                             </gmd:date>
@@ -363,7 +363,7 @@
                                         <gco:Date>2015-04-21</gco:Date>
                                     </gmd:date>
                                     <gmd:dateType>
-                                        <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                                        <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                                     </gmd:dateType>
                                 </gmd:CI_Date>
                             </gmd:date>
@@ -378,7 +378,7 @@
                                         </gmd:PT_FreeText>
                                     </gmd:organisationName>
                                     <gmd:role>
-                                        <gmd:CI_RoleCode codeListValue="RI_409" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
+                                        <gmd:CI_RoleCode codeListValue="RI_409" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
                                     </gmd:role>
                                 </gmd:CI_ResponsibleParty>
                             </gmd:citedResponsibleParty>
@@ -398,10 +398,10 @@
                         </gmd:PT_FreeText>
                     </gmd:useLimitation>
                     <gmd:accessConstraints>
-                        <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+                        <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
                     </gmd:accessConstraints>
                     <gmd:useConstraints>
-                        <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+                        <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
                     </gmd:useConstraints>
                     <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
                         <gco:CharacterString/>
@@ -441,7 +441,7 @@
                 </gmd:EX_Extent>
             </srv:extent>
             <srv:couplingType>
-                <srv:SV_CouplingType codeListValue="" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_114"/>
+                <srv:SV_CouplingType codeListValue="" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_114"/>
             </srv:couplingType>
             <srv:containsOperations>
                 <srv:SV_OperationMetadata>
@@ -449,7 +449,7 @@
                         <gco:CharacterString></gco:CharacterString>
                     </srv:operationName>
                     <srv:DCP>
-                        <srv:DCPList codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_112" codeListValue=""/>
+                        <srv:DCPList codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_112" codeListValue=""/>
                     </srv:DCP>
                     <srv:operationDescription gco:nilReason="missing">
                         <gco:CharacterString></gco:CharacterString>
@@ -614,7 +614,7 @@
                                 </gmd:CI_Contact>
                             </gmd:contactInfo>
                             <gmd:role>
-                              <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                              <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                                codeListValue="RI_412">distributor; distributeur</gmd:CI_RoleCode>
                             </gmd:role>
                         </gmd:CI_ResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector-unilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector-unilingual.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gmd:MD_Metadata xmlns="http://www.isotc211.org/2005/gmd"
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<gmd:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:gco="http://www.isotc211.org/2005/gco"
                  xmlns:gfc="http://www.isotc211.org/2005/gfc"
                  xmlns:gmd="http://www.isotc211.org/2005/gmd"

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector-unilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector-unilingual.xml
@@ -19,10 +19,10 @@
     <gco:CharacterString>eng; CAN</gco:CharacterString>
   </gmd:language>
   <gmd:characterSet>
-    <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+    <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
   </gmd:characterSet>
   <gmd:hierarchyLevel>
-    <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
+    <gmd:MD_ScopeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
   </gmd:hierarchyLevel>
   <gmd:contact>
     <gmd:CI_ResponsibleParty>
@@ -66,7 +66,7 @@
         </gmd:CI_Contact>
       </gmd:contactInfo>
       <gmd:role>
-        <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+        <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                          codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
       </gmd:role>
     </gmd:CI_ResponsibleParty>
@@ -86,15 +86,15 @@
   <gmd:locale>
     <gmd:PT_Locale id="eng">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116"
+        <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116"
                           codeListValue="eng">English; Anglais</gmd:LanguageCode>
       </gmd:languageCode>
       <gmd:country>
-        <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117"
+        <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117"
                      codeListValue="CAN">Canada; Canada</gmd:Country>
       </gmd:country>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95"
+        <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95"
                                  codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
@@ -129,7 +129,7 @@
                 <gco:Date/>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -139,7 +139,7 @@
                 <gco:Date/>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
+                <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -190,7 +190,7 @@
                 </gmd:CI_Contact>
               </gmd:contactInfo>
               <gmd:role>
-                <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                  codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
               </gmd:role>
             </gmd:CI_ResponsibleParty>
@@ -201,12 +201,12 @@
         <gco:CharacterString/>
       </gmd:abstract>
       <gmd:status>
-        <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
+        <gmd:MD_ProgressCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
       </gmd:status>
       <gmd:resourceMaintenance>
         <gmd:MD_MaintenanceInformation>
           <gmd:maintenanceAndUpdateFrequency>
-            <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
+            <gmd:MD_MaintenanceFrequencyCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
           </gmd:maintenanceAndUpdateFrequency>
         </gmd:MD_MaintenanceInformation>
       </gmd:resourceMaintenance>
@@ -216,7 +216,7 @@
             <gco:CharacterString/>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
+            <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -230,7 +230,7 @@
                   </gmd:date>
                   <gmd:dateType>
                     <gmd:CI_DateTypeCode codeListValue="RI_366"
-                                         codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
+                                         codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -240,7 +240,7 @@
                     <gco:Date>2015-04-21</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                    <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -250,7 +250,7 @@
                     <gco:CharacterString>Government of Canada</gco:CharacterString>
                   </gmd:organisationName>
                   <gmd:role>
-                    <gmd:CI_RoleCode codeListValue="RI_409" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
+                    <gmd:CI_RoleCode codeListValue="RI_409" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
                   </gmd:role>
                 </gmd:CI_ResponsibleParty>
               </gmd:citedResponsibleParty>
@@ -266,10 +266,10 @@
             </gco:CharacterString>
           </gmd:useLimitation>
           <gmd:accessConstraints>
-            <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+            <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
           </gmd:accessConstraints>
           <gmd:useConstraints>
-            <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+            <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
           </gmd:useConstraints>
           <gmd:otherConstraints >
             <gco:CharacterString/>
@@ -277,13 +277,13 @@
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
       <gmd:spatialRepresentationType>
-        <gmd:MD_SpatialRepresentationTypeCode codeListValue="" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_109"/>
+        <gmd:MD_SpatialRepresentationTypeCode codeListValue="" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_109"/>
       </gmd:spatialRepresentationType>
       <gmd:language>
         <gco:CharacterString>eng; CAN</gco:CharacterString>
       </gmd:language>
       <gmd:characterSet>
-        <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="utf8"/>
+        <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="utf8"/>
       </gmd:characterSet>
       <gmd:topicCategory gco:nilReason="missing">
         <gmd:MD_TopicCategoryCode></gmd:MD_TopicCategoryCode>
@@ -386,7 +386,7 @@
                 </gmd:CI_Contact>
               </gmd:contactInfo>
               <gmd:role>
-                <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                  codeListValue="RI_412">distributor; distributeur</gmd:CI_RoleCode>
               </gmd:role>
             </gmd:CI_ResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gmd:MD_Metadata xmlns="http://www.isotc211.org/2005/gmd"
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<gmd:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:gco="http://www.isotc211.org/2005/gco"
                  xmlns:gfc="http://www.isotc211.org/2005/gfc"
                  xmlns:gmd="http://www.isotc211.org/2005/gmd"

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
@@ -19,10 +19,10 @@
     <gco:CharacterString>eng; CAN</gco:CharacterString>
   </gmd:language>
   <gmd:characterSet>
-    <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+    <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
   </gmd:characterSet>
   <gmd:hierarchyLevel>
-    <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
+    <gmd:MD_ScopeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
   </gmd:hierarchyLevel>
   <gmd:contact>
     <gmd:CI_ResponsibleParty>
@@ -96,7 +96,7 @@
         </gmd:CI_Contact>
       </gmd:contactInfo>
       <gmd:role>
-        <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+        <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                          codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
       </gmd:role>
     </gmd:CI_ResponsibleParty>
@@ -121,13 +121,13 @@
   <gmd:locale>
     <gmd:PT_Locale id="fra">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
+        <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
       </gmd:languageCode>
       <gmd:country>
-        <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
+        <gmd:Country codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
       </gmd:country>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+        <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
@@ -167,7 +167,7 @@
                 <gco:Date/>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -177,7 +177,7 @@
                 <gco:Date/>
               </gmd:date>
               <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
+                <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
@@ -258,7 +258,7 @@
                 </gmd:CI_Contact>
               </gmd:contactInfo>
               <gmd:role>
-                <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                  codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
               </gmd:role>
             </gmd:CI_ResponsibleParty>
@@ -274,12 +274,12 @@
         </gmd:PT_FreeText>
       </gmd:abstract>
       <gmd:status>
-        <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
+        <gmd:MD_ProgressCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_106" codeListValue=""/>
       </gmd:status>
       <gmd:resourceMaintenance>
         <gmd:MD_MaintenanceInformation>
           <gmd:maintenanceAndUpdateFrequency>
-            <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
+            <gmd:MD_MaintenanceFrequencyCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_102" codeListValue=""/>
           </gmd:maintenanceAndUpdateFrequency>
         </gmd:MD_MaintenanceInformation>
       </gmd:resourceMaintenance>
@@ -294,7 +294,7 @@
             </gmd:PT_FreeText>
           </gmd:keyword>
           <gmd:type>
-            <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
+            <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
           </gmd:type>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
@@ -313,7 +313,7 @@
                   </gmd:date>
                   <gmd:dateType>
                     <gmd:CI_DateTypeCode codeListValue="RI_366"
-                                         codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
+                                         codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87">creation;création</gmd:CI_DateTypeCode>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -323,7 +323,7 @@
                     <gco:Date>2015-04-21</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                    <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>
@@ -338,7 +338,7 @@
                     </gmd:PT_FreeText>
                   </gmd:organisationName>
                   <gmd:role>
-                    <gmd:CI_RoleCode codeListValue="RI_409" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
+                    <gmd:CI_RoleCode codeListValue="RI_409" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90">custodian; conservateur</gmd:CI_RoleCode>
                   </gmd:role>
                 </gmd:CI_ResponsibleParty>
               </gmd:citedResponsibleParty>
@@ -358,10 +358,10 @@
             </gmd:PT_FreeText>
           </gmd:useLimitation>
           <gmd:accessConstraints>
-            <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+            <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
           </gmd:accessConstraints>
           <gmd:useConstraints>
-            <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+            <gmd:MD_RestrictionCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
           </gmd:useConstraints>
           <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
             <gco:CharacterString/>
@@ -374,13 +374,13 @@
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
       <gmd:spatialRepresentationType>
-        <gmd:MD_SpatialRepresentationTypeCode codeListValue="" codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_109"/>
+        <gmd:MD_SpatialRepresentationTypeCode codeListValue="" codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_109"/>
       </gmd:spatialRepresentationType>
       <gmd:language>
         <gco:CharacterString>eng; CAN</gco:CharacterString>
       </gmd:language>
       <gmd:characterSet>
-        <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="utf8"/>
+        <gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="utf8"/>
       </gmd:characterSet>
       <gmd:topicCategory gco:nilReason="missing">
         <gmd:MD_TopicCategoryCode></gmd:MD_TopicCategoryCode>
@@ -513,7 +513,7 @@
                 </gmd:CI_Contact>
               </gmd:contactInfo>
               <gmd:role>
-                <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90"
+                <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                                  codeListValue="RI_412">distributor; distributeur</gmd:CI_RoleCode>
               </gmd:role>
             </gmd:CI_ResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -195,7 +195,7 @@
 
 			<!-- fixed to uft8 -->
 			<gmd:characterSet>
-				<gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+				<gmd:MD_CharacterSetCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
 			</gmd:characterSet>
 
 			<xsl:choose>
@@ -553,7 +553,7 @@
   <xsl:template match="gmd:Country[@codeListValue='CAN']" priority="2200">
   	<xsl:copy>
   	  <xsl:apply-templates select="@*"/>
-  	  <xsl:attribute name="codeList">http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117</xsl:attribute>
+  	  <xsl:attribute name="codeList">https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_117</xsl:attribute>
   	  <xsl:text>Canada; Canada</xsl:text>
   	</xsl:copy>
   </xsl:template>
@@ -661,7 +661,7 @@
         <xsl:choose>
           <xsl:when test="normalize-space($codelistCode) != ''">
             <xsl:value-of
-              select="concat('http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#',$codelistCode)"/>
+              select="concat('https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#',$codelistCode)"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:value-of
@@ -744,7 +744,7 @@
           <xsl:copy-of select="@*" />
 
           <gmd:languageCode>
-            <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116">
+            <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116">
               <xsl:attribute name="codeListValue">
                 <xsl:value-of select="$id"/>
               </xsl:attribute>
@@ -765,7 +765,7 @@
 					</xsl:attribute>
 
           <gmd:languageCode>
-            <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116">
+            <gmd:LanguageCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_116">
               <xsl:attribute name="codeListValue">
                 <xsl:value-of select="$id"/>
               </xsl:attribute>
@@ -876,7 +876,7 @@
 
 
             <gmd:type>
-              <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="{@type}">
+              <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="{@type}">
                   <xsl:value-of select="$codelistDocument/codelists/codelist[@name='gmd:MD_KeywordTypeCode']/entry[code = $currentCodeValue]/value"/>
               </gmd:MD_KeywordTypeCode>
             </gmd:type>

--- a/src/sphinx/admin/index.rst
+++ b/src/sphinx/admin/index.rst
@@ -6,7 +6,8 @@ The administrator has access to manage record privileges, user permissions, and 
 
 .. toctree::
    :maxdepth: 1
-   
+
    privileges
    users
    settings
+   upgrade

--- a/src/sphinx/admin/upgrade.rst
+++ b/src/sphinx/admin/upgrade.rst
@@ -57,5 +57,5 @@ GeoNetwork 3 content can be updated using the following SQL:
      replace(
        data,
        'http://nap.geogratis.gc.ca/metadata/register/',
-       'https://schemas.metadata.geo.ca/register/
+       'https://schemas.metadata.geo.ca/register/'
      );

--- a/src/sphinx/admin/upgrade.rst
+++ b/src/sphinx/admin/upgrade.rst
@@ -1,0 +1,61 @@
+Upgrade
+=======
+
+Migration to schemas.metadata.geo.ca
+------------------------------------
+
+The published location of the HNAP schema has changed from
+`nap.geogratis.gc.ca <http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/>`__ to
+`schemas.metadata.geo.ca <https://schemas.metadata.geo.ca/2009/>`__.
+
+The location of the HNAP registry used for code list definitions has also changed:
+
+* ``http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml``
+  | ``https://schemas.metadata.geo.ca/register/napMetadataRegister.xml``
+* ``http://nap.geogratis.gc.ca/metadata/register/registerItemClasses-eng.html``
+  | ``https://schemas.metadata.geo.ca/register/registerItemClasses-eng.html``
+
+Individual records can be upgraded by saving and loading in the editor:
+
+1. Open the record in the editor.
+2. Select :command:`Save and Close`.
+
+GeoNetwork 4 provides the ability to perform a search and replace in the database:
+
+1. Navigate to :menuselection:`Contribue > Edit Console`.
+2. Press :guilabel:`Batch editing`.
+3. From :guilabel:`Choose a set of records` tab, select ``All``.
+4. Navigate to :guilabel:`Define edits` tab, select :guilabel:`Search and replace` with:
+
+   .. list-table::
+      :widths: 30 70
+      :width: 100%
+      :stub-columns: 1
+
+      * - Value:
+        - :kbd:`http://nap.geogratis.gc.ca/metadata/register/`
+      * - Replacement:
+        - :kbd:`https://schemas.metadata.geo.ca/register/`
+      * - Regular expression flags
+        - (no selection is required)
+
+5. Navigate to :guilabel:`Apply edits` tab, and press :guilabel:`Save`.
+
+   .. note:: We have not selected :guilabel:`Update the modification date in the metadata document` as this change reflects a change of infrastructure and not a change of the content of the metadata record.
+
+GeoNetwork 3 content can be updated using the following SQL:
+
+.. code-block:: text
+
+   UPDATE Metadata SET data =
+     replace(
+        data,
+       'http://nap.geogratis.gc.ca/metadata/register/',
+       'https://schemas.metadata.geo.ca/register/'
+     );
+   UPDATE MetadataDraft SET data =
+     replace(
+       data,
+       'http://nap.geogratis.gc.ca/metadata/register/',
+       'https://schemas.metadata.geo.ca/register/
+     );


### PR DESCRIPTION
This pull request prepares the 4.2.x branch for the relocation of hnap schemas and registry to schemas.metadata.geo.ca.

For context and discussion see https://github.com/metadata101/iso19139.ca.HNAP/issues/118