### PR TITLE
Fix unwanted date time if for resourceDate index

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -335,11 +335,16 @@
 
             <xsl:variable name="zuluDate"
                           select="date-util:convertToISOZuluDateTime($date)"/>
-            <xsl:if test="$zuluDate != ''">
-              <resourceDate type="object">
-                {"type": "<xsl:value-of select="$dateType"/>", "date": "<xsl:value-of select="$zuluDate"/>"}
-              </resourceDate>
-            </xsl:if>
+            <resourceDate type="object">
+              <xsl:choose>
+                <xsl:when test="$zuluDate != '' and gn-fn-index:is-dateTime($date)">
+                  {"type": "<xsl:value-of select="$dateType"/>", "date": "<xsl:value-of select="$zuluDate"/>"}
+                </xsl:when>
+                <xsl:otherwise>
+                  {"type": "<xsl:value-of select="$dateType"/>", "date": "<xsl:value-of select="$date"/>"}
+                </xsl:otherwise>
+              </xsl:choose>
+            </resourceDate>
           </xsl:for-each>
 
           <xsl:if test="$useDateAsTemporalExtent">


### PR DESCRIPTION
The XML of the record contains no such datetime or date information but just simple year.

![image](https://github.com/user-attachments/assets/698aecaf-fafd-49b9-8e87-a05bfde523f2)


However the record view page added extra information

![image](https://github.com/user-attachments/assets/007e68fb-0c4d-4e67-86a6-941eb6d8539c)

In the xsl-view mode which was sent by notification email (for example:
https://YOUR_HOST/catalogue/srv/eng/catalog.search#/metadata/36f1a5bf-9a28-4c05-9acc-f838de67b167/formatters/xsl-view?root=div&view=advanced). The view renders as is.

![image](https://github.com/user-attachments/assets/1907cae3-84f8-417b-b9b6-052a1dff34c6)


It created confusion to the user. If the original xml contains no such date, datetime, or zone information, we should not add extra information to confuse the user. Therefore, this pull request is to remove the conversion from the index for this specific "resourceDate" field
