### PR TITLE
Enable show-hints-on-focus for typeahead fields

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -53,13 +53,13 @@
     <!-- for name="gmd:userNote" use="textarea"/ -->
     <for name="gmd:userNote"
          use="data-gn-keyword-picker">
-      <directiveAttributes data-thesaurus-key="external.theme.GC_Security_Level" data-focus-to-input="false"/>
+      <directiveAttributes data-thesaurus-key="external.theme.GC_Security_Level" data-focus-to-input="false" data-show-hints-on-focus="true"/>
     </for>
 
     <!--for name="gmd:useLimitation" use="textarea"/-->
     <for name="gmd:useLimitation"
              use="data-gn-keyword-picker">
-          <directiveAttributes data-thesaurus-key="external.theme.GC_Open_Licenses" data-focus-to-input="false"/>
+          <directiveAttributes data-thesaurus-key="external.theme.GC_Open_Licenses" data-focus-to-input="false" data-show-hints-on-focus="true"/>
     </for>
 
     <for name="gco:Distance" use="number"/>
@@ -78,19 +78,23 @@
 
     <for name="gmd:electronicMailAddress" use="email"/>
 
-    <for name="gmd:language" use="data-gn-language-picker"/>
-    <for name="gmd:languageCode" use="data-gn-language-picker"/>
+    <for name="gmd:language" use="data-gn-language-picker">
+      <directiveAttributes data-show-hints-on-focus="true"/>
+    </for>
+    <for name="gmd:languageCode" use="data-gn-language-picker">
+      <directiveAttributes data-show-hints-on-focus="true"/>
+    </for>
 
 <!--    <for name="gmd:country" use="data-gn-country-selector-ec"/>-->
     <for name="gmd:country"
              use="data-gn-keyword-picker">
-          <directiveAttributes data-thesaurus-key="external.theme.ISO_Countries" data-focus-to-input="false" data-number-of-suggestions="250"/>
+          <directiveAttributes data-thesaurus-key="external.theme.ISO_Countries" data-focus-to-input="false" data-number-of-suggestions="250" data-show-hints-on-focus="true"/>
 
     </for>
 
     <for name="gmd:administrativeArea"
          use="data-gn-keyword-picker">
-      <directiveAttributes data-thesaurus-key="external.theme.GC_State_Province" data-focus-to-input="false" data-number-of-suggestions="75"/>
+      <directiveAttributes data-thesaurus-key="external.theme.GC_State_Province" data-focus-to-input="false" data-number-of-suggestions="75" data-show-hints-on-focus="true"/>
 
     </for>
 

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -219,7 +219,8 @@
             "defaultValues": {
                   "eng": "<xsl:value-of select="$DefaultMainOrganizationName_en"/>",
                   "fra": "<xsl:value-of select="$DefaultMainOrganizationName_fr"/>"
-            }
+            },
+            "showHintsOnFocus": "true"
           },
 
           {
@@ -229,7 +230,8 @@
               "fra": "Département/agence"
             },
             "thesaurus": "external.theme.GC_Departments",
-            "numberOfSuggestions": 200
+            "numberOfSuggestions": 200,
+            "showHintsOnFocus": true
           },
 
           {

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout.xsl
@@ -89,6 +89,9 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
       <xsl:with-param name="type" select="gn-fn-iso19139:getCodeListType(name())"/>
+      <xsl:with-param name="directiveAttributes">
+        <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name(),name(*[@codeListValue]), $xpath)"/>
+      </xsl:with-param>
       <xsl:with-param name="name"
                       select="if ($isEditing) then concat(*/gn:element/@ref, '_codeListValue') else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>


### PR DESCRIPTION
Currently fields with typeahead do not give any initial indication that the field has suggested values. This is an issue for new users as the field appears as a plain text field. When a keywordPicker field is validated against its suggested values it is unclear to the user how to see all the options.

This PR aims to fix this issue by introducing the `show-hints-on-focus` feature for typeahead fields. This feature shows all options on the initial click and adds a caret to the field to mock a dropdown list. Adding the caret will make it more clear to the user that they will see some options once they click into the field.

![image](https://github.com/user-attachments/assets/a76e4f39-fb0a-43d5-b186-7a088a3a2390)
![image](https://github.com/user-attachments/assets/f85f155f-c241-4888-8af9-49388082a891)
