### PR TITLE
Fix http/https inconsistencies with GC_Open_Licenses

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/inflate-metadata.xsl
@@ -339,16 +339,16 @@
             <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
               <gco:CharacterString>
                 <xsl:choose>
-                  <xsl:when test="$altLang = 'fra'">Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</xsl:when>
-                  <xsl:otherwise>Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</xsl:otherwise>
+                  <xsl:when test="$altLang = 'fra'">Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</xsl:when>
+                  <xsl:otherwise>Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</xsl:otherwise>
                 </xsl:choose>
               </gco:CharacterString>
               <gmd:PT_FreeText>
                 <gmd:textGroup>
                   <gmd:LocalisedCharacterString locale="#{$altLang}">
                     <xsl:choose>
-                      <xsl:when test="$altLang = 'fra'">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</xsl:when>
-                      <xsl:otherwise>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</xsl:otherwise>
+                      <xsl:when test="$altLang = 'fra'">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</xsl:when>
+                      <xsl:otherwise>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</xsl:otherwise>
                     </xsl:choose>
                   </gmd:LocalisedCharacterString>
                 </gmd:textGroup>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Dynamic Radar Coverage/6b02c778-8eaa-46f5-8786-ae80b0ea0f72/metadata/metadata-iso19139.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Dynamic Radar Coverage/6b02c778-8eaa-46f5-8786-ae80b0ea0f72/metadata/metadata-iso19139.xml
@@ -687,10 +687,10 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Dynamic Radar Coverage/6b02c778-8eaa-46f5-8786-ae80b0ea0f72/metadata/metadata.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Dynamic Radar Coverage/6b02c778-8eaa-46f5-8786-ae80b0ea0f72/metadata/metadata.xml
@@ -686,10 +686,10 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Harbour Porpoise Presence/58ea48ab-f052-48ab-9c18-4353e51b8bea/metadata/metadata-iso19139.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Harbour Porpoise Presence/58ea48ab-f052-48ab-9c18-4353e51b8bea/metadata/metadata-iso19139.xml
@@ -502,10 +502,10 @@ Une version de cet ensemble de données a été créée pour le Centre national 
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Harbour Porpoise Presence/58ea48ab-f052-48ab-9c18-4353e51b8bea/metadata/metadata.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Harbour Porpoise Presence/58ea48ab-f052-48ab-9c18-4353e51b8bea/metadata/metadata.xml
@@ -501,10 +501,10 @@ Une version de cet ensemble de données a été créée pour le Centre national 
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/North American Radar/37aecae5-7783-4274-b595-df02aa003ac3/metadata/metadata-iso19139.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/North American Radar/37aecae5-7783-4274-b595-df02aa003ac3/metadata/metadata-iso19139.xml
@@ -687,10 +687,10 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/North American Radar/37aecae5-7783-4274-b595-df02aa003ac3/metadata/metadata.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/North American Radar/37aecae5-7783-4274-b595-df02aa003ac3/metadata/metadata.xml
@@ -686,10 +686,10 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Ocean Salmon Program/b16db0fe-a4ec-4844-819e-630e33137b6d/metadata/metadata-iso19139.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Ocean Salmon Program/b16db0fe-a4ec-4844-819e-630e33137b6d/metadata/metadata-iso19139.xml
@@ -504,10 +504,10 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Ocean Salmon Program/b16db0fe-a4ec-4844-819e-630e33137b6d/metadata/metadata.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Ocean Salmon Program/b16db0fe-a4ec-4844-819e-630e33137b6d/metadata/metadata.xml
@@ -503,10 +503,10 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Potential Haul Out Sites/3b0ccbbe-e0f7-4e6f-a6aa-8b327c69a169/metadata/metadata-iso19139.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Potential Haul Out Sites/3b0ccbbe-e0f7-4e6f-a6aa-8b327c69a169/metadata/metadata-iso19139.xml
@@ -323,7 +323,7 @@ Andersen, A. et M. Gagnon. 1980. Les ressources halieutiques de l'estuaire du Sa
 
 Argus Groupe-Conseil inc. 1992. Synthèse et analyse des connaissances relatives aux ressources naturelles du Saguenay et de l'estuaire maritime du Saint-Laurent. Parc marin du Saguenay. Service canadien des parcs, région du Québec.
 
-Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes. 
+Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes.
 
 Biorex. 1996. Base de données géoréférencées sur les ressources halieutiques et leurs habitats : estuaire maritime du Saint-Laurent et fjord du Saguenay. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. Volume 1 : 38 p. + annexes et Volume 2 : 34 p. + annexes.
 
