### PR TITLE
update required field and not force render element to check with xsd schema

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -310,6 +310,7 @@
       <xsl:with-param name="parentEditInfo" select="gn:element"/>
       <xsl:with-param name="listOfValues"
                       select="$listOfValues/entries"/>
+      <xsl:with-param name="forceXsdSchemaCheck" select="false()"/>
     </xsl:call-template>
   </xsl:template>
 
@@ -818,6 +819,7 @@
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>
       <xsl:with-param name="isDisabled" select="true()"/>
+      <xsl:with-param name="forceXsdSchemaCheck" select="false()"/>
     </xsl:call-template>
 
   </xsl:template>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -103,6 +103,8 @@
       called without context eg. render-table. -->
       <xsl:with-param name="isDisabled"
                       select="count($metadata//*[gn:element/@ref = $ref]/ancestor-or-self::node()[contains(@xlink:href, 'api/registries/entries')]) > 0"/>
+
+      <xsl:with-param name="forceXsdSchemaCheck" select="false()"/>
     </xsl:call-template>
 
   </xsl:template>
@@ -312,6 +314,8 @@
       called without context eg. render-table. -->
       <xsl:with-param name="isDisabled"
                       select="count($metadata//*[gn:element/@ref = $theElement/gn:element/@ref]/ancestor-or-self::node()[contains(@xlink:href, 'api/registries/entries')]) > 0"/>
+
+      <xsl:with-param name="forceXsdSchemaCheck" select="false()"/>
     </xsl:call-template>
 
   </xsl:template>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1261,7 +1261,7 @@
         <label>Metadata language</label>
         <btnLabel>Add language</btnLabel>
         <description>Select the language used to create the metadata</description>
-        <condition>conditional</condition>
+        <condition>mandatory</condition>
     </element>
     <element name="gmd:language" context="gmd:MD_DataIdentification" id="39.0">
         <label>Language</label>
@@ -2152,6 +2152,7 @@
     <element name="gmd:version" id="208.2" context="gmd:RS_Identifier">
         <label>Version</label>
         <description>Version identifier for the namespace</description>
+        <condition>mandatory</condition>
     </element>
     <element name="gmd:version" context="gmd:MD_Format" id="286.0">
         <label>File Format Version</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -1809,7 +1809,7 @@
     <label>Langue</label>
     <btnLabel>Ajouter langue</btnLabel>
     <description>Sélectionner la langue d'usage pour la création de métadonnées.</description>
-    <condition>Obligatoire</condition>
+    <condition>mandatory</condition>
   </element>
   <element name="gmd:language" id="39.0" context="gmd:MD_DataIdentification">
     <label>Langue</label>
@@ -2952,7 +2952,7 @@
   <element name="gmd:version" context="gmd:MD_Format" id="286.0">
     <label>Version</label>
     <description>Indiquer la version du format de transfert de données. Pour une liste de versions possibles, consulter le menu « Suggestions ». Si la version est inconnue, indiquer « inconnue ».</description>
-    <condition>Obligatoire</condition>
+    <condition>mandatory</condition>
   </element>
 
   <element name="gmd:verticalElement" id="338.0">


### PR DESCRIPTION
As the discussion from https://github.com/metadata101/iso19139.ca.HNAP/issues/315

The label.xml will updated with the required field. When it goes to rendering the element, the template should have an option not check the xsd schema. So there is an ongoing change for that in Geonetwork main branch https://github.com/geonetwork/core-geonetwork/pull/8294

