### PR TITLE
Add validation of extents

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -386,6 +386,50 @@
 
       <xsl:apply-templates select="gmd:environmentDescription" />
       <xsl:apply-templates select="gmd:extent" />
+
+      <!-- Add mandatory temporal extent if gmd:spatialRepresentationType exists -->
+      <xsl:if test="(gmd:spatialRepresentationType) and (count(gmd:extent/gmd:EX_Extent/gmd:temporalElement[gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod]) = 0)">
+        <gmd:extent>
+          <gmd:EX_Extent>
+            <gmd:temporalElement>
+              <gmd:EX_TemporalExtent>
+                <gmd:extent>
+                  <gml:TimePeriod gml:id="{generate-id(.)}">
+                    <gml:beginPosition></gml:beginPosition>
+                    <gml:endPosition></gml:endPosition>
+                  </gml:TimePeriod>
+                </gmd:extent>
+              </gmd:EX_TemporalExtent>
+            </gmd:temporalElement>
+          </gmd:EX_Extent>
+        </gmd:extent>
+      </xsl:if>
+
+      <!-- Add mandatory geographic extent if gmd:spatialRepresentationType exists -->
+      <xsl:if test="(gmd:spatialRepresentationType) and (count(gmd:extent/gmd:EX_Extent/gmd:geographicElement[gmd:EX_GeographicBoundingBox]) = 0)">
+        <gmd:extent>
+          <gmd:EX_Extent>
+            <gmd:geographicElement>
+              <gmd:EX_GeographicBoundingBox>
+                <gmd:westBoundLongitude>
+                  <gco:Decimal></gco:Decimal>
+                </gmd:westBoundLongitude>
+                <gmd:eastBoundLongitude>
+                  <gco:Decimal></gco:Decimal>
+                </gmd:eastBoundLongitude>
+                <gmd:southBoundLatitude>
+                  <gco:Decimal></gco:Decimal>
+                </gmd:southBoundLatitude>
+                <gmd:northBoundLatitude>
+                  <gco:Decimal></gco:Decimal>
+                </gmd:northBoundLatitude>
+              </gmd:EX_GeographicBoundingBox>
+            </gmd:geographicElement>
+          </gmd:EX_Extent>
+        </gmd:extent>
+
+      </xsl:if>
+
       <xsl:apply-templates select="gmd:supplementalInformation" />
     </xsl:copy>
   </xsl:template>

--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -2,6 +2,7 @@
 
 <xsl:stylesheet   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                   xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                  xmlns:gml="http://www.opengis.net/gml/3.2"
                   xmlns:xlink='http://www.w3.org/1999/xlink'
                   xmlns:gco="http://www.isotc211.org/2005/gco"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -42,6 +42,10 @@
   <DistributionFormatInvalid>Value for distribution format is not valid</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
   <OnlineResourceProtocol>Protocol of Online Resource is not valid. Valid values are: </OnlineResourceProtocol>
+  <TemporalExtentRequired>Temporal extent is required</TemporalExtentRequired>
+  <GeographicExtentRequired>Geographic extent is required</GeographicExtentRequired>
+  <GeographicExtentWestEast>Geographic extent - westbound longitude should be lower than eastbound longitude</GeographicExtentWestEast>
+  <GeographicExtentNorthSouth>Geographic extent - southbound latitude should be lower than northbound latitude</GeographicExtentNorthSouth>
 
   <MapResourcesREST>REST Map Resources should be available in english and french</MapResourcesREST>
   <MapResourcesRESTNumber>The number of ESRI REST Map Resources should be at most 2 (one for english and one for french)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -42,6 +42,10 @@
   <DistributionFormatInvalid>Valeur du format de distribution n'est pas valide</DistributionFormatInvalid>
   <OnlineResourceUrl>Value is required for Online Resource URL</OnlineResourceUrl>
   <OnlineResourceProtocol>Protocole de ressource en ligne n'est pas valide. Les valeurs valides sont </OnlineResourceProtocol>
