### PR TITLE
allow other constraint to be filled

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -45,7 +45,8 @@
   <SecurityNoteMismatchedBothLang>Value mismatched for Security User Note in both languages</SecurityNoteMismatchedBothLang>
   <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
-  <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>
+  <OtherConstraintsNote>If you have indicated 'Other Restrictions' in either the 'Access Constraints' or 'Use Constraints' fields, the ‘Other constraints' text box must be completed.</OtherConstraintsNote>
+  <OtherConstraintsNoteEmpty>If you did not indicate 'Other Restrictions' in either the 'Access Constraints' or 'Use Constraints' fields, the ‘Other constraints’ text box must be empty.</OtherConstraintsNoteEmpty>
   <UseLimitation>Value is required for Use Limitation in both languages</UseLimitation>
 
   <ContactOrganisationName>Contact - Organization name is required in both languages</ContactOrganisationName>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -45,7 +45,8 @@
   <SecurityNoteMismatchedBothLang>Valeur non concordante pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteMismatchedBothLang>
   <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont :</SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Explications sur les restrictions devrait être vide pour la restriction de manipulation</SecurityClassificationUserNoteEmpty>
-  <OtherConstraintsNote>Si vous indiquez «Autres restrictions» dans les champs «Contraintes d'accès» ou «Utiliser les contraintes», les autres contraintes d'accès ou d'utilisation de la ressource doivent être expliquées ici.</OtherConstraintsNote>
+  <OtherConstraintsNote>Si vous avez indiqué « Autres restrictions » dans les champs « Contraintes d'accès » ou « Contraintes d'utilisation », la zone de texte « Autres contraintes » doit être complétée.</OtherConstraintsNote>
+  <OtherConstraintsNoteEmpty>Si vous n'avez pas indiqué « Autres restrictions » dans les champs « Contraintes d'accès » ou « Contraintes d'utilisation », la zone de texte « Autres contraintes » doit être vide.</OtherConstraintsNoteEmpty>
   <UseLimitation>Limitation d'utilisation est obligatoire dans les deux langues</UseLimitation>
 
   <ContactOrganisationName>Contact - Nom de l'organisation est obligatoire dans les deux langues</ContactOrganisationName>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -741,9 +741,8 @@
                 and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'
                 or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609')) or
 
-                (not(string(gco:CharacterString)) and not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))
-                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
-                and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609')
+                (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
+                and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
                 )" />
       <sch:assert
         test="$filledFine"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -744,9 +744,19 @@
                 (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
                 and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
                 )" />
+      <sch:let name="emptyFine" value="(
+                (not(string(gco:CharacterString)) and not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))
+                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
+                or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609')
+                ) or
+                (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'
+                or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'))" />
       <sch:assert
         test="$filledFine"
       >$loc/strings/OtherConstraintsNote</sch:assert>
+      <sch:assert
+        test="$emptyFine"
+      >$loc/strings/OtherConstraintsNoteEmpty</sch:assert>
 
     </sch:rule>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -425,9 +425,20 @@
                 (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
                 and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
                 ))" />
+      <sch:let name="emptyFine" value="(
+                (not(string(gco:CharacterString))
+                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
+                or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609')
+                ) or
+                (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'
+                or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609')
+                )" />
       <sch:assert
         test="$filledFine"
       >$loc/strings/OtherConstraintsNote</sch:assert>
+      <sch:assert
+        test="$emptyFine"
+      >$loc/strings/OtherConstraintsNoteEmpty</sch:assert>
     </sch:rule>
 
     <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:userNote">

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -422,9 +422,8 @@
                 and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'
                 or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609')) or
 
-                (not(string(gco:CharacterString))
-                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
-                and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609')
+                (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
+                and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
                 ))" />
       <sch:assert
         test="$filledFine"


### PR DESCRIPTION
The current validation doesn't allow this other constraint field to be filled if the user didn't select "other restriction" for Access Constraint field or User Constraint field.

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/b9df1378-3f4f-41a9-8b0d-9f6b3fb027a9)

This pull request removes such barrier. Other validation will still stay (i.e. check other constraint's emptiness if the user select "Other restriction" for Access Constraint field or User Constraint field.)