### PR TITLE
remove name for spatialRepresentationType in config-editor.xml adding module

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -468,7 +468,7 @@
 
           <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:spatialRepresentationType"/>
 
-          <action type="add" name="spatialRepresentationType" or="spatialRepresentationType"
+          <action type="add" or="spatialRepresentationType"
                   in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification"
                   if="count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:spatialRepresentationType) = 0">
             <template>


### PR DESCRIPTION
Spatial Representation type has label issue for none spatial type record.

![image](https://github.com/user-attachments/assets/e00715bc-4bf8-4453-b9af-13ab9448b579)


After the fix:
![image](https://github.com/user-attachments/assets/6da09ed6-39af-4c51-96e5-e17287bc6220)