+  <TemporalExtentRequired>Une valeur est nécessaire pour: Etendue temporelle</TemporalExtentRequired>
+  <GeographicExtentRequired>Une valeur est nécessaire pour: Étendue géographique</GeographicExtentRequired>
+  <GeographicExtentWestEast>Étendue géographique - la longitude ouest doit être inférieure à la longitude est</GeographicExtentWestEast>
+  <GeographicExtentNorthSouth>Étendue géographique - la latitude sud devrait être inférieure à la latitude nord</GeographicExtentNorthSouth>
 
   <MapResourcesREST>Les sources de la carte REST devraient être disponibles en anglais et en français</MapResourcesREST>
   <MapResourcesRESTNumber>Le nombre de sources de la carte ESRI REST devrait être au plus 2 (une pour l'anglais et une pour le français)</MapResourcesRESTNumber>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -284,6 +284,47 @@
       <sch:assert test="$missingBeginPosition or $missingEndPosition or (XslUtilHnap:compareDates($endPosition, $beginPosition) &gt;= 0)">$loc/strings/EndPosition</sch:assert>
     </sch:rule>
 
+    <!-- Geographical extent - mandatory if spatialRepresentationType exists -->
+    <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification[gmd:spatialRepresentationType]/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox
+                      |//gmd:identificationInfo/srv:SV_ServiceIdentification[gmd:spatialRepresentationType]/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox
+                      |//*[@gco:isoType='gmd:MD_DataIdentification' and gmd:spatialRepresentationType]/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox
+                      |//*[@gco:isoType='srv:SV_ServiceIdentification' and gmd:spatialRepresentationType]/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
+      <sch:let name="missing" value="(not(string(gmd:westBoundLongitude/gco:Decimal))
+                                  or not(string(gmd:eastBoundLongitude/gco:Decimal))
+                                  or not(string(gmd:southBoundLatitude/gco:Decimal))
+                                  or not(string(gmd:northBoundLatitude/gco:Decimal)))
+                                  or (@gco:nilReason)" />
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/GeographicExtentRequired</sch:assert>
+    </sch:rule>
+
+    <!-- Geographic extent - east-west check -->
+    <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude
+                |//gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude
+                |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude
+                |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude">
+
+      <sch:let name="westBoundLongitude" value="gco:Decimal" />
+      <sch:let name="eastBoundLongitude" value="../gmd:eastBoundLongitude/gco:Decimal" />
+
+      <sch:assert
+        test="not(string($westBoundLongitude))  or not(string($eastBoundLongitude)) or (number($westBoundLongitude) &lt; number($eastBoundLongitude))">$loc/strings/GeographicExtentWestEast</sch:assert>
+    </sch:rule>
+
+    <!-- Geographic extent - north-south check -->
+    <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude
+          |//gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude
+          |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude
+          |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude">
+
+      <sch:let name="southBoundLatitude" value="gco:Decimal" />
+      <sch:let name="northBoundLatitude" value="../gmd:northBoundLatitude/gco:Decimal" />
+
+      <sch:assert
+        test="not(string($northBoundLatitude))  or not(string($southBoundLatitude)) or (number($southBoundLatitude) &lt; number($northBoundLatitude))">$loc/strings/GeographicExtentNorthSouth</sch:assert>
+    </sch:rule>
+
     <!-- Dataset language -->
     <sch:rule context="//gmd:identificationInfo/*/gmd:language
                    |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:language
@@ -361,6 +402,14 @@
               */gmd:thesaurusName/*/gmd:title/*/text() = 'Thésaurus des sujets de base du gouvernement du Canada']) > 0" />
 
       <sch:assert test="$coreSubjectThesaurusExists">$loc/strings/CoreSubjectThesaurusMissing</sch:assert>
+
+      <!-- Temporal extent - mandatory if spatialRepresentationType exists -->
+      <sch:let name="hasTemporalExtent" value="count(gmd:extent/*/gmd:temporalElement/*/gmd:extent/gml:TimePeriod) > 0" />
+      <sch:assert test="not(gmd:spatialRepresentationType) or  $hasTemporalExtent">$loc/strings/TemporalExtentRequired</sch:assert>
+
+      <!-- Geographic extent - mandatory if spatialRepresentationType exists -->
+      <sch:let name="hasGeographicExtent" value="count(gmd:extent/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox) > 0" />
+      <sch:assert test="not(gmd:spatialRepresentationType) or $hasGeographicExtent">$loc/strings/GeographicExtentRequired</sch:assert>
     </sch:rule>
 
     <!-- Access constraints -->


### PR DESCRIPTION
Add validation of extents
Also extents should be mandatory when gmd:spatialRepresentationType exists.

In the past some of validation was removed for the extents however I think it was incorrect.  It was remove to support non spatial data however instead of removing it completely, it should have probably just been checked when gmd:spatialRepresentationType exists.

This fixes an issue where records would validate however when publishing to FGP, the record would fail due to extent validation issues. Since FGP required spatialRepresentationType, making the check only enforce the rules when spatialRepresentationType  exists seems to fix the issue with FGP and also still works for non-spatial metadata which does not have spatialRepresentationType.