### PR TITLE
Increase search csv export template priority

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
@@ -39,7 +39,7 @@
   <xsl:import href="utility-fn.xsl"/>
 
   <xsl:template mode="csv" match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']"
-                priority="2">
+                priority="10">
     <xsl:variable name="langId" select="gn-fn-iso19139:getLangIdHNAP(., $lang)"/>
     <xsl:variable name="info" select="gn:info"/>
     <xsl:variable name="codelists" select="document('../loc/eng/codelists.xml')/codelists"/>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/tpl-csv.xsl
@@ -35,7 +35,6 @@
                 exclude-result-prefixes="#all"
                 version="2.0">
 
-  <xsl:import href="../../iso19139/layout/tpl-csv.xsl"/>
   <xsl:import href="utility-fn.xsl"/>
 
   <xsl:template mode="csv" match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']"


### PR DESCRIPTION
In some environments, while exporting iso19139.ca.HNAP search results as CSV the iso19139 template is executed instead of the iso19139.ca.HNAP template.

This PR aims to fix this issue by increasing the priority of the iso19139.ca.HNAP template and removing a seemingly unused iso19139 import.

Ex. The following image is from the CSV output in an environment where the issue occurs:
![image](https://github.com/metadata101/iso19139.ca.HNAP/assets/163562062/f967a7d9-2fa6-4c53-9595-2457e9185051)

Here the reference system is missing and the codes are being used directly indicating that this is actually the iso19139 template.