@@ -333,9 +333,9 @@ Comité de la zone d'intervention prioritaire (ZIP) de la Côte-Nord du golfe. 1
 
 Comité de protection de la santé et de l'environnement de Gaspé inc. (C.P.S.E.G.). 1996.
 
-Communication personnelle par Carol Fournier, MPO. 1999. 
+Communication personnelle par Carol Fournier, MPO. 1999.
 
-Communications personnelles par Gosselin, J-F-. 1996. 
+Communications personnelles par Gosselin, J-F-. 1996.
 
 Desaulniers, J. 1989. Étude des populations de pinnipèdes de l'Archipel-de-Mingan et relation entre l'activité de chasse au phoque et la sécurité publique 1987 à 1989. Parcs Canada. Région du Québec. Service de la conservation des ressources naturelles.
 
@@ -360,7 +360,7 @@ Andersen, A. et M. Gagnon. 1980. Les ressources halieutiques de l'estuaire du Sa
 
 Argus Groupe-Conseil inc. 1992. Synthèse et analyse des connaissances relatives aux ressources naturelles du Saguenay et de l'estuaire maritime du Saint-Laurent. Parc marin du Saguenay. Service canadien des parcs, région du Québec.
 
-Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes. 
+Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes.
 
 Biorex. 1996. Base de données géoréférencées sur les ressources halieutiques et leurs habitats : estuaire maritime du Saint-Laurent et fjord du Saguenay. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. Volume 1 : 38 p. + annexes et Volume 2 : 34 p. + annexes.
 
@@ -370,9 +370,9 @@ Comité de la zone d'intervention prioritaire (ZIP) de la Côte-Nord du golfe. 1
 
 Comité de protection de la santé et de l'environnement de Gaspé inc. (C.P.S.E.G.). 1996.
 
-Communication personnelle par Carol Fournier, MPO. 1999. 
+Communication personnelle par Carol Fournier, MPO. 1999.
 
-Communications personnelles par Gosselin, J-F-. 1996. 
+Communications personnelles par Gosselin, J-F-. 1996.
 
 Desaulniers, J. 1989. Étude des populations de pinnipèdes de l'Archipel-de-Mingan et relation entre l'activité de chasse au phoque et la sécurité publique 1987 à 1989. Parcs Canada. Région du Québec. Service de la conservation des ressources naturelles.
 
@@ -584,10 +584,10 @@ Naturam Environnement inc. 1996. Caractérisation physique et biologique de l'ha
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
+            <gco:CharacterString>Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/sample-data/Potential Haul Out Sites/3b0ccbbe-e0f7-4e6f-a6aa-8b327c69a169/metadata/metadata.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/sample-data/Potential Haul Out Sites/3b0ccbbe-e0f7-4e6f-a6aa-8b327c69a169/metadata/metadata.xml
@@ -322,7 +322,7 @@ Andersen, A. et M. Gagnon. 1980. Les ressources halieutiques de l'estuaire du Sa
 
 Argus Groupe-Conseil inc. 1992. Synthèse et analyse des connaissances relatives aux ressources naturelles du Saguenay et de l'estuaire maritime du Saint-Laurent. Parc marin du Saguenay. Service canadien des parcs, région du Québec.
 
-Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes. 
+Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes.
 
 Biorex. 1996. Base de données géoréférencées sur les ressources halieutiques et leurs habitats : estuaire maritime du Saint-Laurent et fjord du Saguenay. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. Volume 1 : 38 p. + annexes et Volume 2 : 34 p. + annexes.
 
@@ -332,9 +332,9 @@ Comité de la zone d'intervention prioritaire (ZIP) de la Côte-Nord du golfe. 1
 
 Comité de protection de la santé et de l'environnement de Gaspé inc. (C.P.S.E.G.). 1996.
 
-Communication personnelle par Carol Fournier, MPO. 1999. 
+Communication personnelle par Carol Fournier, MPO. 1999.
 
-Communications personnelles par Gosselin, J-F-. 1996. 
+Communications personnelles par Gosselin, J-F-. 1996.
 
 Desaulniers, J. 1989. Étude des populations de pinnipèdes de l'Archipel-de-Mingan et relation entre l'activité de chasse au phoque et la sécurité publique 1987 à 1989. Parcs Canada. Région du Québec. Service de la conservation des ressources naturelles.
 
