### PR TITLE
improve error message for multilingual field security notes

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -41,6 +41,8 @@
   <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
   <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
+  <SecurityLevelEn>Security User Note is not valid and required by both languages. Valid English values are: </SecurityLevelEn>
+  <SecurityLevelFr> Valid French values are: </SecurityLevelFr>
   <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -41,6 +41,8 @@
   <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
+  <SecurityLevelEn>La note d'utilisateur de sécurité n'est pas valide et requise par les deux langues. Les valeurs anglaises valides sont : </SecurityLevelEn>
+  <SecurityLevelFr> Les valeurs françaises valides sont : </SecurityLevelFr>
   <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont :</SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Explications sur les restrictions devrait être vide pour la restriction de manipulation</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>Si vous indiquez «Autres restrictions» dans les champs «Contraintes d'accès» ou «Utiliser les contraintes», les autres contraintes d'accès ou d'utilisation de la ressource doivent être expliquées ici.</OtherConstraintsNote>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -68,6 +68,22 @@
     <xsl:value-of select="$v" />
   </xsl:function>
 
+  <xsl:function name="geonet:securityLevelListWithLang" as="xs:string">
+    <xsl:param name="thesaurusDir" as="xs:string"/>
+    <xsl:param name="securityLevelLang" as="xs:string"/>
+
+    <xsl:variable name="security-level-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+      <xsl:variable name="v">
+        <xsl:for-each select="$security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$securityLevelLang]">
+          <xsl:sort select="lower-case(.)" order="ascending"/>
+          <xsl:value-of select="."/>
+          <xsl:if test="position() != last()">, </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+
+    <xsl:value-of select="$v" />
+  </xsl:function>
+
   <xsl:function xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                 name="geonet:checkUserNoteSecurityClassificationCode"
                 as="xs:string">
@@ -763,8 +779,12 @@
       <sch:let name="securityLevel" value="gco:CharacterString" />
       <sch:let name="securityLevelTranslated" value="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]" />
       <sch:let name="securityLevelList" value="geonet:securityLevelList($thesaurusDir)" />
+      <sch:let name="securityLevelListEn" value="geonet:securityLevelListWithLang($thesaurusDir, 'en')" />
+      <sch:let name="securityLevelListFr" value="geonet:securityLevelListWithLang($thesaurusDir, 'fr')" />
 
-      <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityLevel, $securityLevelList)" />
+      <sch:let name="locMsgEn" value="geonet:appendLocaleMessage($loc/strings/SecurityLevelEn, $securityLevelListEn)" />
+      <sch:let name="locMsgFr" value="geonet:appendLocaleMessage($loc/strings/SecurityLevelFr, $securityLevelListFr)" />
+      <sch:let name="locMsg" value="geonet:appendLocaleMessage($locMsgEn, $locMsgFr)" />
 
       <sch:let name="validSecurityLevel" value="($missingTitle and $missingTitleOtherLang) or
                         ($security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel and


### PR DESCRIPTION
This PR is improvement PR to display both English and French valid value for security notes in the validation error message

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/9fd1738f-891b-4e04-ae7c-c1db2f51ab26)
