### PR TITLE
Mismatching security code in both language validation, missing lang i…

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -41,6 +41,8 @@
   <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
   <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
+  <SecurityNoteBothLangRequired>Value is required for Security User Note in both languages</SecurityNoteBothLangRequired>
+  <SecurityNoteMismatchedBothLang>Value mismatched for Security User Note in both languages</SecurityNoteMismatchedBothLang>
   <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -41,6 +41,8 @@
   <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
+  <SecurityNoteBothLangRequired>Une valeur est requise pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteBothLangRequired>
+  <SecurityNoteMismatchedBothLang>Valeur non concordante pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteMismatchedBothLang>
   <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont :</SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Explications sur les restrictions devrait être vide pour la restriction de manipulation</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>Si vous indiquez «Autres restrictions» dans les champs «Contraintes d'accès» ou «Utiliser les contraintes», les autres contraintes d'accès ou d'utilisation de la ressource doivent être expliquées ici.</OtherConstraintsNote>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -769,7 +769,7 @@
       <sch:let name="missingOneTitleExclusively" value="($missingTitle and not($missingTitleOtherLang)) or (not($missingTitle) and $missingTitleOtherLang)" />
       <sch:let name="missingBothTitle" value="($missingTitle and $missingTitleOtherLang)" />
 
-      <sch:let name="validSecurityLevel" value="(missingBothTitle) or
+      <sch:let name="validSecurityLevel" value="($missingBothTitle) or
                         ($security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel and
                          $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char]=$securityLevelTranslated)"/>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -766,21 +766,29 @@
 
       <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityLevel, $securityLevelList)" />
 
-      <sch:let name="validSecurityLevel" value="($missingTitle and $missingTitleOtherLang) or
+      <sch:let name="missingOneTitleExclusively" value="($missingTitle and not($missingTitleOtherLang)) or (not($missingTitle) and $missingTitleOtherLang)" />
+      <sch:let name="missingBothTitle" value="($missingTitle and $missingTitleOtherLang)" />
+
+      <sch:let name="validSecurityLevel" value="(missingBothTitle) or
                         ($security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]=$securityLevel and
                          $security-level-list//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char]=$securityLevelTranslated)"/>
 
-      <sch:assert test="$validSecurityLevel">$locMsg</sch:assert>
+      <sch:assert test="not($missingOneTitleExclusively)">$loc/strings/SecurityNoteBothLangRequired</sch:assert>
+
+      <sch:assert test="$missingOneTitleExclusively or $validSecurityLevel">$locMsg</sch:assert>
 
       <sch:let name="securityLevelCode" value="replace($security-level-list//rdf:Description[lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])=lower-case($securityLevel)]/@rdf:about, 'http://geonetwork-opensource.org/GC/GC_Security_Classification#', '')"/>
+      <sch:let name="securityLevelCodeTranslated" value="replace($security-level-list//rdf:Description[lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])=lower-case($securityLevelTranslated)]/@rdf:about, 'http://geonetwork-opensource.org/GC/GC_Security_Classification#', '')"/>
+      <sch:let name="securityLevelCodeMismatched" value="$securityLevelCode != $securityLevelCodeTranslated"/>
 
       <sch:let name="checkUserNoteSecurityClassificationCode" value="geonet:checkUserNoteSecurityClassificationCode($securityLevelCode, ../gmd:classification/gmd:MD_ClassificationCode)" />
 
       <sch:let name="locSecurityClassificationUserNoteMsg" value="geonet:appendLocaleMessage($loc/strings/SecurityClassificationUserNote, $checkUserNoteSecurityClassificationCode)" />
 
-      <sch:assert test="($missingTitle and $missingTitleOtherLang) or not($validSecurityLevel) or $checkUserNoteSecurityClassificationCode='NULL' or $checkUserNoteSecurityClassificationCode = ''">$locSecurityClassificationUserNoteMsg</sch:assert>
+      <sch:assert test="not($validSecurityLevel) or not($securityLevelCodeMismatched)">$loc/strings/SecurityNoteMismatchedBothLang</sch:assert>
+      <sch:assert test="($missingBothTitle) or not($validSecurityLevel) or not($securityLevelCodeMismatched) or $checkUserNoteSecurityClassificationCode='NULL' or $checkUserNoteSecurityClassificationCode = ''">$locSecurityClassificationUserNoteMsg</sch:assert>
 
-      <sch:assert test="($missingTitle and $missingTitleOtherLang) or not($validSecurityLevel) or $checkUserNoteSecurityClassificationCode!='NULL' or $checkUserNoteSecurityClassificationCode = ''">$loc/strings/SecurityClassificationUserNoteEmpty</sch:assert>
+      <sch:assert test="($missingBothTitle) or not($validSecurityLevel) or not($securityLevelCodeMismatched) or $checkUserNoteSecurityClassificationCode!='NULL' or $checkUserNoteSecurityClassificationCode = ''">$loc/strings/SecurityClassificationUserNoteEmpty</sch:assert>
 
     </sch:rule>
 


### PR DESCRIPTION
Added couple of improvement validations.

1) This field is not mandatory so both lang can be missing, but if the user decide to input one lang and skip another. It will returns error:

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/48ef2bc4-1a04-4198-a5ac-612609f8513f)

2) The existing logic still works. It will catch the invalid security code.
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/6d1467e5-dff6-445f-bf21-df2868602729)


3) Both lang input are valid, but they are mismatched security code. For example one is Protected A and one is protected B

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/e249565c-a3a2-49bc-9dfe-583642a4e330)
