### PR TITLE
Spatial representation type mandatory and validation rules

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1936,6 +1936,7 @@
         <label>Spatial representation type</label>
         <btnLabel>Add spatial representation type</btnLabel>
         <description>Method used to spatially represent geographic information</description>
+        <condition>mandatory</condition>
     </element>
     <element name="gmd:spatialResolution" id="38.0">
         <label>Spatial resolution</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -58,6 +58,6 @@
 
   <hasDuplicatedOnlineResource>Duplicated Online Resource URLs for the same language are not allowed. The following duplicate(s) (language; URL) were identified:</hasDuplicatedOnlineResource>
 
-  <SpatialRepresentationTypeMissing>Spatial Representation Type is required</SpatialRepresentationTypeMissing>
+  <SpatialRepresentationTypeMissing>Value is required for Spatial representation</SpatialRepresentationTypeMissing>
 
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -58,4 +58,6 @@
 
   <hasDuplicatedOnlineResource>Duplicated Online Resource URLs for the same language are not allowed. The following duplicate(s) (language; URL) were identified:</hasDuplicatedOnlineResource>
 
+  <SpatialRepresentationTypeMissing>Spatial Representation Type is required</SpatialRepresentationTypeMissing>
+
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2665,6 +2665,7 @@
     <label>Type de représentation spatiale</label>
     <btnLabel>Ajouter type de représentation spatiale</btnLabel>
     <description>Méthode utilisée pour représenter spatialement l'information géographique</description>
+    <condition>mandatory</condition>
   </element>
   <element name="gmd:spatialResolution" id="38.0">
     <label>Résolution spatiale</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -58,4 +58,6 @@
 
   <hasDuplicatedOnlineResource>Les URL de ressources en ligne dupliquées pour la même langue ne sont pas autorisées. Les doublons suivants (langue ; URL) ont été identifiés :</hasDuplicatedOnlineResource>
 
+  <SpatialRepresentationTypeMissing>Le type de représentation spatiale est requis</SpatialRepresentationTypeMissing>
+
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -58,6 +58,6 @@
 
   <hasDuplicatedOnlineResource>Les URL de ressources en ligne dupliquées pour la même langue ne sont pas autorisées. Les doublons suivants (langue ; URL) ont été identifiés :</hasDuplicatedOnlineResource>
 
-  <SpatialRepresentationTypeMissing>Le type de représentation spatiale est requis</SpatialRepresentationTypeMissing>
+  <SpatialRepresentationTypeMissing>Une valeur est nécessaire pour: Type de représentation spatiale</SpatialRepresentationTypeMissing>
 
 </strings>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -241,6 +241,7 @@
                    |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:spatialRepresentationType
                    |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:spatialRepresentationType">
 
+      <sch:let name="spatialRepresentationTypeCodeListValue" value="gmd:MD_SpatialRepresentationTypeCode/@codeListValue"/>
       <sch:let name="spatialRepresentationTypeCodelistLabel"
                value="tr:codelist-value-label(
                             tr:create($schema),
@@ -249,6 +250,9 @@
 
       <sch:let name="isValid" value="($spatialRepresentationTypeCodelistLabel = '') or ($spatialRepresentationTypeCodelistLabel != gmd:MD_SpatialRepresentationTypeCode/@codeListValue)"/>
 
+      <sch:assert
+        test="$spatialRepresentationTypeCodeListValue != '' "
+      >$loc/strings/SpatialRepresentationTypeMissing</sch:assert>
       <sch:assert
         test="$isValid"
       >$loc/strings/InvalidSpatialRepresentationType</sch:assert>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -241,7 +241,6 @@
                    |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:spatialRepresentationType
                    |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:spatialRepresentationType">
 
-      <sch:let name="spatialRepresentationTypeCodeListValue" value="gmd:MD_SpatialRepresentationTypeCode/@codeListValue"/>
       <sch:let name="spatialRepresentationTypeCodelistLabel"
                value="tr:codelist-value-label(
                             tr:create($schema),
@@ -251,7 +250,7 @@
       <sch:let name="isValid" value="($spatialRepresentationTypeCodelistLabel = '') or ($spatialRepresentationTypeCodelistLabel != gmd:MD_SpatialRepresentationTypeCode/@codeListValue)"/>
 
       <sch:assert
-        test="$spatialRepresentationTypeCodeListValue != '' "
+        test="$spatialRepresentationTypeCodelistLabel != '' "
       >$loc/strings/SpatialRepresentationTypeMissing</sch:assert>
       <sch:assert
         test="$isValid"


### PR DESCRIPTION
Spatial Representation type is needed for spatial type metadata. This field is needed as mandatory. So the condition and related validation rule is needed.

Here is the change result.

![image](https://github.com/user-attachments/assets/278d6e13-6c1b-4d9e-99ae-2b8c3ebcdc4a)

This field can be removed or added by user's decision. So the red asterisk sign wont be shown if it's missing. But it will be showing when it presents.

![image](https://github.com/user-attachments/assets/c1f2d241-cd10-4c7b-be85-9b3abd8d564e)


Also the related validation rule is added when this field is showing but leave as empty.

![image](https://github.com/user-attachments/assets/7d7c6e00-3db1-4aee-8cf7-123447c479cb)
