### PR TITLE
title in batch edit

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -660,9 +660,9 @@
       <field name="title"
              xpath="gmd:identificationInfo/*/
                       gmd:citation/gmd:CI_Citation/gmd:title"
+             insertMode="gn_replace"
              indexField="title">
-        <template>
-          <![CDATA[<gco:CharacterString xmlns:gco='http://www.isotc211.org/2005/gco'>{{value}}</gco:CharacterString>]]></template>
+        <template><![CDATA[<gco:CharacterString xmlns:gco='http://www.isotc211.org/2005/gco'>{{value}}</gco:CharacterString>]]></template>
       </field>
 
       <!-- Insert a new keyword in the first gmd:descriptiveKeywords found.


### PR DESCRIPTION
This PR fixed the issue in batch editing. With batch edit the title
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/52a73c2f-105d-49c1-9c83-f0efc8dba6e8)


the title will totally wiped out 

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/83a606b5-29e4-4662-a6a2-0752f3d08842)


Issue 1: The operation name GN_Replace was missing from the api call
Issue 2: There is unwanted line change in the API call value

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/cbe9ceae-bf64-41fe-9793-57dae2f70146)


This is what it looks like in GN3.12 with ISO19139
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/201a7670-c017-4de3-8ec8-370c435bdb34)


Fixing Code refers to:
https://github.com/geonetwork/core-geonetwork/blob/57c116c539be00fdef2d7be61d1f72af4f35b405/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml#L3398-L3402