### PR TITLE
disable hierarchyLevel field

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -823,42 +823,42 @@
   </xsl:template>
 
   <!-- Readonly hierarchyLevel in flat mode - changing the hierarchyLevel may cause issues with the xsd schema validation. -->
-  <xsl:template mode="mode-iso19139" priority="2100" match="//gmd:MD_Metadata/gmd:hierarchyLevel[$isFlatMode and $schema = 'iso19139.ca.HNAP']">
-    <xsl:param name="schema" select="$schema" required="no"/>
-    <xsl:param name="labels" select="$labels" required="no"/>
-    <xsl:param name="overrideLabel" select="''" required="no"/>
+<!--  <xsl:template mode="mode-iso19139" priority="2100" match="//gmd:MD_Metadata/gmd:hierarchyLevel[$isFlatMode and $schema = 'iso19139.ca.HNAP']">-->
+<!--    <xsl:param name="schema" select="$schema" required="no"/>-->
+<!--    <xsl:param name="labels" select="$labels" required="no"/>-->
+<!--    <xsl:param name="overrideLabel" select="''" required="no"/>-->
 
-    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
-    <xsl:variable name="fieldLabelConfig"
-                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+<!--    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>-->
+<!--    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>-->
+<!--    <xsl:variable name="fieldLabelConfig"-->
+<!--                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>-->
 
-    <xsl:variable name="labelConfig">
-      <xsl:choose>
-        <xsl:when test="$overrideLabel != ''">
-          <element>
-            <label><xsl:value-of select="$overrideLabel"/></label>
-          </element>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:copy-of select="$fieldLabelConfig"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
+<!--    <xsl:variable name="labelConfig">-->
+<!--      <xsl:choose>-->
+<!--        <xsl:when test="$overrideLabel != ''">-->
+<!--          <element>-->
+<!--            <label><xsl:value-of select="$overrideLabel"/></label>-->
+<!--          </element>-->
+<!--        </xsl:when>-->
+<!--        <xsl:otherwise>-->
+<!--          <xsl:copy-of select="$fieldLabelConfig"/>-->
+<!--        </xsl:otherwise>-->
+<!--      </xsl:choose>-->
+<!--    </xsl:variable>-->
 
-    <xsl:call-template name="render-element">
-      <xsl:with-param name="label"
-                      select="$labelConfig/*"/>
-      <xsl:with-param name="value" select="*"/>
-      <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="xpath" select="$xpath"/>
-      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
-      <xsl:with-param name="name" select="''"/>
-      <xsl:with-param name="editInfo" select="*/gn:element"/>
-      <xsl:with-param name="parentEditInfo" select="gn:element"/>
-      <xsl:with-param name="isDisabled" select="true()"/>
-    </xsl:call-template>
+<!--    <xsl:call-template name="render-element">-->
+<!--      <xsl:with-param name="label"-->
+<!--                      select="$labelConfig/*"/>-->
+<!--      <xsl:with-param name="value" select="*"/>-->
+<!--      <xsl:with-param name="cls" select="local-name()"/>-->
+<!--      <xsl:with-param name="xpath" select="$xpath"/>-->
+<!--      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>-->
+<!--      <xsl:with-param name="name" select="''"/>-->
+<!--      <xsl:with-param name="editInfo" select="*/gn:element"/>-->
+<!--      <xsl:with-param name="parentEditInfo" select="gn:element"/>-->
+<!--      <xsl:with-param name="isDisabled" select="true()"/>-->
+<!--    </xsl:call-template>-->
 
-  </xsl:template>
+<!--  </xsl:template>-->
 
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -822,43 +822,4 @@
 
   </xsl:template>
 
-  <!-- Readonly hierarchyLevel in flat mode - changing the hierarchyLevel may cause issues with the xsd schema validation. -->
-<!--  <xsl:template mode="mode-iso19139" priority="2100" match="//gmd:MD_Metadata/gmd:hierarchyLevel[$isFlatMode and $schema = 'iso19139.ca.HNAP']">-->
-<!--    <xsl:param name="schema" select="$schema" required="no"/>-->
-<!--    <xsl:param name="labels" select="$labels" required="no"/>-->
-<!--    <xsl:param name="overrideLabel" select="''" required="no"/>-->
-
-<!--    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>-->
-<!--    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>-->
-<!--    <xsl:variable name="fieldLabelConfig"-->
-<!--                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>-->
-
-<!--    <xsl:variable name="labelConfig">-->
-<!--      <xsl:choose>-->
-<!--        <xsl:when test="$overrideLabel != ''">-->
-<!--          <element>-->
-<!--            <label><xsl:value-of select="$overrideLabel"/></label>-->
-<!--          </element>-->
-<!--        </xsl:when>-->
-<!--        <xsl:otherwise>-->
-<!--          <xsl:copy-of select="$fieldLabelConfig"/>-->
-<!--        </xsl:otherwise>-->
-<!--      </xsl:choose>-->
-<!--    </xsl:variable>-->
-
-<!--    <xsl:call-template name="render-element">-->
-<!--      <xsl:with-param name="label"-->
-<!--                      select="$labelConfig/*"/>-->
-<!--      <xsl:with-param name="value" select="*"/>-->
-<!--      <xsl:with-param name="cls" select="local-name()"/>-->
-<!--      <xsl:with-param name="xpath" select="$xpath"/>-->
-<!--      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>-->
-<!--      <xsl:with-param name="name" select="''"/>-->
-<!--      <xsl:with-param name="editInfo" select="*/gn:element"/>-->
-<!--      <xsl:with-param name="parentEditInfo" select="gn:element"/>-->
-<!--      <xsl:with-param name="isDisabled" select="true()"/>-->
-<!--    </xsl:call-template>-->
-
-<!--  </xsl:template>-->
-
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -822,4 +822,43 @@
 
   </xsl:template>
 
