### PR TITLE
Removed subtuitionGroup for some gmx schema. Add labels

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -2300,6 +2300,54 @@
         <label>Projected CRS</label>
         <description/>
     </element>
+  <element name="gml:CompoundCRS">
+    <label>Compound CRS</label>
+    <description/>
+  </element>
+  <element name="gml:DerivedCRS">
+    <label>Derived CRS</label>
+    <description/>
+  </element>
+  <element name="gml:EngineeringCRS">
+    <label>Engineering CRS</label>
+    <description/>
+  </element>
+  <element name="gml:GeocentricCRS">
+    <label>Geocentric CRS</label>
+    <description/>
+  </element>
+  <element name="gml:GeodeticCRS">
+    <label>Geodetic CRS</label>
+    <description/>
+  </element>
+  <element name="gml:GeographicCRS">
+    <label>Geographic CRS</label>
+    <description/>
+  </element>
+  <element name="gml:ImageCRS">
+    <label>Image CRS</label>
+    <description/>
+  </element>
+  <element name="gml:TemporalCRS">
+    <label>Temporal CRS</label>
+    <description/>
+  </element>
+  <element name="gml:BaseUnit">
+    <label>Base Unit</label>
+    <description/>
+  </element>
+  <element name="gml:ConventionalUnit">
+    <label>Conventional Unit</label>
+    <description/>
+  </element>
+  <element name="gml:DerivedUnit">
+    <label>Derived Unit</label>
+    <description/>
+  </element>
+  <element name="gml:UnitDefinition">
+    <label>Unit Definition</label>
+    <description/>
+  </element>
 
     <element name="gml:id">
         <label>Identifier</label>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -3658,6 +3658,58 @@
     <label>CRS vertical</label>
     <description>Information sur l'origine depuis laquelle les altitudes maximale et minimale ont été mesurées</description>
   </element>
+  <element name="gml:ProjectedCRS">
+    <label>SRC Projeté</label>
+    <description/>
+  </element>
+  <element name="gml:CompoundCRS">
+    <label>SRC Composé</label>
+    <description/>
+  </element>
+  <element name="gml:DerivedCRS">
+    <label>SRC Dérivé</label>
+    <description/>
+  </element>
+  <element name="gml:EngineeringCRS">
+    <label>SRC Ingénierie</label>
+    <description/>
+  </element>
+  <element name="gml:GeocentricCRS">
+    <label>SRC Géocentrique</label>
+    <description/>
+  </element>
+  <element name="gml:GeodeticCRS">
+    <label>SRC Géodésique</label>
+    <description/>
+  </element>
+  <element name="gml:GeographicCRS">
+    <label>SRC Géographique</label>
+    <description/>
+  </element>
+  <element name="gml:ImageCRS">
+    <label>SRC Image</label>
+    <description/>
+  </element>
+  <element name="gml:TemporalCRS">
+    <label>SRC Temporel</label>
+    <description/>
+  </element>
+  <element name="gml:BaseUnit">
+    <label>Unité de base</label>
+    <description/>
+  </element>
+  <element name="gml:ConventionalUnit">
+    <label>Unité conventionnelle</label>
+    <description/>
+  </element>
+  <element name="gml:DerivedUnit">
+    <label>Unité dérivée</label>
+    <description/>
+  </element>
+  <element name="gml:UnitDefinition">
+    <label>Définition de l'unité</label>
+    <description/>
+  </element>
   <element name="gmx:FileName">
     <label>Nom du fichier</label>
     <description>Nom du fichier et URL.</description>

