### PR TITLE
Replace RI codes in security and legal constraints with english string

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
@@ -167,13 +167,31 @@
 
       <xsl:for-each select="gmd:identificationInfo/*/*/gmd:MD_SecurityConstraints/*">
         <SecurityConstraints>
-          <xsl:copy-of select="."/>
+          <xsl:choose>
+            <xsl:when test="*/@codeListValue">
+              <xsl:variable name="classificationCode" select="*/@codeListValue"/>
+              <xsl:variable name="classificationCodeReadable" select="tokenize($codelists/codelist[@name = 'gmd:MD_ClassificationCode']/entry[code/text() = $classificationCode]/value/text(), ';')[1]"/>
+              <xsl:value-of select="$classificationCodeReadable"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="*/text()"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </SecurityConstraints>
       </xsl:for-each>
 
       <xsl:for-each select="gmd:identificationInfo/*/*/gmd:MD_LegalConstraints/*">
         <LegalConstraints>
-          <xsl:value-of select="*/text()|*/@codeListValue"/>
+          <xsl:choose>
+            <xsl:when test="*/@codeListValue">
+              <xsl:variable name="restrictionCode" select="*/@codeListValue"/>
+              <xsl:variable name="restrictionCodeReadable" select="tokenize($codelists/codelist[@name = 'gmd:MD_RestrictionCode']/entry[code/text() = $restrictionCode]/value/text(), ';')[1]"/>
+              <xsl:value-of select="$restrictionCodeReadable"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="*/text()"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </LegalConstraints>
       </xsl:for-each>
 


### PR DESCRIPTION
When exporting search results as CSV, RI_* codes are shown in the field values.

This PR is to replace the RI_* codes and values output in the csv for the security and legal constraints. For consistency with headers the readable English value string should be used.

Without this PR RI_* codes are not formatted in a consistent way between headers and field values.

Ex. A license in LegalConstraints displays as "RI_606 license; licence" instead of "license"

![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/163562062/3dbd4e24-ed09-4d4f-bf6a-8dc24a9a9c36)
