### PR TITLE
remove url as part of unit of measurement

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -912,24 +912,6 @@
   </xsl:template>
 
 
-  <xsl:template  match="gco:Distance">
-    <xsl:element name="gco:{local-name()}">
-      <xsl:apply-templates select="@*"/>
-      <xsl:choose>
-        <!--Avoid append the url recursively. Only append the url once. -->
-        <xsl:when test="starts-with(@uom, 'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#')">
-          <xsl:attribute name="uom"><xsl:value-of select="concat(., ' ', tokenize(@uom, '#')[2])"/></xsl:attribute>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:attribute name="uom"><xsl:value-of select="@uom"/></xsl:attribute>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:apply-templates select="node()"/>
-    </xsl:element>
-  </xsl:template>
-
-
-
   <xsl:template match="gmd:onLine[@xlink:title]" priority="100">
     <xsl:copy>
       <xsl:apply-templates select="@*[name()!='xlink:title']" />

--- a/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/update-fixed-info.xsl
@@ -917,8 +917,8 @@
       <xsl:apply-templates select="@*"/>
       <xsl:choose>
         <!--Avoid append the url recursively. Only append the url once. -->
-        <xsl:when test="not(starts-with(@uom, 'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#'))">
-          <xsl:attribute name="uom">http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#<xsl:value-of select="@uom"/></xsl:attribute>
+        <xsl:when test="starts-with(@uom, 'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/gmxUom.xml#')">
+          <xsl:attribute name="uom"><xsl:value-of select="concat(., ' ', tokenize(@uom, '#')[2])"/></xsl:attribute>
         </xsl:when>
         <xsl:otherwise>
           <xsl:attribute name="uom"><xsl:value-of select="@uom"/></xsl:attribute>


### PR DESCRIPTION
The url appended to the uom attribute (unit of measurement) is causing some issue https://github.com/metadata101/iso19139.ca.HNAP/issues/415

The discussion is to not enforce such url which is brought from indexing

https://github.com/metadata101/iso19139.ca.HNAP/blob/adcfe954b0e7a4b0ac98f043c32a0cd46630c5a0/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl#L576-L578