### PR TITLE
change label to "Access to the catalogue"

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/strings.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/strings.xml
@@ -43,7 +43,7 @@
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <viewMode>Views</viewMode>
-  <linkToPortal>Access to the portal</linkToPortal>
+  <linkToPortal>Access to the catalogue</linkToPortal>
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/strings.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/strings.xml
@@ -42,7 +42,7 @@
   <providedBy>Fourni par</providedBy>
   <shareOnSocialSite>Partager</shareOnSocialSite>
   <viewMode>Mode d'affichage</viewMode>
-  <linkToPortal>Lien vers le portail</linkToPortal>
+  <linkToPortal>Lien vers le catalogue</linkToPortal>
   <linkToPortal-help>Consultez l'intégralité des métadonnées et accédez à la donnée.</linkToPortal-help>
   <citationProposal>Proposition de citation</citationProposal>
   <citationProposal-help>Cette proposition de citation a été générée automatiquement selon le format suggéré par DataCite. Nous vous invitons à vérifier dans les métadonnées si les auteurs n'ont pas imposé un format de citation spécifique.</citationProposal-help>


### PR DESCRIPTION
The label will be changed from the parent schema in this pull request https://github.com/geonetwork/core-geonetwork/pull/7467/files

Here is the original label
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/d8f6a262-c0e2-4bd2-9497-4f8cc9d4118c)