--- a/src/main/plugin/iso19139.ca.HNAP/schema/gmx/crsItem.xsd
+++ b/src/main/plugin/iso19139.ca.HNAP/schema/gmx/crsItem.xsd
@@ -113,7 +113,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_CompoundCRS" type="gmx:ML_CompoundCRS_Type" substitutionGroup="gml:CompoundCRS"/>
+	<xs:element name="ML_CompoundCRS" type="gmx:ML_CompoundCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_CompoundCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -175,7 +175,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_GeodeticCRS" type="gmx:ML_GeodeticCRS_Type" substitutionGroup="gml:GeodeticCRS"/>
+	<xs:element name="ML_GeodeticCRS" type="gmx:ML_GeodeticCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_GeodeticCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -195,7 +195,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_EngineeringCRS" type="gmx:ML_EngineeringCRS_Type" substitutionGroup="gml:EngineeringCRS"/>
+	<xs:element name="ML_EngineeringCRS" type="gmx:ML_EngineeringCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_EngineeringCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -215,7 +215,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_VerticalCRS" type="gmx:ML_VerticalCRS_Type" substitutionGroup="gml:VerticalCRS"/>
+	<xs:element name="ML_VerticalCRS" type="gmx:ML_VerticalCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_VerticalCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -235,7 +235,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_TemporalCRS" type="gmx:ML_TemporalCRS_Type" substitutionGroup="gml:TemporalCRS"/>
+	<xs:element name="ML_TemporalCRS" type="gmx:ML_TemporalCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_TemporalCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -255,7 +255,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_ImageCRS" type="gmx:ML_ImageCRS_Type" substitutionGroup="gml:ImageCRS"/>
+	<xs:element name="ML_ImageCRS" type="gmx:ML_ImageCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_ImageCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -275,7 +275,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_ProjectedCRS" type="gmx:ML_ProjectedCRS_Type" substitutionGroup="gml:ProjectedCRS"/>
+	<xs:element name="ML_ProjectedCRS" type="gmx:ML_ProjectedCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_ProjectedCRS_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -295,7 +295,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_DerivedCRS" type="gmx:ML_DerivedCRS_Type" substitutionGroup="gml:DerivedCRS"/>
+	<xs:element name="ML_DerivedCRS" type="gmx:ML_DerivedCRS_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_DerivedCRS_PropertyType">
 		<xs:sequence minOccurs="0">

--- a/src/main/plugin/iso19139.ca.HNAP/schema/gmx/gmxUsage.xsd
+++ b/src/main/plugin/iso19139.ca.HNAP/schema/gmx/gmxUsage.xsd
@@ -115,7 +115,7 @@
 	</xs:complexType>
 	<!-- =========================================================================== -->
 	<!-- ........................................................................ -->
-	<xs:element name="MX_ScopeCode" type="gco:CodeListValue_Type" substitutionGroup="gmd:MD_ScopeCode"/>
+	<xs:element name="MX_ScopeCode" type="gco:CodeListValue_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="MX_ScopeCode_PropertyType">
 		<xs:sequence minOccurs="0">

--- a/src/main/plugin/iso19139.ca.HNAP/schema/gmx/uomItem.xsd
+++ b/src/main/plugin/iso19139.ca.HNAP/schema/gmx/uomItem.xsd
@@ -61,7 +61,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_BaseUnit" type="gmx:ML_BaseUnit_Type" substitutionGroup="gml:BaseUnit"/>
+	<xs:element name="ML_BaseUnit" type="gmx:ML_BaseUnit_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_BaseUnit_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -81,7 +81,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_DerivedUnit" type="gmx:ML_DerivedUnit_Type" substitutionGroup="gml:DerivedUnit"/>
+	<xs:element name="ML_DerivedUnit" type="gmx:ML_DerivedUnit_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_DerivedUnit_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -101,7 +101,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_ConventionalUnit" type="gmx:ML_ConventionalUnit_Type" substitutionGroup="gml:ConventionalUnit"/>
+	<xs:element name="ML_ConventionalUnit" type="gmx:ML_ConventionalUnit_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_ConventionalUnit_PropertyType">
 		<xs:sequence minOccurs="0">
@@ -121,7 +121,7 @@
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="ML_UnitDefinition" type="gmx:ML_UnitDefinition_Type" substitutionGroup="gml:UnitDefinition"/>
+	<xs:element name="ML_UnitDefinition" type="gmx:ML_UnitDefinition_Type"/>
 	<!-- ........................................................................ -->
 	<xs:complexType name="ML_UnitDefinition_PropertyType">
 		<xs:sequence minOccurs="0">


### PR DESCRIPTION
In the advanced view, there are a few labels missing for the data quality section. Also some substitutional schema popped out. For example, [gmd:level](https://www.datypic.com/sc/niem21/e-gmd_level-1.html) only have [gmd:MD_ScopeCode](https://www.datypic.com/sc/niem21/e-gmd_MD_ScopeCode.html)



But gmx:MX_ScopeCode is also showing.
![image](https://github.com/user-attachments/assets/1768e7ae-6154-4589-a68a-2758afe90eb4)

So of the xsd change to get the substitutionGroup removed. Also added couple of missing labels for

![image](https://github.com/user-attachments/assets/919cb2ea-e0fb-44aa-a241-84e187618f9a)
and
![image](https://github.com/user-attachments/assets/c8fd31a5-872e-4d8e-9845-40c8a1cd6c50)
