### PR TITLE
Unable to rename graphicOverview

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
@@ -104,9 +104,9 @@
 
   <!-- Updating the gmd:graphicOverview based on update parameters -->
   <!-- Template to match all gmd:graphicOverview elements -->
-  <xsl:template match="//gmd:MD_DataIdentification/gmd:graphicOverview" priority="2">
+  <xsl:template match="//gmd:graphicOverview" priority="2">
     <!-- Calculate the global position of the current gmd:graphicOverview element -->
-    <xsl:variable name="position" select="count(//gmd:MD_DataIdentification/gmd:graphicOverview[current() >> .]) + 1" />
+    <xsl:variable name="position" select="count(//gmd:graphicOverview[current() >> .]) + 1" />
 
     <xsl:choose>
       <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->

--- a/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/process/thumbnail-add.xsl
@@ -103,17 +103,27 @@
 
 
   <!-- Updating the gmd:graphicOverview based on update parameters -->
-  <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
-  <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
-  <xsl:template
-    priority="2"
-    match="*//gmd:graphicOverview
-         [$resourceIdx = '' or position() = xs:integer($resourceIdx)]
-         [    ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
-                           */gmd:fileName/gco:CharacterString,
-                           */gmd:fileDescription/gco:CharacterString)))
-          and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(.))) = $resourceHash)]">
-    <xsl:call-template name="fill"/>
+  <!-- Template to match all gmd:graphicOverview elements -->
+  <xsl:template match="//gmd:MD_DataIdentification/gmd:graphicOverview" priority="2">
+    <!-- Calculate the global position of the current gmd:graphicOverview element -->
+    <xsl:variable name="position" select="count(//gmd:MD_DataIdentification/gmd:graphicOverview[current() >> .]) + 1" />
+
+    <xsl:choose>
+      <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
+      <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
+      <xsl:when test="($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                        ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+                            */gmd:fileName/gco:CharacterString,
+                            */gmd:fileDescription/gco:CharacterString)))
+                        and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)">
+        <xsl:call-template name="fill"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- TMP TO REMOVE when gco:characterString is added in multilingual elements


### PR DESCRIPTION
Currently when you add a thumbnail and then go back to edit the name the updated name is never saved.

Initial Name:
![image](https://github.com/user-attachments/assets/8f87a1fd-f991-4215-8dea-b08d1698261e)
Updated Name:
![image](https://github.com/user-attachments/assets/bbb1e959-4bbc-4cf2-b113-4554a9a8b9c9)
Name After Update:
![image](https://github.com/user-attachments/assets/bd774fee-30a0-4a9d-9916-a54b13e95369)


This is caused by the template in `thumbnail-add.xsl` not matching the correct `graphicOverview` element.

Here `position()` is used to match the `resourceIdx` but `position()` does not return the index of the graphic element causing the match to fail.

Also the `resourceHash` is failing to match the generated `md5Hex` value.

This PR aims to fix this issue by changing the template in `thumbnail-add.xsl` to be more like the one in `onlinesrc-add.xsl` which correctly gets the matching position and resource hash.