### PR TITLE
Change artifactId gn-schema-iso19139.ca.HNAP consistent others schemas and add-schema.sh script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>schema-iso19139.ca.HNAP</artifactId>
+  <artifactId>gn-schema-iso19139.ca.HNAP</artifactId>
   <name>Schema Plugin HNAP ISO19139/119</name>
 
   <description>


### PR DESCRIPTION
When using add-schema.sh script on a fresh checkout, the script references ``gn-schema-${schema}``. Checking the other schemes on 4.4.x ``gn-schema`` is used.

See also https://github.com/geonetwork/core-geonetwork/issues/8640