### PR TITLE
Remove condition for gmd:RS_Identifier/gmd:version

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1261,7 +1261,7 @@
         <label>Metadata language</label>
         <btnLabel>Add language</btnLabel>
         <description>Select the language used to create the metadata</description>
-        <condition>mandatory</condition>
+        <condition>conditional</condition>
     </element>
     <element name="gmd:language" context="gmd:MD_DataIdentification" id="39.0">
         <label>Language</label>
@@ -2152,7 +2152,6 @@
     <element name="gmd:version" id="208.2" context="gmd:RS_Identifier">
         <label>Version</label>
         <description>Version identifier for the namespace</description>
-        <condition>mandatory</condition>
     </element>
     <element name="gmd:version" context="gmd:MD_Format" id="286.0">
         <label>File Format Version</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -1809,7 +1809,7 @@
     <label>Langue</label>
     <btnLabel>Ajouter langue</btnLabel>
     <description>Sélectionner la langue d'usage pour la création de métadonnées.</description>
-    <condition>mandatory</condition>
+    <condition>Obligatoire</condition>
   </element>
   <element name="gmd:language" id="39.0" context="gmd:MD_DataIdentification">
     <label>Langue</label>
@@ -2946,7 +2946,7 @@
   <element name="gmd:version" id="208.2" context="gmd:RS_Identifier">
     <label>Version</label>
     <description>Identification de la version pour la domaine de valeurs</description>
-    <condition>mandatory</condition>
+    <condition/>
   </element>
   <element name="gmd:version" context="gmd:MD_Format" id="286.0">
     <label>Version</label>


### PR DESCRIPTION
Due to the previous commit change https://github.com/metadata101/iso19139.ca.HNAP/commit/33dc433a48c538feba659442cd34983f547e7728 There are two conditions for gmd:languae and gmd:version were added which are not necessary.

The change in Geonetwork's form-builder will still build required tag for the DTD schema https://github.com/geonetwork/core-geonetwork/blob/bedfe3da2b9461e5549f6c9935a5f9c73a9a4f97/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl#L124-L128

So I am restoring the code for these two fields. 