### PR TITLE
language country instead of ISO language code

### DIFF
--- a/src/main/config/codelist/local/thesauri/theme/ISO_Languages_Countries.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/ISO_Languages_Countries.rdf
@@ -28,7 +28,7 @@
             xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">eng; CAN
         </ns2:prefLabel>
     </rdf:Description>
-    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/languages#FRA">
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/GC/languages#FRA">
             <ns2:scopeNote
                 xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition
             </ns2:scopeNote>

--- a/src/main/config/codelist/local/thesauri/theme/ISO_Languages_Countries.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/ISO_Languages_Countries.rdf
@@ -13,7 +13,7 @@
         <dc:description></dc:description>
       </skos:ConceptScheme>
 
-    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/languages#ENG">
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/GC/languages#ENG">
         <ns2:scopeNote
             xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition
         </ns2:scopeNote>

--- a/src/main/config/codelist/local/thesauri/theme/ISO_Languages_Countries.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/ISO_Languages_Countries.rdf
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+      <skos:ConceptScheme>
+        <dc:title>Languages</dc:title>
+        <dc:title xml:lang="en">Languages</dc:title>
+        <dc:title xml:lang="fr">Langues</dc:title>
+        <dc:publisher xml:lang="en">Government of Canada; Library and Archives Canada</dc:publisher>
+        <dc:publisher xml:lang="fr">Gouvernement du Canada; Bibliothèque et Archives Canada</dc:publisher>
+        <dc:description></dc:description>
+      </skos:ConceptScheme>
+
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/languages#ENG">
+        <ns2:scopeNote
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition
+        </ns2:scopeNote>
+        <ns2:scopeNote
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition
+        </ns2:scopeNote>
+        <ns2:prefLabel
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">eng; CAN
+        </ns2:prefLabel>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <ns2:prefLabel
+            xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">eng; CAN
+        </ns2:prefLabel>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://geonetwork-opensource.org/EC/languages#FRA">
+            <ns2:scopeNote
+                xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition
+            </ns2:scopeNote>
+            <ns2:scopeNote
+                xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition
+            </ns2:scopeNote>
+            <ns2:prefLabel
+                xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">fra; CAN
+            </ns2:prefLabel>
+            <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+            <ns2:prefLabel
+                xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">fra; CAN
+            </ns2:prefLabel>
+    </rdf:Description>
+</rdf:RDF>

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -78,11 +78,13 @@
 
     <for name="gmd:electronicMailAddress" use="email"/>
 
-    <for name="gmd:language" use="data-gn-language-picker">
-      <directiveAttributes data-show-hints-on-focus="true"/>
+    <for name="gmd:language"
+         use="data-gn-keyword-picker">
+      <directiveAttributes data-thesaurus-key="external.theme.ISO_Languages_Countries" data-focus-to-input="false" data-number-of-suggestions="250" data-show-hints-on-focus="true"/>
     </for>
-    <for name="gmd:languageCode" use="data-gn-language-picker">
-      <directiveAttributes data-show-hints-on-focus="true"/>
+    <for name="gmd:languageCode"
+         use="data-gn-keyword-picker">
+      <directiveAttributes data-thesaurus-key="external.theme.ISO_Languages_Countries" data-focus-to-input="false" data-number-of-suggestions="250" data-show-hints-on-focus="true"/>
     </for>
 
 <!--    <for name="gmd:country" use="data-gn-country-selector-ec"/>-->


### PR DESCRIPTION
The language code was defined in the template as : https://github.com/metadata101/iso19139.ca.HNAP/blob/adcfe954b0e7a4b0ac98f043c32a0cd46630c5a0/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml#L18

However, in the editor mode, the language code is from ISO language code which is different from the original templte. It is adding some confusing to the user.

The purpose of this change is to introduce a new codelist library, and use "eng;CAN" or "fra:CAN" as standard language code. So this library can be expended in the future if new language code as needed.