### PR TITLE
Remove persisting referenceSystemInfo element

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -206,29 +206,6 @@
 
       <xsl:apply-templates select="gmd:spatialRepresentationInfo" />
       <xsl:apply-templates select="gmd:referenceSystemInfo" />
-      <xsl:if test="not(gmd:referenceSystemInfo)">
-        <xsl:variable name="spatialRepresentationType" select="gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode/@codeListValue" />
-
-        <xsl:if test="$spatialRepresentationType = 'RI_635' or $spatialRepresentationType = 'RI_636' or $spatialRepresentationType = 'RI_638'">
-          <gmd:referenceSystemInfo>
-            <gmd:MD_ReferenceSystem>
-              <gmd:referenceSystemIdentifier>
-                <gmd:RS_Identifier>
-                  <gmd:code>
-                    <gco:CharacterString/>
-                  </gmd:code>
-                  <gmd:codeSpace>
-                    <gco:CharacterString/>
-                  </gmd:codeSpace>
-                  <gmd:version>
-                    <gco:CharacterString/>
-                  </gmd:version>
-                </gmd:RS_Identifier>
-              </gmd:referenceSystemIdentifier>
-            </gmd:MD_ReferenceSystem>
-          </gmd:referenceSystemInfo>
-        </xsl:if>
-      </xsl:if>
 
       <xsl:apply-templates select="gmd:identificationInfo" />
       <xsl:apply-templates select="gmd:contentInfo" />

--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -206,6 +206,29 @@
 
       <xsl:apply-templates select="gmd:spatialRepresentationInfo" />
       <xsl:apply-templates select="gmd:referenceSystemInfo" />
+      <xsl:if test="not(gmd:referenceSystemInfo)">
+        <xsl:variable name="spatialRepresentationType" select="gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode/@codeListValue" />
+
+        <xsl:if test="$spatialRepresentationType = 'RI_635' or $spatialRepresentationType = 'RI_636' or $spatialRepresentationType = 'RI_638'">
+          <gmd:referenceSystemInfo>
+            <gmd:MD_ReferenceSystem>
+              <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString/>
+                  </gmd:code>
+                  <gmd:codeSpace>
+                    <gco:CharacterString/>
+                  </gmd:codeSpace>
+                  <gmd:version>
+                    <gco:CharacterString/>
+                  </gmd:version>
+                </gmd:RS_Identifier>
+              </gmd:referenceSystemIdentifier>
+            </gmd:MD_ReferenceSystem>
+          </gmd:referenceSystemInfo>
+        </xsl:if>
+      </xsl:if>
 
       <xsl:apply-templates select="gmd:identificationInfo" />
       <xsl:apply-templates select="gmd:contentInfo" />

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -509,11 +509,31 @@
 
         </section>
 
-
-        <section name="referenceSystemInfo">
-          <field xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"
-                 in="/gmd:MD_Metadata"
-                 or="referenceSystemInfo"/>
+        <section name="referenceSystemInfo" displayIfRecord="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">
+          <field
+            xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"
+            if="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0"
+            del="../../../..">
+          </field>
+          <action type="add" name="referenceSystemInfo" or="referenceSystemInfo"
+                  in="/gmd:MD_Metadata"
+                  if="count(/gmd:MD_Metadata/gmd:referenceSystemInfo) = 0">
+            <template>
+              <snippet>
+                <gmd:referenceSystemInfo>
+                  <gmd:MD_ReferenceSystem>
+                    <gmd:referenceSystemIdentifier>
+                      <RS_Identifier>
+                        <code>
+                          <gco:CharacterString></gco:CharacterString>
+                        </code>
+                      </RS_Identifier>
+                    </gmd:referenceSystemIdentifier>
+                  </gmd:MD_ReferenceSystem>
+                </gmd:referenceSystemInfo>
+              </snippet>
+            </template>
+          </action>
         </section>
 
         <section xpath="/gmd:MD_Metadata/gmd:spatialRepresentationInfo"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -509,30 +509,10 @@
 
         </section>
 
-        <section name="referenceSystemInfo">
-          <field
-            xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"
-            if="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">
-          </field>
-          <action type="add" name="referenceSystemInfo" or="referenceSystemInfo"
-                  in="/gmd:MD_Metadata"
-                  if="count(/gmd:MD_Metadata/gmd:referenceSystemInfo) = 0">
-            <template>
-              <snippet>
-                <gmd:referenceSystemInfo>
-                  <gmd:MD_ReferenceSystem>
-                    <gmd:referenceSystemIdentifier>
-                      <RS_Identifier>
-                        <code>
-                          <gco:CharacterString></gco:CharacterString>
-                        </code>
-                      </RS_Identifier>
-                    </gmd:referenceSystemIdentifier>
-                  </gmd:MD_ReferenceSystem>
-                </gmd:referenceSystemInfo>
-              </snippet>
-            </template>
-          </action>
+        <section name="referenceSystemInfo" displayIfRecord="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">
+          <field xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"
+                 in="/gmd:MD_Metadata"
+                 or="referenceSystemInfo"/>
         </section>
 
         <section xpath="/gmd:MD_Metadata/gmd:spatialRepresentationInfo"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -512,8 +512,7 @@
         <section name="referenceSystemInfo" displayIfRecord="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">
           <field
             xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"
-            if="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0"
-            del="../../../..">
+            if="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">
           </field>
           <action type="add" name="referenceSystemInfo" or="referenceSystemInfo"
                   in="/gmd:MD_Metadata"

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -509,7 +509,7 @@
 
         </section>
 
-        <section name="referenceSystemInfo" displayIfRecord="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">
+        <section name="referenceSystemInfo">
           <field
             xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"
             if="count(gmd:MD_Metadata/gmd:referenceSystemInfo) > 0">


### PR DESCRIPTION
Bug- Empty referenceSystemInfo element persists in view:
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/29507317/947135aa-897b-4953-b260-2ddfba8b0361)

Bug fix removes referenceSystemInfo element from view when is empty element or all child field sets are removed.
