### PR TITLE
Add multilingual thesaurus title to index

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -458,6 +458,12 @@
                     id="{$thesaurusId}"
                     uri="{$thesaurusUri}"
                     title="{$thesaurusTitle}">
+                <xsl:if test="not(starts-with($thesaurusTitle, 'otherKeywords'))">
+                  <multilingualTitle>
+                    <xsl:copy-of select="gn-fn-index:add-multilingual-field('multilingualTitle',
+                            gmd:thesaurusName/*/gmd:title, $allLanguages, false(), true())"/>
+                  </multilingualTitle>
+                </xsl:if>
               </info>
               <keywords>
                 <xsl:for-each select="$keywords">


### PR DESCRIPTION
Original Issue: #384 
Depends on: https://github.com/geonetwork/core-geonetwork/pull/8154

The purpose of this PR is to implement multilingual thesaurus titles to take advantage of the changes from https://github.com/geonetwork/core-geonetwork/pull/8154. This will allow translated thesaurus titles to be displayed in the record "default view".

Backwards compatibility is maintained by keeping the title attribute available as a fallback.

Changes will be ineffective without the above core-geonetwork changes.