### PR TITLE
Remove geonet:* elements from update-fixed-info

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -968,6 +968,8 @@
   <!-- Remove empty extent sections -->
   <xsl:template match="gmd:MD_DataIdentification/gmd:extent[count(gmd:EX_Extent/*) = 0]" />
 
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2" />
 
   <xsl:template match="@xsi:schemaLocation">
     <xsl:if test="XslUtil:getSettingValue('system/metadata/validation/removeSchemaLocation') = 'false'">


### PR DESCRIPTION
When an imported record is processed and the `geonet:info` element is added it is possible that there is already a (possibly invalid) `geonet:info` element.

This results in a sequence of elements which causes other xslt like `csv-search` to fail as they expect a single element.

![image](https://github.com/user-attachments/assets/0291070c-155f-400d-b9e7-8bc0a481af72)

```
Error on line 94 of csv-search.xsl:
  XTTE1020: A sequence of more than one item is not allowed as the @select attribute of xsl:sort
```

This PR aims to fix this issue by adding a template to `update-fixed-info` that will match and remove all old `geonet:*` elements when the record is saved.

That way there is only a single valid geonet:info element for the other xslt to use.