### PR TITLE
switch to GC_Org_Names.rdf as government-names in the index

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/language-default.xsl
@@ -68,7 +68,7 @@
 
   <xsl:variable name="altLanguageId" select="/*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue != $mainLanguage and (gmd:languageCode/*/@codeListValue = 'eng' or gmd:languageCode/*/@codeListValue = 'fra')]/@id"/>
 
-  <xsl:variable name="government-names" select="document(concat('file:///', replace(concat($thesauriDir, '/local/thesauri/theme/GC_Government_Names.rdf'), '\\', '/')))"/>
+  <xsl:variable name="government-names" select="document(concat('file:///', replace(concat($thesauriDir, '/local/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
 
   <xsl:variable name="useDateAsTemporalExtent" select="false()"/>
 


### PR DESCRIPTION
Continuing the issue from 
https://github.com/metadata101/iso19139.ca.HNAP/pull/376#issuecomment-2069070442

The "GC_Org_Names.rdf" should be used as goc name thesaurus 