### PR TITLE
dynamic err msg of description for online resource validation schema

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -37,9 +37,9 @@
 
   <ResourceName>Online resource name is required in both language</ResourceName>
   <ResourceDescription>Online resource description is not valid. The format should be: ContentType;Format;Lang</ResourceDescription>
-  <ResourceDescriptionContentType>Online resource description content type is not valid. Valid values are: Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
-  <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
-  <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
+  <ResourceDescriptionContentType>French online resource description content type is not valid. Valid values are: Service Web,Données,API,Application,Document de soutien</ResourceDescriptionContentType>
+  <ResourceDescriptionFormat>French online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
+  <ResourceDescriptionLanguage>French online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
   <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
   <SecurityNoteBothLangRequired>Value is required for Security User Note in both languages</SecurityNoteBothLangRequired>
   <SecurityNoteMismatchedBothLang>Value mismatched for Security User Note in both languages</SecurityNoteMismatchedBothLang>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
@@ -53,9 +53,9 @@
   <ECThesaurusRole>Thesaurus cited responsible party role is required</ECThesaurusRole>
   <ECThesaurusEmail>Thesaurus cited responsible party email is required</ECThesaurusEmail>
 
-  <ResourceDescriptionContentType>Online resource description content type is not valid. Valid values are: Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
-  <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
-  <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
+  <ResourceDescriptionContentType>English online resource description content type is not valid. Valid values are: Web Service,Dataset,API,Application,Supporting Document</ResourceDescriptionContentType>
+  <ResourceDescriptionFormat>English online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
+  <ResourceDescriptionLanguage>English online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
 
   <ElectronicMailFormat>Electronic mail address format is invalid (for example abc@abc.com)</ElectronicMailFormat>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -37,9 +37,9 @@
 
   <ResourceName>Le nom des ressources en ligne est obligatoire dans les deux langues</ResourceName>
   <ResourceDescription>La description des ressources en ligne n'est pas valide. Le format devrait être : TypeContenu;Format;Lang</ResourceDescription>
-  <ResourceDescriptionContentType>Le type de contenu dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
-  <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
-  <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
+  <ResourceDescriptionContentType>Le type de contenu français dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Service Web,Données,API,Application,Document de soutien</ResourceDescriptionContentType>
+  <ResourceDescriptionFormat>Le format français dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
+  <ResourceDescriptionLanguage>La langue française dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
   <SecurityNoteBothLangRequired>Une valeur est requise pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteBothLangRequired>
   <SecurityNoteMismatchedBothLang>Valeur non concordante pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteMismatchedBothLang>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-non-multilingual.xml
@@ -53,9 +53,9 @@
   <ECThesaurusRole>Le rôle du responsable du thésaurus est requis</ECThesaurusRole>
   <ECThesaurusEmail>Le courriel du responsable du thésaurus est requis</ECThesaurusEmail>
 
-  <ResourceDescriptionContentType>Le type de contenu dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien</ResourceDescriptionContentType>
-  <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
-  <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
+  <ResourceDescriptionContentType>Le type de contenu anglais dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : Web Service,Dataset,API,Application,Supporting Document</ResourceDescriptionContentType>
+  <ResourceDescriptionFormat>Le format anglais dans la description de la ressource en ligne n'est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
+  <ResourceDescriptionLanguage>La langue anglaise dans la description de la ressource en ligne n'est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
 
   <ElectronicMailFormat>Le format de l'adresse électronique n'est pas valide (par exemple abc@abc.com)</ElectronicMailFormat>
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -141,11 +141,19 @@
   <xsl:function name="geonet:prependLocaleMessage">
     <xsl:param name="localeStringNode"/>
     <xsl:param name="prependText" as="xs:string"/>
+    <xsl:param name="insertText" as="xs:string"/>
 
     <xsl:for-each select="$localeStringNode">
       <xsl:copy>
         <xsl:copy-of select="@*"/>
-        <xsl:value-of select="concat($prependText, $localeStringNode)"/>
+        <xsl:choose>
+          <xsl:when test="$lang = 'fre'">
+            <xsl:value-of select="concat(substring-before($localeStringNode, 'n''est pas valide'), ' ',  concat('&quot;', $insertText, '&quot;'), ' n''est pas valide', substring-after($localeStringNode, 'n''est pas valide'))"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(substring-before($localeStringNode, 'is not valid'), ' ',  concat('&quot;', $insertText, '&quot;'), ' is not valid', substring-after($localeStringNode, 'is not valid'))"/>
+          </xsl:otherwise>
+          </xsl:choose>
       </xsl:copy>
     </xsl:for-each>
   </xsl:function>
@@ -834,7 +842,7 @@
 
       <sch:let name="missingResourceNameOtherLang" value="not(string(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
 
