### PR TITLE
Add gmd:dataQualityInfo to template and inflate missing ones

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -233,11 +233,39 @@
       <xsl:apply-templates select="gmd:identificationInfo" />
       <xsl:apply-templates select="gmd:contentInfo" />
       <xsl:apply-templates select="gmd:distributionInfo" />
-      <xsl:apply-templates select="gmd:dataQualityInfo" />
       <xsl:apply-templates select="gmd:portrayalCatalogueInfo" />
       <xsl:apply-templates select="gmd:metadataConstraints" />
       <xsl:apply-templates select="gmd:applicationSchemaInfo" />
       <xsl:apply-templates select="gmd:metadataMaintenance" />
+
+      <!-- Inflate gmd:dataQualityInfo and add required gmd:scope -->
+      <xsl:if test="(gmd:dataQualityInfo)">
+        <xsl:apply-templates select="gmd:dataQualityInfo" />
+      </xsl:if>
+
+      <!-- Previouls metadata template has no such gmd:dataQualityInfo, add it for now -->
+      <xsl:if test="not(gmd:dataQualityInfo)">
+        <gmd:dataQualityInfo>
+          <gmd:DQ_DataQuality>
+            <gmd:scope>
+              <gmd:DQ_Scope>
+                <gmd:level>
+                  <gmd:MD_ScopeCode codeListValue="dataset"
+                                    codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+                </gmd:level>
+              </gmd:DQ_Scope>
+            </gmd:scope>
+            <gmd:lineage>
+              <gmd:LI_Lineage>
+                <gmd:statement gco:nilReason="missing">
+                  <gco:CharacterString/>
+                </gmd:statement>
+              </gmd:LI_Lineage>
+            </gmd:lineage>
+          </gmd:DQ_DataQuality>
+        </gmd:dataQualityInfo>
+      </xsl:if>
+
     </xsl:copy>
   </xsl:template>
 
@@ -522,6 +550,44 @@
       <xsl:apply-templates select="gmd:specification" />
       <xsl:apply-templates select="gmd:fileDecompressionTechnique" />
       <xsl:apply-templates select="gmd:formatDistributor" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!--Inflating gmd:dataQualityInfo -->
+  <xsl:template match="gmd:dataQualityInfo">
+    <xsl:copy>
+      <xsl:copy-of select="@*" />
+      <xsl:choose>
+        <xsl:when test="gmd:DQ_DataQuality/gmd:scope">
+          <xsl:for-each select="gmd:DQ_DataQuality">
+            <xsl:copy>
+              <xsl:copy-of select="node()"/>
+            </xsl:copy>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="gmd:DQ_DataQuality" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:copy>
+  </xsl:template>
+
+  <!--Inflating gmd:DQ_DataQuality. Added the required gmd:scope -->
+  <xsl:template match="gmd:DQ_DataQuality">
+    <xsl:copy>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <xsl:for-each select="gmd:lineage">
+        <xsl:copy>
+          <xsl:copy-of select="node()"/>
+        </xsl:copy>
+      </xsl:for-each>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -233,10 +233,6 @@
       <xsl:apply-templates select="gmd:identificationInfo" />
       <xsl:apply-templates select="gmd:contentInfo" />
       <xsl:apply-templates select="gmd:distributionInfo" />
-      <xsl:apply-templates select="gmd:portrayalCatalogueInfo" />
-      <xsl:apply-templates select="gmd:metadataConstraints" />
-      <xsl:apply-templates select="gmd:applicationSchemaInfo" />
-      <xsl:apply-templates select="gmd:metadataMaintenance" />
 
       <!-- Inflate gmd:dataQualityInfo and add required gmd:scope -->
       <xsl:if test="(gmd:dataQualityInfo)">
@@ -265,6 +261,11 @@
           </gmd:DQ_DataQuality>
         </gmd:dataQualityInfo>
       </xsl:if>
+
+      <xsl:apply-templates select="gmd:portrayalCatalogueInfo" />
+      <xsl:apply-templates select="gmd:metadataConstraints" />
+      <xsl:apply-templates select="gmd:applicationSchemaInfo" />
+      <xsl:apply-templates select="gmd:metadataMaintenance" />
 
     </xsl:copy>
   </xsl:template>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-english.xml
@@ -573,4 +573,23 @@
          </gmd:transferOptions>
       </gmd:MD_Distribution>
   </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement gco:nilReason="missing">
+            <gco:CharacterString/>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
 </gmd:MD_Metadata>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-french.xml
@@ -573,4 +573,23 @@
          </gmd:transferOptions>
       </gmd:MD_Distribution>
   </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement gco:nilReason="missing">
+            <gco:CharacterString/>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
 </gmd:MD_Metadata>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
@@ -622,4 +622,23 @@
          </gmd:transferOptions>
       </gmd:MD_Distribution>
   </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement gco:nilReason="missing">
+            <gco:CharacterString/>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
 </gmd:MD_Metadata>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
@@ -622,4 +622,23 @@
          </gmd:transferOptions>
       </gmd:MD_Distribution>
   </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement gco:nilReason="missing">
+            <gco:CharacterString/>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
 </gmd:MD_Metadata>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector-unilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector-unilingual.xml
@@ -399,4 +399,23 @@
       </gmd:transferOptions>
     </gmd:MD_Distribution>
   </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement gco:nilReason="missing">
+            <gco:CharacterString/>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
 </gmd:MD_Metadata>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
@@ -526,4 +526,23 @@
       </gmd:transferOptions>
     </gmd:MD_Distribution>
   </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset"
+                              codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ScopeCode"/>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement gco:nilReason="missing">
+            <gco:CharacterString/>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
 </gmd:MD_Metadata>


### PR DESCRIPTION
The current template has no such gmd:dataQualityInfo therefore all metadata created are lack of this section. When the user click on "link to a source dataset"
![image](https://user-images.githubusercontent.com/74916635/233385435-4cbaf443-da04-40ac-943a-09eb06ea2273.png)

Geonetwork will add such section into the metadata. However it wasn't added correctly. The required gmd:scope is missing according to the schema https://github.com/metadata101/iso19139.ca.HNAP/blob/14ead08ef492220fb5d7a6e8c22022807b941201/src/main/plugin/iso19139.ca.HNAP/schema/gmd/dataQuality.xsd#L505

![image](https://user-images.githubusercontent.com/74916635/233385599-e5685f9f-d93e-4355-a3b0-26139fc65d91.png)


As result, the schema validation will fail 
![image](https://user-images.githubusercontent.com/74916635/233386126-0d38087c-4b28-4760-8983-7f59d37ab856.png)


This PR will ensure to inflate existing missing gmd:dataQualityInfo also add it to the template. It is backwards compatible by testing with both existing data and adding new data.

![image](https://user-images.githubusercontent.com/74916635/233386611-b1d2e123-9e88-424d-9df9-3d5a1586a72f.png)
