### PR TITLE
Search CSV Export - Get codelists file directly instead of using "/root/gui/schemas/..."

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
@@ -42,7 +42,7 @@
                 priority="2">
     <xsl:variable name="langId" select="gn-fn-iso19139:getLangIdHNAP(., $lang)"/>
     <xsl:variable name="info" select="gn:info"/>
-    <xsl:variable name="codelists" select="/root/gui/schemas/iso19139.ca.HNAP/codelists"/>
+    <xsl:variable name="codelists" select="document('../loc/eng/codelists.xml')/codelists"/>
 
     <metadata>
       <title>


### PR DESCRIPTION
Following GeoNetwork 4 upgrade, `tpl-csv` cannot access the codelists. This PR changes `tpl-csv` to use the codelists file directly as `/root/gui/schemas/iso19139/codelists` is inaccessible.

Without this PR csv search exports are unable to transform `RI_*` codes into string values resulting in the output of empty strings.

For example this results in all dates grouped together under "date-" instead of "date-publication, date-creation, ...".

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/163562062/1fd4ccf1-5ba0-4496-85d0-c2b74e3fdb73)
