### PR TITLE
Remove empty extent sections and don't display the container element in the metadata editor

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -505,7 +505,8 @@
                  if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0">
           </field>
 
-          <section name="gmd:EX_Extent">
+          <section name="gmd:EX_Extent" displayIfRecord="(count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent[gmd:EX_Extent/gmd:description]) +
+                                                         count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent[gmd:EX_Extent/gmd:geographicElement])) > 0">
             <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:description"/>
             <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement"/>
           </section>

--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -964,6 +964,11 @@
     </xsl:copy>
   </xsl:template>
 
+
+  <!-- Remove empty extent sections -->
+  <xsl:template match="gmd:MD_DataIdentification/gmd:extent[count(gmd:EX_Extent/*) = 0]" />
+
+
   <xsl:template match="@xsi:schemaLocation">
     <xsl:if test="XslUtil:getSettingValue('system/metadata/validation/removeSchemaLocation') = 'false'">
       <xsl:copy-of select="."/>


### PR DESCRIPTION
Replaces #339

