### PR TITLE
Update index with new keys for static and interactive maps

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -223,10 +223,10 @@
           <resourceType>map</resourceType>
           <xsl:choose>
             <xsl:when test="$isStatic">
-              <resourceType>map/static</resourceType>
+              <resourceType>map-static</resourceType>
             </xsl:when>
             <xsl:when test="$isInteractive or $isPublishedWithWMCProtocol">
-              <resourceType>map/interactive</resourceType>
+              <resourceType>map-interactive</resourceType>
             </xsl:when>
           </xsl:choose>
         </xsl:when>


### PR DESCRIPTION
Following GeoNetwork PR: [8568](https://github.com/geonetwork/core-geonetwork/pull/8568) the index key needs to be updated so the correct label and icon are used in the UI.

This PR updates the key from `map/static` and `map/interactive` to `map-static` and `map-interactive`.