### PR TITLE
pass index and hash in resource and thumbnail add

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/onlinesrc-add.xsl
@@ -25,10 +25,20 @@
 <!--
 Processing to insert or update an online resource element.
 Insert is made in first transferOptions found.
+
+Note: It assumes that it will be adding new items in
+      the first /gmd:distributionInfo
+      and first /gmd:MD_Distribution
+      and first /gmd:transferOptions
+
 -->
 <xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:digestUtils="java:org.apache.commons.codec.digest.DigestUtils"
+                xmlns:exslt="http://exslt.org/common"
+                exclude-result-prefixes="#all"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 version="2.0">
@@ -52,9 +62,19 @@ Insert is made in first transferOptions found.
   in this one. -->
   <xsl:param name="extra_metadata_uuid"/>
 
-  <!-- Target element to update. The key is based on the concatenation
-  of URL+Protocol+Name -->
-  <xsl:param name="updateKey"/>
+  <!-- Target element to update.
+      updateKey is used to identify the resource name to be updated - it is for backwards compatibility.  Will not be used if resourceHash is set.
+                The key is based on the concatenation of URL+Protocol+Name
+      resourceHash is hash value of the object to be removed which will ensure the correct value is removed. It will override the usage of updateKey
+      resourceIdx is the index location of the object to be removed - can be used when duplicate entries exists to ensure the correct one is removed.
+  -->
+  <xsl:param name="updateKey" select="''"/>
+  <xsl:param name="resourceHash" select="''"/>
+  <xsl:param name="resourceIdx" select="''"/>
+
+  <xsl:variable name="update_flag">
+    <xsl:value-of select="boolean($updateKey != '' or $resourceHash != '' or $resourceIdx != '')"/>
+  </xsl:variable>
 
 
   <xsl:variable name="mainLang">
@@ -62,7 +82,9 @@ Insert is made in first transferOptions found.
       select="(gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata'])/gmd:language/gco:CharacterString"/>
   </xsl:variable>
 
-  <xsl:template match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
+  <!-- Add new gmd:onLine and consider cases where parent elements don't exist -->
+  <!--  <gmd:distributionInfo> does not exist-->
+  <xsl:template match="gmd:MD_Metadata[not(gmd:distributionInfo) and $update_flag = false()]|*[@gco:isoType='gmd:MD_Metadata' and not(gmd:distributionInfo) and $update_flag = false()]">
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
       <xsl:apply-templates
@@ -86,38 +108,11 @@ Insert is made in first transferOptions found.
 
       <gmd:distributionInfo>
         <gmd:MD_Distribution>
-          <xsl:apply-templates
-            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"/>
-          <xsl:apply-templates
-            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor"/>
           <gmd:transferOptions>
             <gmd:MD_DigitalTransferOptions>
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:unitsOfDistribution"/>
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:transferSize"/>
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:onLine"/>
-
-
-              <xsl:if test="$updateKey = ''">
-                <xsl:call-template name="createOnlineSrc"/>
-              </xsl:if>
-
-              <xsl:apply-templates
-                select="gmd:distributionInfo/gmd:MD_Distribution/
-                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:offLine"/>
+              <xsl:call-template name="createOnlineSrc"/>
             </gmd:MD_DigitalTransferOptions>
           </gmd:transferOptions>
-
-
-          <xsl:apply-templates
-            select="gmd:distributionInfo/gmd:MD_Distribution/
-                      gmd:transferOptions[position() > 1]"/>
-
         </gmd:MD_Distribution>
       </gmd:distributionInfo>
 
@@ -135,14 +130,71 @@ Insert is made in first transferOptions found.
     </xsl:copy>
   </xsl:template>
 
+  <!--  <gmd:MD_Distribution> does not exist-->
+  <xsl:template match="*/gmd:distributionInfo[not(gmd:MD_Distribution) and $update_flag = false() and position() = 1]">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <gmd:MD_Distribution>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <xsl:call-template name="createOnlineSrc"/>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+      </gmd:MD_Distribution>
+    </xsl:copy>
+  </xsl:template>
 
