### PR TITLE
Fix duplicated eng or fra online resource issue

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -551,20 +551,31 @@
       <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
       <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
 
-      <sch:let name="mapRESTCount" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service']) +
-                count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+      <sch:let name="mapRESTCountE" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+      <sch:let name="mapRESTCountF" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+      <sch:let name="mapRESTCount" value="$mapRESTCountE + $mapRESTCountF" />
+
+      <!--  mapRESTTiledCount &gt; 2 to fail in the 2on rule only and avoid 2 messages -->
+      <sch:assert test="($mapRESTCountE = 0 and $mapRESTCountF = 0) or ($mapRESTCountE = 1 and $mapRESTCountF = 1) or $mapRESTCount &gt; 2">$loc/strings/MapResourcesREST</sch:assert>
+      <sch:assert test="$mapRESTCount = 0 or $mapRESTCount &lt;= 2">$loc/strings/MapResourcesRESTNumber</sch:assert>
+
+      <sch:let name="mapRESTServerCountE" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map server'])" />
+      <sch:let name="mapRESTServerCountF" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map server'])" />
+      <sch:let name="mapRESTServerCount" value="$mapRESTServerCountE + $mapRESTServerCountF" />
+
+      <!--  mapRESTServerCount &gt; 2 to fail in the 2on rule only and avoid 2 messages -->
+      <sch:assert test="($mapRESTServerCountE = 0 and $mapRESTServerCountF = 0) or ($mapRESTServerCountE = 1 and $mapRESTServerCountF = 1) or $mapRESTServerCount &gt; 2">$loc/strings/MapResourcesREST</sch:assert>
+      <sch:assert test="$mapRESTServerCount = 0 or $mapRESTServerCount &lt;= 2">$loc/strings/MapResourcesRESTNumber</sch:assert>
+
+      <sch:let name="mapWMSCountE" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
+      <sch:let name="mapWMSCountF" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
+      <sch:let name="mapWMSCount" value="$mapWMSCountE + $mapWMSCountF" />
+
+      <!--  $mapWMSCount &gt; 2 to fail in the 2on check only and avoid 2 messages -->
+      <sch:assert test="($mapWMSCountE = 0 and $mapWMSCountF = 0) or ($mapWMSCountE = 1 and $mapWMSCountF = 1) or $mapWMSCount &gt; 2">$loc/strings/MapResourcesWMS</sch:assert>
+      <sch:assert test="$mapWMSCount = 0 or $mapWMSCount &lt;= 2">$loc/strings/MapResourcesWMSNumber</sch:assert>
 
       <sch:let name="onlineResources" value="gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource" />
-
-      <sch:assert test="$mapRESTCount &lt;= 2">$loc/strings/MapResourcesRESTNumber</sch:assert>
-      <sch:assert test="$mapRESTCount = 0 or $mapRESTCount = 2 or $mapRESTCount &gt; 2">$loc/strings/MapResourcesREST</sch:assert>
-
-      <sch:let name="mapWMSCount" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms']) +
-                count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
-
-      <sch:assert test="$mapWMSCount &lt;= 2">$loc/strings/MapResourcesWMSNumber</sch:assert>
-      <sch:assert test="$mapWMSCount = 0 or $mapWMSCount = 2 or $mapWMSCount &gt; 2">$loc/strings/MapResourcesWMS</sch:assert>
-
       <sch:let name="duplicatedResource" value="geonet:getDuplicateResources($onlineResources)" />
       <sch:let name="locMsg" value="geonet:appendLocaleMessage($loc/strings/hasDuplicatedOnlineResource, $duplicatedResource)" />
 


### PR DESCRIPTION
If there are two English or two French ESRI or WMS resources

![image](https://github.com/user-attachments/assets/039fe2e5-85ed-4b45-ae5c-08b46f6534aa)


The existing validation does not catch such error. However the older version validation does:
https://github.com/metadata101/iso19139.ca.HNAP/blob/5a2ca4838d95c7c7cc17bc9ec0eb61275311c4fa/src/main/plugin/iso19139.nap/schematron/schematron-rules-iso19139.nap-internal.sch#L660-L666

So the pull request is to bring back such code. So this error can be caught.

![image](https://github.com/user-attachments/assets/51a32145-cbf2-4331-8c69-0ddc2e3c3621)


i also added extra ESRI Map Server which should be validated as well.