### PR TITLE
Fix inconsistencies with hyphens for GC_Open_Licenses

### DIFF
--- a/src/main/config/codelist/local/thesauri/theme/GC_Open_Licenses.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/GC_Open_Licenses.rdf
@@ -43,32 +43,32 @@
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition</ns2:scopeNote>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence – Newfoundland and Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)</ns2:prefLabel>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert – Terre-Neuve-et-Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)'</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence - Newfoundland and Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert - Terre-Neuve-et-Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)'</ns2:prefLabel>
   </rdf:Description>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/GC/GC_OpenLicense#NovaScotia">
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition</ns2:scopeNote>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence – Nova Scotia (https://novascotia.ca/opendata/licence.asp)</ns2:prefLabel>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert – Nouvelle-Écosse (https://novascotia.ca/opendata/licence.asp)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence - Nova Scotia (https://novascotia.ca/opendata/licence.asp)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert - Nouvelle-Écosse (https://novascotia.ca/opendata/licence.asp)</ns2:prefLabel>
   </rdf:Description>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/GC/GC_OpenLicense#Ontario">
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition</ns2:scopeNote>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence – Ontario (https://www.ontario.ca/page/open-government-licence-ontario)</ns2:prefLabel>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert – Ontario (https://www.ontario.ca/fr/page/licence-du-gouvernement-ouvert-ontario)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence - Ontario (https://www.ontario.ca/page/open-government-licence-ontario)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert - Ontario (https://www.ontario.ca/fr/page/licence-du-gouvernement-ouvert-ontario)</ns2:prefLabel>
   </rdf:Description>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/GC/GC_OpenLicense#PrinceEdwardIsland">
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Definition</ns2:scopeNote>
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition</ns2:scopeNote>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence – Prince Edward Island (https://www.princeedwardisland.ca/en/information/finance/open-government-licence-prince-edward-island)</ns2:prefLabel>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert – Île-du-Prince-Édouard (https://www.princeedwardisland.ca/fr/information/finances/licence-du-gouvernement-ouvert-ile-du-prince-edouard)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence - Prince Edward Island (https://www.princeedwardisland.ca/en/information/finance/open-government-licence-prince-edward-island)</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert - Île-du-Prince-Édouard (https://www.princeedwardisland.ca/fr/information/finances/licence-du-gouvernement-ouvert-ile-du-prince-edouard)</ns2:prefLabel>
   </rdf:Description>
 </rdf:RDF>
 

--- a/src/main/config/codelist/local/thesauri/theme/GC_Open_Licenses.rdf
+++ b/src/main/config/codelist/local/thesauri/theme/GC_Open_Licenses.rdf
@@ -44,7 +44,7 @@
     <ns2:scopeNote xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Definition</ns2:scopeNote>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Open Government Licence - Newfoundland and Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)</ns2:prefLabel>
-    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert - Terre-Neuve-et-Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)'</ns2:prefLabel>
+    <ns2:prefLabel xmlns:ns2="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Licence du gouvernement ouvert - Terre-Neuve-et-Labrador (https://opendata.gov.nl.ca/public/opendata/page/?page-id=licence)</ns2:prefLabel>
   </rdf:Description>
 
   <rdf:Description rdf:about="http://geonetwork-opensource.org/GC/GC_OpenLicense#NovaScotia">


### PR DESCRIPTION
Some licenses use en dash (`–`) instead of hyphen (`-`) causing issues with typeahead as not all options are shown when one of the two dashes are typed into the field.

This PR aims to fix this issue by making all the licenses consistently use hyphen instead of en dash.

Additionally there is a typo in the French Newfoundland and Labrador license.

Split from #409 