### PR TITLE
fix uom url appending bug. Fix search#/metadata/{UUID} ui issue

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -573,7 +573,9 @@
 
           <xsl:for-each select="gmd:distance/gco:Distance[. != '']">
             <resolutionDistance>
-              <xsl:value-of select="concat(., ' ', @uom)"/>
+              <xsl:value-of select="if (contains(@uom, '#'))
+                                    then concat(., ' ', tokenize(@uom, '#')[2])
+                                    else  concat(., ' ', @uom)"/>
             </resolutionDistance>
           </xsl:for-each>
         </xsl:for-each>

--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -912,11 +912,18 @@
   </xsl:template>
 
 
-
   <xsl:template  match="gco:Distance">
     <xsl:element name="gco:{local-name()}">
       <xsl:apply-templates select="@*"/>
-      <xsl:attribute name="uom">http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#<xsl:value-of select="@uom"/></xsl:attribute>
+      <xsl:choose>
+        <!--Avoid append the url recursively. Only append the url once. -->
+        <xsl:when test="not(starts-with(@uom, 'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#'))">
+          <xsl:attribute name="uom">http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#<xsl:value-of select="@uom"/></xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="uom"><xsl:value-of select="@uom"/></xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="node()"/>
     </xsl:element>
   </xsl:template>


### PR DESCRIPTION
Related to issue https://github.com/metadata101/iso19139.ca.HNAP/issues/395

The url was appended multiple time in the [update-fixed-info.xsl](https://github.com/metadata101/iso19139.ca.HNAP/blob/3f7ed80b30eef0e4ca4f0011f352a60b2e6987de/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl#L916-L922)

Also the geonetwork/srv/eng/catalog.search#/metadata/{UUID} ui is retrieving the uom from the search engine. Similar code from other schema like:

https://github.com/geonetwork/core-geonetwork/blob/22a87f68d2ec74ddbed86a83e0208fc2a8ce262d/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl#L701-L703

should apply to HNAP in order to make the display user friendly