### PR TITLE
indexing with byte64 data in search engine

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -391,6 +391,11 @@
             <xsl:if test="normalize-space(../../gmd:fileDescription) != ''">,
               "nameObject": <xsl:value-of select="gn-fn-index:add-multilingual-field('name', ../../gmd:fileDescription, $allLanguages, true())"/>
             </xsl:if>
+            <xsl:variable name="data"
+                          select="util:buildDataUrl(., 140)"/>
+            <xsl:if test="$data != ''">,
+              "data": "<xsl:value-of select="$data"/>"
+            </xsl:if>
             }</overview>
         </xsl:for-each>
 


### PR DESCRIPTION
On the search page, catalogue search engine contains some byte data which can speed up the page loading and avoid unwanted backend api querying. HNAP is lack of such indexing mechanism.

![image](https://github.com/user-attachments/assets/1212ec45-8a19-454d-a3d3-adc280e0fd49)


So this change should be brought from dublin-core

https://github.com/geonetwork/core-geonetwork/blob/cd72f8ec309e866c0fdd2d87ea142dea52627afc/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl#L248-L252

Result, 

![image](https://github.com/user-attachments/assets/a25b4a60-fb8a-45e1-b86f-1e0be2f7a787)

This is related to #[5467](https://github.com/geonetwork/core-geonetwork/pull/5467)