-      <sch:let name="locMsgResourceName" value="geonet:prependLocaleMessage($loc/strings/ResourceName, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsgResourceName" value="geonet:prependLocaleMessage($loc/strings/ResourceName, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '), '')" />
 
       <sch:assert
         test="not($missingResourceName) and not($missingResourceNameOtherLang)"
@@ -859,7 +867,7 @@
       <sch:let name="languageTranslated_present" value="geonet:values-in($languageTranslated,
               ('eng', 'fra', 'spa', 'zxx'))"/>
 
-      <sch:let name="locMsgCt" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionContentType, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsgCt" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionContentType, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '), if (normalize-space($contentTypeTranslated) = '') then '' else $contentTypeTranslated)" />
 
       <sch:assert test="($contentType = 'Web Service' or $contentType = 'Service Web' or
               $contentType = 'Dataset' or $contentType = 'Données' or
@@ -873,12 +881,12 @@
 
       <sch:let name="formatTranslated" value="subsequence(tokenize($descriptionTranslated, ';'), 2, 1)" />
       <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
-      <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '), if (normalize-space($formatTranslated) = '') then '' else $formatTranslated)" />
 
       <sch:assert test="$formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($mainLanguage2char)]/text() = $format and
                           $formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($altLanguage2char)]/text() = $formatTranslated">$locMsg</sch:assert>
 
-      <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '),if (normalize-space($languageTranslated) = '') then '' else $languageTranslated)" />
 
       <sch:assert test="normalize-space($language) != '' and normalize-space($languageTranslated) != ''">$locMsgLang</sch:assert>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -137,11 +137,19 @@
   <xsl:function name="geonet:prependLocaleMessage">
     <xsl:param name="localeStringNode"/>
     <xsl:param name="prependText" as="xs:string"/>
+    <xsl:param name="insertText" as="xs:string"/>
 
     <xsl:for-each select="$localeStringNode">
       <xsl:copy>
         <xsl:copy-of select="@*"/>
-        <xsl:value-of select="concat($prependText, $localeStringNode)"/>
+        <xsl:choose>
+          <xsl:when test="$lang = 'fre'">
+            <xsl:value-of select="concat(substring-before($localeStringNode, 'n''est pas valide'), ' ',  concat('&quot;', $insertText, '&quot;'), ' n''est pas valide', substring-after($localeStringNode, 'n''est pas valide'))"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(substring-before($localeStringNode, 'is not valid'), ' ',  concat('&quot;', $insertText, '&quot;'), ' is not valid', substring-after($localeStringNode, 'is not valid'))"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:copy>
     </xsl:for-each>
   </xsl:function>
@@ -504,7 +512,7 @@
       <sch:let name="language_present" value="geonet:values-in($language,
               ('eng', 'fra', 'spa', 'zxx'))"/>
 
-      <sch:let name="locMsgCt" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionContentType, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsgCt" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionContentType, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '), if (normalize-space($contentType) = '') then '' else $contentType)" />
 
       <sch:assert test="($contentType = 'Web Service' or $contentType = 'Service Web' or
               $contentType = 'Dataset' or $contentType = 'Données' or
@@ -513,11 +521,11 @@
 
 
       <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
-      <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList),  concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList),  concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '), if (normalize-space($format) = '') then '' else $format)" />
 
       <sch:assert test="$formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($mainLanguage2char)]/text() = $format">$locMsg</sch:assert>
 
-      <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '), if (normalize-space($language) = '') then '' else $language)" />
 
       <sch:assert test="normalize-space($language) != ''">$locMsgLang</sch:assert>
 


### PR DESCRIPTION
### The PR intends to address the following issues

- Issue checking empty alternative language.
- Issue with clarity of the message which should display the language if possible.
- Issue with clarity of the message which should display value that is not correct.
- Issue with error message showing the incorrect list of expected options

When adding a new online resource, user can input their own description values or leave blank instead of selecting from the list
![image](https://github.com/user-attachments/assets/c7e467c0-1847-49a4-a3f0-784b4f038a3c)

But the validation errors do not clearly describe the information![image](https://github.com/user-attachments/assets/74f1d694-ea47-4216-b0a2-0109d956aeeb)

i.e. instead of
```
Online resource description format is not valid
```
It should have been
```
French online resource description format "" is not valid
```
This would have made it clear what language has the issue and that "" was an empty value. But this also helps for other errors as well. i.e. if someone entered abc then the error would be
```
 French online resource description format "abc" is not valid 
```
which makes it much clearer on what the error is.

There is also another issue

The error states the following
Online resource description content type is not valid. Valid values are: Web Service,Service Web,Dataset,Données,API,Application,Supporting Document,Document de soutien

But the options to select from are the following. (Web Service not in the list)
![image](https://github.com/user-attachments/assets/dba22324-9477-4f80-92e2-cd5ea9910543)

It looks like the list of items put in the expected options is using both English and French values in on list which is not correct. It should have only displayed the French items.
