### PR TITLE
Add missing for-each to logic for keywords without thesaurus

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
@@ -105,19 +105,23 @@
           </xsl:when>
           <!-- All keywords with a valid keywordTypeCode -->
           <xsl:when test="$keywordTypeCodeReadable != ''">
-            <xsl:element name="keyword-{$keywordTypeCodeReadable}">
-              <xsl:apply-templates mode="localised" select=".">
-                <xsl:with-param name="langId" select="$langId"/>
-              </xsl:apply-templates>
-            </xsl:element>
+            <xsl:for-each select="gmd:keyword[not(@gco:nilReason) or */text() != '']">
+              <xsl:element name="keyword-{$keywordTypeCodeReadable}">
+                <xsl:apply-templates mode="localised" select=".">
+                  <xsl:with-param name="langId" select="$langId"/>
+                </xsl:apply-templates>
+              </xsl:element>
+            </xsl:for-each>
           </xsl:when>
           <!-- All keywords without a valid thesaurusName or keywordTypeCode -->
           <xsl:otherwise>
-            <keyword-other>
-              <xsl:apply-templates mode="localised" select=".">
-                <xsl:with-param name="langId" select="$langId"/>
-              </xsl:apply-templates>
-            </keyword-other>
+            <xsl:for-each select="gmd:keyword[not(@gco:nilReason) or */text() != '']">
+              <keyword-other>
+                <xsl:apply-templates mode="localised" select=".">
+                  <xsl:with-param name="langId" select="$langId"/>
+                </xsl:apply-templates>
+              </keyword-other>
+            </xsl:for-each>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:for-each>


### PR DESCRIPTION
For-each was missing from the logic for displaying the values of keywords without a thesaurus reference.

Without this PR all keywords without a thesaurus reference have empty values.

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/163562062/31e9b629-bef2-4f25-adbc-d28b07f68561)

Fixes issues caused in PR https://github.com/metadata101/iso19139.ca.HNAP/pull/374