### PR TITLE
replace RI_528 to hardcoded codelist value

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/bulk-edit-process.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/bulk-edit-process.xsl
@@ -713,7 +713,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.theme.EC_Information_Category">
@@ -789,7 +789,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.place.EC_Geographic_Scope">
@@ -867,7 +867,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.theme.EC_Data_Usage_Scope">
@@ -944,7 +944,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.theme.EC_Content_Scope">
@@ -1198,7 +1198,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.theme.EC_Information_Category">
@@ -1274,7 +1274,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.place.EC_Geographic_Scope">
@@ -1352,7 +1352,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.theme.EC_Data_Usage_Scope">
@@ -1429,7 +1429,7 @@
                 </gmd:PT_FreeText>
               </gmd:keyword>
               <gmd:type>
-                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+                <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
               </gmd:type>
               <gmd:thesaurusName>
                 <gmd:CI_Citation id="local.theme.EC_Content_Scope">

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-english.xml
@@ -326,7 +326,7 @@
                </gmd:keyword>
                <gmd:type>
                   <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101"
-                                           codeListValue="theme" />
+                                          codeListValue="RI_528" >theme; thème</gmd:MD_KeywordTypeCode>
                </gmd:type>
                <gmd:thesaurusName>
                   <gmd:CI_Citation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-french.xml
@@ -326,7 +326,7 @@
                </gmd:keyword>
                <gmd:type>
                   <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101"
-                                          codeListValue="theme" />
+                                          codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
                </gmd:type>
                <gmd:thesaurusName>
                   <gmd:CI_Citation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
@@ -121,7 +121,7 @@
          <gmd:role>
             <gmd:CI_RoleCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_90"
                              codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
-         </gmd:role>                    
+         </gmd:role>
       </gmd:CI_ResponsibleParty>
   </gmd:contact>
    <gmd:dateStamp>
@@ -343,7 +343,7 @@
                </gmd:keyword>
                <gmd:type>
                   <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101"
-                                           codeListValue="theme" />
+                                          codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
                </gmd:type>
                <gmd:thesaurusName>
                   <gmd:CI_Citation>
@@ -363,7 +363,7 @@
                            <gmd:dateType>
                               <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                                    codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
-                           </gmd:dateType>                        
+                           </gmd:dateType>
                         </gmd:CI_Date>
                      </gmd:date>
 					 <gmd:date>
@@ -374,7 +374,7 @@
                            <gmd:dateType>
                               <gmd:CI_DateTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_87"
                                                    codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
-                           </gmd:dateType>                        
+                           </gmd:dateType>
                         </gmd:CI_Date>
                      </gmd:date>
                      <gmd:citedResponsibleParty>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
@@ -343,7 +343,7 @@
                </gmd:keyword>
                <gmd:type>
                   <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101"
-                                           codeListValue="theme" />
+                                          codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
                </gmd:type>
                <gmd:thesaurusName>
                   <gmd:CI_Citation>

--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -876,9 +876,18 @@
 
 
             <gmd:type>
-              <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="{@type}">
-                  <xsl:value-of select="$codelistDocument/codelists/codelist[@name='gmd:MD_KeywordTypeCode']/entry[code = $currentCodeValue]/value"/>
-              </gmd:MD_KeywordTypeCode>
+              <xsl:choose>
+                <xsl:when test="$currentCodeValue='theme'">
+                  <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">
+                    <xsl:value-of select="$codelistDocument/codelists/codelist[@name='gmd:MD_KeywordTypeCode']/entry[code = 'RI_528']/value"/>
+                  </gmd:MD_KeywordTypeCode>
+                </xsl:when>
+                <xsl:otherwise>
+                  <gmd:MD_KeywordTypeCode codeList="https://schemas.metadata.geo.ca/register/napMetadataRegister.xml#IC_101" codeListValue="{@type}">
+                    <xsl:value-of select="$codelistDocument/codelists/codelist[@name='gmd:MD_KeywordTypeCode']/entry[code = $currentCodeValue]/value"/>
+                  </gmd:MD_KeywordTypeCode>
+                </xsl:otherwise>
+              </xsl:choose>
             </gmd:type>
 
             <xsl:copy-of select="keyword[1]/gmd:thesaurusName" />


### PR DESCRIPTION
Several template consist of incorrect codeList value for the theme.

The value supposed to be 

https://github.com/metadata101/iso19139.ca.HNAP/blob/43efe958be6b8eb18acec2372e945056037b18e2/src/main/plugin/iso19139.ca.HNAP/loc/eng/codelists.xml#L1272

https://github.com/metadata101/iso19139.ca.HNAP/blob/43efe958be6b8eb18acec2372e945056037b18e2/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml#L1204