@@ -359,7 +359,7 @@ Andersen, A. et M. Gagnon. 1980. Les ressources halieutiques de l'estuaire du Sa
 
 Argus Groupe-Conseil inc. 1992. Synthèse et analyse des connaissances relatives aux ressources naturelles du Saguenay et de l'estuaire maritime du Saint-Laurent. Parc marin du Saguenay. Service canadien des parcs, région du Québec.
 
-Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes. 
+Biorex. 1995. Cartographie des ressources halieutiques et de leurs habitats dans l'estuaire moyen du Saint-Laurent. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. 36 p. + annexes.
 
 Biorex. 1996. Base de données géoréférencées sur les ressources halieutiques et leurs habitats : estuaire maritime du Saint-Laurent et fjord du Saguenay. Rapport au ministère des Pêches et des Océans, Région du Québec, Division de la gestion de l'habitat du poisson. Volume 1 : 38 p. + annexes et Volume 2 : 34 p. + annexes.
 
@@ -369,9 +369,9 @@ Comité de la zone d'intervention prioritaire (ZIP) de la Côte-Nord du golfe. 1
 
 Comité de protection de la santé et de l'environnement de Gaspé inc. (C.P.S.E.G.). 1996.
 
-Communication personnelle par Carol Fournier, MPO. 1999. 
+Communication personnelle par Carol Fournier, MPO. 1999.
 
-Communications personnelles par Gosselin, J-F-. 1996. 
+Communications personnelles par Gosselin, J-F-. 1996.
 
 Desaulniers, J. 1989. Étude des populations de pinnipèdes de l'Archipel-de-Mingan et relation entre l'activité de chasse au phoque et la sécurité publique 1987 à 1989. Parcs Canada. Région du Québec. Service de la conservation des ressources naturelles.
 
@@ -583,10 +583,10 @@ Naturam Environnement inc. 1996. Caractérisation physique et biologique de l'ha
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
+            <gco:CharacterString>Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-english.xml
@@ -385,10 +385,10 @@
          <gmd:resourceConstraints>
             <gmd:MD_LegalConstraints>
                <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-                  <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+                  <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
                   <gmd:PT_FreeText>
                      <gmd:textGroup>
-                        <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                        <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
                      </gmd:textGroup>
                   </gmd:PT_FreeText>
                </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnap_nonspatial-french.xml
@@ -385,10 +385,10 @@
          <gmd:resourceConstraints>
             <gmd:MD_LegalConstraints>
                <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-                  <gco:CharacterString>Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
+                  <gco:CharacterString>Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
                   <gmd:PT_FreeText>
                      <gmd:textGroup>
-                        <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
+                        <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
                      </gmd:textGroup>
                   </gmd:PT_FreeText>
                </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml
@@ -402,10 +402,10 @@
          <gmd:resourceConstraints>
             <gmd:MD_LegalConstraints>
                <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-                  <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+                  <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
                   <gmd:PT_FreeText>
                      <gmd:textGroup>
-                        <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                        <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
                      </gmd:textGroup>
                   </gmd:PT_FreeText>
                </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml
@@ -403,10 +403,10 @@
          <gmd:resourceConstraints>
             <gmd:MD_LegalConstraints>
                <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-                  <gco:CharacterString>Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
+                  <gco:CharacterString>Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gco:CharacterString>
                   <gmd:PT_FreeText>
                      <gmd:textGroup>
-                        <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
+                        <gmd:LocalisedCharacterString locale="#eng">Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)</gmd:LocalisedCharacterString>
                      </gmd:textGroup>
                   </gmd:PT_FreeText>
                </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/service.xml
@@ -388,11 +388,11 @@
             <gmd:resourceConstraints>
                 <gmd:MD_LegalConstraints>
                     <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
-                        <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)
+                        <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)
                         </gco:CharacterString>
                         <gmd:PT_FreeText>
                             <gmd:textGroup>
-                                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
                             </gmd:textGroup>
                         </gmd:PT_FreeText>
                     </gmd:useLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/templates/vector.xml
@@ -348,11 +348,11 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
-            <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)
+            <gco:CharacterString>Open Government Licence - Canada (https://open.canada.ca/en/open-government-licence-canada)
             </gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:useLimitation>


### PR DESCRIPTION
Samples and templates were not updated to use https for `Open Government Licence - Canada` causing them to be invalid with the pre-populated values. 

This PR aims to fix this issue by updating the licenses in samples and templates to use https.

Edit: Split some of the changes into #418