### PR TITLE
[Backport 4.2.x] update french label for RI_490 (#425)

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/codelists.xml
@@ -864,8 +864,8 @@
 		<entry>
       <code>RI_490</code>
       <value>forOfficialUseOnly; réservéÀOrganisation</value>
-			<label>Réservé À Organisation</label>
-			<description>For Official Use Only</description>
+			<label>Réservé à un usage officiel uniquement</label>
+			<description>Pour usage officiel seulement</description>
 		</entry>
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 	</codelist>


### PR DESCRIPTION
Backport https://github.com/metadata101/iso19139.ca.HNAP/pull/425