### PR TITLE
citation validation

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -56,4 +56,7 @@
   <ServiceNamespace>srv:SV_ServiceIdentification is misplaced for gmd:MD_ScopeCode: </ServiceNamespace>
   <MissingContactMail>Contact - Electronic mail address is required</MissingContactMail>
 
+  <requireCitation>Citation</requireCitation>
+  <alert.requiredCitation>Data Identification Citation is a required element</alert.requiredCitation>
+
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -56,4 +56,7 @@
   <ServiceNamespace>srv:SV_ServiceIdentification est mal placé pour gmd:MD_ScopeCode: </ServiceNamespace>
   <MissingContactMail>Contact - Adresse de courrier électronique obligatoire</MissingContactMail>
 
+  <requireCitation>Citation</requireCitation>
+  <alert.requiredCitation>La citation d’identification des données est un élément obligatoire</alert.requiredCitation>
+
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -153,7 +153,7 @@
   <sch:pattern>
       <sch:title>$loc/strings/requireCitation</sch:title>
       <sch:rule context="//gmd:identificationInfo/*/gmd:citation">
-          <sch:assert test="gmd:CI_Citation | @gco:nilReason">
+          <sch:assert test="gmd:CI_Citation">
               <sch:value-of select="$loc/strings/alert.requiredCitation"/>
           </sch:assert>
       </sch:rule>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -149,6 +149,15 @@
     </sch:rule>
   </sch:pattern>
 
+  <!--Citation -->
+  <sch:pattern>
+      <sch:title>$loc/strings/requireCitation</sch:title>
+      <sch:rule context="//gmd:identificationInfo/*/gmd:citation">
+          <sch:assert test="gmd:CI_Citation | @gco:nilReason">
+              <sch:value-of select="$loc/strings/alert.requiredCitation"/>
+          </sch:assert>
+      </sch:rule>
+  </sch:pattern>
 
   <!--- Data Identification pattern -->
   <sch:pattern>


### PR DESCRIPTION
There was some good validation in https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-iso.sch

But HNAP schema has no such validation Sschematron in place. I attempt to introduce such Schematron and found they are not so compactable. 

One validation rule I would like to bring in is:
https://github.com/geonetwork/core-geonetwork/blob/bd153b0b9af09db01d0faf7d5cfc6b8708110047/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-iso.sch#L573-L583

There are many fields (i.e. title) in this citation is mandatory  

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/0ccbd329-5f93-41e5-ac33-6a195f055dbb)

If we attempt to remove this citation, these mandatory fields are removed as well
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/ed832bb2-3611-4218-b5c9-73f0c4026110)

But the data validates fine:
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/95882ac4-88e9-4eb0-906d-b7ea87164d3e)

Here is the fixed result:
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/01bcd5e0-899e-49c5-b691-76766c0d3640)
