### PR TITLE
Add missing rdf:type in GC_OG_Geographic_Region

### DIFF
--- a/src/main/config/codelist/local/thesauri/place/GC_OG_Geographic_Region.rdf
+++ b/src/main/config/codelist/local/thesauri/place/GC_OG_Geographic_Region.rdf
@@ -77,6 +77,7 @@
       <ns2:scopeNote xml:lang="fr">Definition</ns2:scopeNote>
    </rdf:Description>
    <rdf:Description rdf:about="http://geonetwork-opensource.org/GC_OG/geographic_region#11">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <ns2:prefLabel xml:lang="fr">Île-du-Prince-Édouard</ns2:prefLabel>
       <ns2:prefLabel xml:lang="en">Prince Edward Island</ns2:prefLabel>
       <ns2:scopeNote xml:lang="en">Definition</ns2:scopeNote>


### PR DESCRIPTION
Add missing rdf:type in GC_OG_Geographic_Region for PEI

It Without this fix users are not able to select PEI from the thesaurus.