### PR TITLE
resource name tool tip

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -2155,7 +2155,7 @@
     </element>
     <element name="gmd:version" context="gmd:MD_Format" id="286.0">
         <label>File Format Version</label>
-        <description>Enter the version of the data transfer format(s). For a list of possible versions, see the 'suggestions' menu. If the version is unknown, enter "unknown"</description>
+        <description>Enter the version of the data transfer format(s) (free text). If the version is unknown, enter "unknown"</description>
     </element>
     <element name="gmd:verticalElement" id="338.0">
         <label>Vertical element</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1486,7 +1486,7 @@
     </element>
     <element name="gmd:name">
         <label>Name</label>
-        <description/>
+        <description>The name of the data resource</description>
     </element>
     <element name="gmd:nameOfMeasure" id="100.0">
         <label>Name of measure</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -849,8 +849,7 @@
     </element>
     <element name="gmd:description" id="561.0">
         <label>Description</label>
-        <description>Description of the event, including related parameters or
-            tolerances</description>
+        <description>Description of the resource includes three sub-fields - Content type, format and language. Content type describes the type of resource, for example, supporting document, while format specifies the format that the resource is available in, and language identifies which language(s) it is available in. All three fields contain drop-down option that show the available code lists.</description>
     </element>
     <element name="gmd:description" id="561.0" context="gmd:MD_AbstractClass">
         <label>Description</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2095,7 +2095,7 @@
   </element>
   <element name="gmd:name">
     <label>Nom</label>
-    <description>Name of the series, or aggregate dataset, of which the dataset is a part</description>
+    <description>Nom de la ressource en ligne</description>
     <help/>
     <condition>Obligatoire</condition>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -1323,7 +1323,7 @@
   </element>
   <element name="gmd:description" id="401.0">
     <label>Description</label>
-    <description></description>
+    <description>La description de la ressource comprend trois sous-champs : le type de contenu, le format et la langue. Le type de contenu décrit le type de ressource, par exemple, un document de support, tandis que le format spécifie le format dans lequel la ressource est disponible et la langue identifie la ou les langues dans lesquelles elle est disponible. Les trois champs contiennent une option déroulante qui affiche les listes de codes disponibles.</description>
     <help></help>
     <condition/>
   </element>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2950,7 +2950,7 @@
   </element>
   <element name="gmd:version" context="gmd:MD_Format" id="286.0">
     <label>Version</label>
-    <description>Indiquer la version du format de transfert de données. Pour une liste de versions possibles, consulter le menu « Suggestions ». Si la version est inconnue, indiquer « inconnue ».</description>
+    <description>Entrez la version du ou des formats de transfert de données (texte libre). Si la version est inconnue, entrez « inconnu »</description>
     <condition>Obligatoire</condition>
   </element>
 


### PR DESCRIPTION
The tooltip of resource name is missing

![image](https://github.com/user-attachments/assets/9059ef7f-27b0-4b75-ac20-2f30a5036ef3)


It is defined in https://github.com/metadata101/iso19139.ca.HNAP/blob/adcfe954b0e7a4b0ac98f043c32a0cd46630c5a0/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json#L25

So the tooltip text is moved from:
https://github.com/metadata101/iso19139.ca.HNAP/blob/adcfe954b0e7a4b0ac98f043c32a0cd46630c5a0/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml#L1464


This pull request change also update gmd:version and gmd:description to have better help text.