### PR TITLE
xpath bug fixed.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -220,8 +220,8 @@
     |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']/gmd:date
     |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']/gmd:date">
 
-      <sch:let name="creationDate" value="../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:Date[1]
-                                         |../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:DateTime[1]" />
+      <sch:let name="creationDate" value="(../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:Date)[1]
+                                         |(../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:DateTime)[1]" />
       <sch:let name="missingCreation" value="not(string($creationDate))" />
       <sch:let name="publicationDate" value="gco:Date|gco:DateTime" />
       <sch:let name="missingPublication" value="not(string($publicationDate))" />

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -220,8 +220,8 @@
     |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']/gmd:date
     |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']/gmd:date">
 
-      <sch:let name="creationDate" value="(../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:Date)[1]
-                                         |(../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:DateTime)[1]" />
+      <sch:let name="creationDate" value="(../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:Date
+                                         | ../../../gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date/gco:DateTime)[1]" />
       <sch:let name="missingCreation" value="not(string($creationDate))" />
       <sch:let name="publicationDate" value="gco:Date|gco:DateTime" />
       <sch:let name="missingPublication" value="not(string($publicationDate))" />


### PR DESCRIPTION
The dual creation date was supported for the date validation. But due to some minor bug. It does not retrieve the xpath correctly.

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/e1f410b5-0f0e-4cda-acc5-ec6afe857783)


I have printed from the local IDE console and found both creation date were selected.
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/276023e5-5a5b-4f08-b5a1-98976682f0e1)


So I made the fix