+  <!-- Readonly hierarchyLevel in flat mode - changing the hierarchyLevel may cause issues with the xsd schema validation. -->
+  <xsl:template mode="mode-iso19139" priority="2100" match="//gmd:MD_Metadata/gmd:hierarchyLevel[$isFlatMode and $schema = 'iso19139.ca.HNAP']">
+    <xsl:param name="schema" select="$schema" required="no"/>
+    <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
+
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+    <xsl:variable name="fieldLabelConfig"
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+
+    <xsl:variable name="labelConfig">
+      <xsl:choose>
+        <xsl:when test="$overrideLabel != ''">
+          <element>
+            <label><xsl:value-of select="$overrideLabel"/></label>
+          </element>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="$fieldLabelConfig"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:call-template name="render-element">
+      <xsl:with-param name="label"
+                      select="$labelConfig/*"/>
+      <xsl:with-param name="value" select="*"/>
+      <xsl:with-param name="cls" select="local-name()"/>
+      <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
+      <xsl:with-param name="name" select="''"/>
+      <xsl:with-param name="editInfo" select="*/gn:element"/>
+      <xsl:with-param name="parentEditInfo" select="gn:element"/>
+      <xsl:with-param name="isDisabled" select="true()"/>
+    </xsl:call-template>
+
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/codelists.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/codelists.xml
@@ -2023,14 +2023,14 @@
 			<description>Information applies to a computer program or routine</description>
 		</entry>
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
-		<entry>
-      <code>RI_631</code>
-			<value>service; service</value>
-			<label>Service</label>
-			<description>Information applies to a capability which a service provider entity makes
-				available to a service user entity through a set of interfaces that define a behaviour,
-				such as a use case</description>
-		</entry>
+<!--		<entry>-->
+<!--      <code>RI_631</code>-->
+<!--			<value>service; service</value>-->
+<!--			<label>Service</label>-->
+<!--			<description>Information applies to a capability which a service provider entity makes-->
+<!--				available to a service user entity through a set of interfaces that define a behaviour,-->
+<!--				such as a use case</description>-->
+<!--		</entry>-->
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 		<entry>
       <code>RI_632</code>
@@ -2064,6 +2064,19 @@
 			<description>Publication</description>
 		</entry>-->
 	</codelist>
+
+  <codelist name="gmd:MD_ScopeCode"
+            displayIf="/ancestor::node()[name()='gmd:MD_Metadata']/gmd:identificationInfo/srv:SV_ServiceIdentification">
+
+    <entry>
+      <code>RI_631</code>
+      <value>service; service</value>
+      <label>Service</label>
+      <description>Information applies to a capability which a service provider entity makes
+        available to a service user entity through a set of interfaces that define a behaviour,
+        such as a use case</description>
+    </entry>
+  </codelist>
 	<!-- ==================================================== -->
 	<codelist name="gmd:MD_SpatialRepresentationTypeCode">
 		<entry>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml
@@ -1946,12 +1946,12 @@
       <description>Informations appliquées à programme ou à une routine</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <entry>
-      <code>RI_631</code>
-      <value>service; service</value>
-      <label>Service</label>
-      <description>Informations appliquées à un service Internet</description>
-    </entry>
+<!--    <entry>-->
+<!--      <code>RI_631</code>-->
+<!--      <value>service; service</value>-->
+<!--      <label>Service</label>-->
+<!--      <description>Informations appliquées à un service Internet</description>-->
+<!--    </entry>-->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>RI_632</code>
@@ -2034,6 +2034,15 @@
 			<description></description>
 		</entry>-->
 	</codelist>
+  <codelist name="gmd:MD_ScopeCode"
+            displayIf="/ancestor::node()[name()='gmd:MD_Metadata']/gmd:identificationInfo/srv:SV_ServiceIdentification">
+        <entry>
+          <code>RI_631</code>
+          <value>service; service</value>
+          <label>Service</label>
+          <description>Informations appliquées à un service Internet</description>
+        </entry>
+  </codelist>
 	<!-- ==================================================== -->
   <codelist name="gmd:MD_TopicCategoryCode" alias="topicCategory">
     <entry>


### PR DESCRIPTION
The hierarchyLevel  will be disabled like this:

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/b752742d-1ba1-49fa-b0a7-2aed769b3fdc)


The issue is service level metadata has validation of 

https://github.com/metadata101/iso19139.ca.HNAP/blob/6066bd8a1504feebf2291d5945a6428d6c002c27/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch#L410-L417

If this metadata was created as dataset which has no such //srv:SV_ServiceIdentification , then switch to service in the hierarchy level, there will be validation error happens.

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/35d5fee8-cd1e-4115-902c-947e32326c5c)


It's not recommended to switch the hierarchyLevel, therefore disabling it from edit mode is the best option.