-  <!-- Updating the link matching the update key. -->
-  <xsl:template match="gmd:onLine[
-        normalize-space($updateKey) = concat(
-        gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
-        gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
-        gmd:CI_OnlineResource/gmd:name/gco:CharacterString)
-        and (not(string($language)) or (string($language) and (@xlink:role = $language)))]">
+  <!--  <gmd:transferOptions> does not exist-->
+  <xsl:template match="*/gmd:distributionInfo[1]/gmd:MD_Distribution[not(gmd:transferOptions) and $update_flag = false() and position() = 1]">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <xsl:call-template name="createOnlineSrc"/>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </xsl:copy>
+  </xsl:template>
+
+  <!--  <gmd:MD_DigitalTransferOptions> does not exist-->
+  <xsl:template match="*/gmd:distributionInfo[1]/gmd:MD_Distribution[1]/gmd:transferOptions[not(gmd:MD_DigitalTransferOptions) and $update_flag = false() and position() = 1]">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <gmd:MD_DigitalTransferOptions>
+        <xsl:call-template name="createOnlineSrc"/>
+      </gmd:MD_DigitalTransferOptions>
+    </xsl:copy>
+  </xsl:template>
+
+  <!--  Add new gmd:gmd:onLine-->
+  <xsl:template match="*/gmd:distributionInfo[1]/gmd:MD_Distribution[1]/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions[$update_flag = false() and position() = 1]">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates
+        select="gmd:unitsOfDistribution|
+                gmd:transferSize|
+                gmd:onLine"/>
+
+      <xsl:call-template name="createOnlineSrc"/>
+
+      <xsl:apply-templates select="gmd:offLine"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- End of inserting gmd:onLine -->
+
+
+  <!-- Updating the gmd:onLine based on update parameters -->
+  <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
+  <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
+  <xsl:template
+    match="*//gmd:MD_DigitalTransferOptions/gmd:onLine
+        [gmd:CI_OnlineResource[gmd:linkage/gmd:URL!=''] and ($resourceIdx = '' or position() = xs:integer($resourceIdx))]
+        [($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+                          gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
+                          gmd:CI_OnlineResource/gmd:protocol/*,
+                          gmd:CI_OnlineResource/gmd:name/gco:CharacterString)))
+                     and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(.))) = $resourceHash)]"
+    priority="2">
     <xsl:call-template name="createOnlineSrc"/>
   </xsl:template>
 
@@ -170,7 +222,7 @@ Insert is made in first transferOptions found.
 
     <xsl:if test="$url">
       <!-- In case the protocol is an OGC protocol
-      the name parameter may contains a list of layers
+      the name parameter may contain a list of layers
       separated by comma.
       In that case on one online element is added per
       layer/featureType.

--- a/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
@@ -111,8 +111,6 @@
          [$resourceIdx = '' or position() = xs:integer($resourceIdx)]
          [    ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
                            */gmd:fileName/gco:CharacterString,
-                           */gmd:fileName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
-                           */gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
                            */gmd:fileDescription/gco:CharacterString)))
           and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(.))) = $resourceHash)]">
     <xsl:call-template name="fill"/>

--- a/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
@@ -28,6 +28,9 @@
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:digestUtils="java:org.apache.commons.codec.digest.DigestUtils"
+                xmlns:exslt="http://exslt.org/common"
                 exclude-result-prefixes="#all"
                 version="2.0">
 
@@ -42,16 +45,27 @@
   <xsl:param name="thumbnail_desc" select="''"/>
   <xsl:param name="thumbnail_type" select="''"/>
 
-  <!-- Target element to update. The key is based on the concatenation
-  of URL+Name -->
-  <xsl:param name="updateKey"/>
+  <!-- Target element to update.
+    updateKey is used to identify the resource name to be updated - it is for backwards compatibility.  Will not be used if resourceHash is set.
+              The key is based on the concatenation of URL+Name
+    resourceHash is hash value of the object to be removed which will ensure the correct value is removed. It will override the usage of updateKey
+    resourceIdx is the index location of the object to be removed - can be used when duplicate entries exists to ensure the correct one is removed.
+-->
+  <xsl:param name="updateKey" select="''"/>
+  <xsl:param name="resourceHash" select="''"/>
+  <xsl:param name="resourceIdx" select="''"/>
+
+  <xsl:variable name="update_flag">
+    <xsl:value-of select="boolean($updateKey != '' or $resourceHash != '' or $resourceIdx != '')"/>
+  </xsl:variable>
 
   <xsl:variable name="mainLang">
     <xsl:value-of
       select="(gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata'])/gmd:language/gco:CharacterString"/>
   </xsl:variable>
 
-  <xsl:template match="gmd:identificationInfo/*">
+  <!--  Add new gmd:graphicOverview -->
+  <xsl:template match="gmd:identificationInfo/*[$update_flag = false()]">
     <xsl:copy>
       <xsl:copy-of select="@*"/>
       <xsl:apply-templates select="gmd:citation"/>
@@ -62,9 +76,7 @@
       <xsl:apply-templates select="gmd:pointOfContact"/>
       <xsl:apply-templates select="gmd:resourceMaintenance"/>
 
-      <xsl:if test="$updateKey = ''">
-        <xsl:call-template name="fill"/>
-      </xsl:if>
+      <xsl:call-template name="fill"/>
 
       <xsl:apply-templates select="gmd:graphicOverview"/>
 
@@ -90,11 +102,19 @@
   </xsl:template>
 
 
-  <xsl:template match="gmd:graphicOverview[concat(
-                         */gmd:fileName/gco:CharacterString,
-                         */gmd:fileName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
-                         */gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
-                         */gmd:fileDescription/gco:CharacterString) = normalize-space($updateKey)]">
+  <!-- Updating the gmd:graphicOverview based on update parameters -->
+  <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
+  <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
+  <xsl:template
+    priority="2"
+    match="*//gmd:graphicOverview
+         [$resourceIdx = '' or position() = xs:integer($resourceIdx)]
+         [    ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+                           */gmd:fileName/gco:CharacterString,
+                           */gmd:fileName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
+                           */gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
+                           */gmd:fileDescription/gco:CharacterString)))
+          and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(.))) = $resourceHash)]">
     <xsl:call-template name="fill"/>
   </xsl:template>
 


### PR DESCRIPTION
This PR is to coordinate with recent change in Geonetwork ISO 19139 schema change. For online resource and thumbnail add/removal, we need to pass index and hash code to determine the correct resource to add or remove.

For details, please see PR https://github.com/geonetwork/core-geonetwork/pull/7740