### PR TITLE
New descriptive tooltip for use limitation

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -2094,8 +2094,7 @@
     </element>
     <element name="gmd:useLimitation" id="68.0">
         <label>Use Limitation</label>
-        <description>Limitation affecting the fitness for use of the resource. Example, _not to be
-            used for navigation_</description>
+      <description>This field captures the license that is applicable to your metadata record and/or attached resource(s). This field has been implemented as a dynamic list, so users should begin typing the name of a license to see available license options. Implementation of this field has been modified from the standard to capture the requirements of external publication partners.</description>
       <condition>mandatory</condition>
     </element>
     <element name="gmd:userContactInfo" id="66.0">

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2873,7 +2873,7 @@
   </element>
   <element name="gmd:useLimitation" id="68.0">
     <label>Limitation d'utilisation</label>
-    <description>Limitation d'utilisation de la ressource où de métadonnées. Exemple: "ne pas utiliser pour la navigation"</description>
+    <description>Ce champ permet de saisir la licence qui s'applique à votre enregistrement de métadonnées et/ou à la (aux) ressource(s) attachée(s). Ce champ a été implémenté sous la forme d'une liste dynamique, de sorte que les utilisateurs doivent commencer à taper le nom d'une licence pour voir les options de licence disponibles. L'implémentation de ce champ a été modifiée par rapport à l'original afin de tenir compte des exigences des partenaires de publication externes.</description>
     <condition>mandatory</condition>
 
     <!--<helper>


### PR DESCRIPTION
The current tooltip for "Use Limitation" does not accurately describe the field’s purpose or behavior, potentially leading to user confusion.

### Old tooltip:
> Limitation affecting the fitness for use of the resource. Example, _not to be used for navigation_

> Limitation d'utilisation de la ressource où de métadonnées. Exemple: "ne pas utiliser pour la navigation"

This PR aims to fix this issue by updating the tooltip text to more clearly explain the field’s purpose—capturing the applicable license for a metadata record or attached resource—and its behavior as a dynamic list. It also notes that the field has been modified from the standard to meet the requirements of external publication partners.

### New tooltip:
> This field captures the license that is applicable to your metadata record and/or attached resource(s). This field has been implemented as a dynamic list, so users should begin typing the name of a license to see available license options. Implementation of this field has been modified from the standard to capture the requirements of external publication partners.

> Ce champ permet de saisir la licence qui s'applique à votre enregistrement de métadonnées et/ou à la (aux) ressource(s) attachée(s). Ce champ a été implémenté sous la forme d'une liste dynamique, de sorte que les utilisateurs doivent commencer à taper le nom d'une licence pour voir les options de licence disponibles. L'implémentation de ce champ a été modifiée par rapport à l'original afin de tenir compte des exigences des partenaires de publication externes.