### PR TITLE
remove gco:distance/@uom enrichment

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -912,17 +912,6 @@
   </xsl:template>
 
 
-
-  <xsl:template  match="gco:Distance">
-    <xsl:element name="gco:{local-name()}">
-      <xsl:apply-templates select="@*"/>
-      <xsl:attribute name="uom">http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#<xsl:value-of select="@uom"/></xsl:attribute>
-      <xsl:apply-templates select="node()"/>
-    </xsl:element>
-  </xsl:template>
-
-
-
   <xsl:template match="gmd:onLine[@xlink:title]" priority="100">
     <xsl:copy>
       <xsl:apply-templates select="@*[name()!='xlink:title']" />


### PR DESCRIPTION
As discussed in issue https://github.com/metadata101/iso19139.ca.HNAP/issues/395. We should probably remove the uom enrichment logic. The the unit will be straight forward readable label.

![image](https://github.com/user-attachments/assets/4934535d-47af-49fa-a291-58bb180f2345)
