### PR TITLE
online resource language and its validation

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -178,12 +178,11 @@ Insert is made in first transferOptions found.
       <xsl:choose>
         <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
 
-          <xsl:variable name="descMainLang" select="substring-before($desc, '|')" />
-          <xsl:variable name="descTranslatedLang" select="substring-after($desc, '|')" />
+          <xsl:variable name="descMainLang" select="tokenize(substring-before($desc, '|'), ';')[last()]" />
 
           <xsl:variable name="resourceLang">
             <xsl:choose>
-              <xsl:when test="ends-with($descMainLang, 'fra') and ends-with($descTranslatedLang, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+              <xsl:when test="ends-with($descMainLang, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
               <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
@@ -374,12 +373,11 @@ Insert is made in first transferOptions found.
           <gmd:onLine>
             <xsl:variable name="isMapProtocol" select="starts-with($protocol, 'ESRI REST:') or starts-with($protocol, 'OGC:')" />
 
-            <xsl:variable name="descMainLang" select="substring-before($desc, '|')" />
-            <xsl:variable name="descTranslatedLang" select="substring-after($desc, '|')" />
+            <xsl:variable name="descMainLang" select="tokenize(substring-before($desc, '|'), ';')[last()]" />
 
             <xsl:variable name="resourceLang">
               <xsl:choose>
-                <xsl:when test="ends-with($descMainLang, 'fra') and ends-with($descTranslatedLang, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+                <xsl:when test="ends-with($descMainLang, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
                 <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
               </xsl:choose>
             </xsl:variable>

--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -178,9 +178,12 @@ Insert is made in first transferOptions found.
       <xsl:choose>
         <xsl:when test="starts-with($protocol, 'OGC:') and $name != ''">
 
+          <xsl:variable name="descMainLang" select="substring-before($desc, '|')" />
+          <xsl:variable name="descTranslatedLang" select="substring-after($desc, '|')" />
+
           <xsl:variable name="resourceLang">
             <xsl:choose>
-              <xsl:when test="ends-with($desc, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+              <xsl:when test="ends-with($descMainLang, 'fra') and ends-with($descTranslatedLang, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
               <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
@@ -371,9 +374,12 @@ Insert is made in first transferOptions found.
           <gmd:onLine>
             <xsl:variable name="isMapProtocol" select="starts-with($protocol, 'ESRI REST:') or starts-with($protocol, 'OGC:')" />
 
+            <xsl:variable name="descMainLang" select="substring-before($desc, '|')" />
+            <xsl:variable name="descTranslatedLang" select="substring-after($desc, '|')" />
+
             <xsl:variable name="resourceLang">
               <xsl:choose>
-                <xsl:when test="ends-with($desc, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
+                <xsl:when test="ends-with($descMainLang, 'fra') and ends-with($descTranslatedLang, 'fra')"><xsl:value-of select="'urn:xml:lang:fra-CAN'"/></xsl:when>
                 <xsl:otherwise><xsl:value-of select="'urn:xml:lang:eng-CAN'"/></xsl:otherwise>
               </xsl:choose>
             </xsl:variable>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -517,17 +517,20 @@
       <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
       <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
 
-      <sch:let name="mapRESTCount" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service']) +
-                count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+      <sch:let name="mapRESTCountE" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+      <sch:let name="mapRESTCountF" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+      <sch:let name="mapRESTCount" value="$mapRESTCountE + $mapRESTCountF" />
 
-      <sch:assert test="$mapRESTCount &lt;= 2">$loc/strings/MapResourcesRESTNumber</sch:assert>
-      <sch:assert test="$mapRESTCount = 0 or $mapRESTCount = 2 or $mapRESTCount &gt; 2">$loc/strings/MapResourcesREST</sch:assert>
+      <sch:assert test="($mapRESTCountE = 0 and $mapRESTCountF = 0) or ($mapRESTCountE = 1 and $mapRESTCountF = 1) or $mapRESTCount &gt; 2">$loc/strings/MapResourcesREST</sch:assert>
+      <sch:assert test="$mapRESTCount = 0 or $mapRESTCount &lt;= 2">$loc/strings/MapResourcesRESTNumber</sch:assert>
 
-      <sch:let name="mapWMSCount" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms']) +
-                count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
 
-      <sch:assert test="$mapWMSCount &lt;= 2">$loc/strings/MapResourcesWMSNumber</sch:assert>
-      <sch:assert test="$mapWMSCount = 0 or $mapWMSCount = 2 or $mapWMSCount &gt; 2">$loc/strings/MapResourcesWMS</sch:assert>
+      <sch:let name="mapWMSCountE" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
+      <sch:let name="mapWMSCountF" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
+		  <sch:let name="mapWMSCount" value="$mapWMSCountE + $mapWMSCountF" />
+
+      <sch:assert test="($mapWMSCountE = 0 and $mapWMSCountF = 0) or ($mapWMSCountE = 1 and $mapWMSCountF = 1) or $mapWMSCount &gt; 2">$loc/strings/MapResourcesWMS</sch:assert>
+      <sch:assert test="$mapWMSCount = 0 or $mapWMSCount &lt;= 2">$loc/strings/MapResourcesWMSNumber</sch:assert>
     </sch:rule>
 
     <!-- Distribution - Format -->


### PR DESCRIPTION
This is an unusual scenario. The user select online resource language as eng; fra. But manually change it to eng. But the user may forget change in the French field.
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/6a0e011b-d13e-4f94-803a-1ca4318af5f9)


So the onlinesrc-add process sends payload 
desc: eng#Web Service;ESRI REST;eng|fra#Service Web;ESRI REST;eng,fra
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/481afd2a-c9e8-47b2-84d1-33076fe546bc)

Here is issue 1), the onlinesrc-add only detect the desc string to be end with fra which is not precised. It is better to break the string to check each eng#Web Service;ESRI REST;eng and fra#Service Web;ESRI REST;eng,fra to be end with fra or default to English.

Issue 2) if we set up the online resource by accidentally in issue 1) and add another normal French resource. We will end up have two French resource
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/1ca62afd-3499-48bd-86e7-985a257745d8)


The current logic only calculate if there are total of two online resources and it does not care if they are in English or French. Therefore it will not return any error at all.
https://github.com/metadata101/iso19139.ca.HNAP/blob/5f7a9d54385f3a55a2af13276229890621b89b55/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch#L526-L530

However in the older version 3.6 which FGP uses, the validation does counting both English and French online resources
https://github.com/metadata101/iso19139.ca.HNAP/blob/5a2ca4838d95c7c7cc17bc9ec0eb61275311c4fa/src/main/plugin/iso19139.nap/schematron/schematron-rules-iso19139.nap-internal.sch#L692-L698

Therefore most recent validation doesn't sync with FGP very well. So data validates as pass but cannot be publish to FGP due to the inconsistent validation. The FGP validation works better and we should bring back the old logic in 3.6.

This error will be captured as:
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/74916635/2e3e72dd-b412-46a4-9306-08fdfe55e9af)
