### PR TITLE
[Backport 4.2] validate all missing keyword

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -31,7 +31,8 @@
   <OpenLicenseEnglish>An English supported license is required. Accepted values: </OpenLicenseEnglish>
   <OpenLicenseFrench>A French supported license is required. Accepted values: </OpenLicenseFrench>
   <SupplementalInfo>Supplemental Information should be empty or filled in both languages</SupplementalInfo>
-  <Keyword>One of the Keyword(s) is(are) missing. Keyword is required in both languages</Keyword>
+  <KeywordMissing>One of the Keyword(s) is(are) missing.</KeywordMissing>
+  <Keyword>Keyword is required in both languages</Keyword>
 
   <OtherConstraintsNote2>Note (Other Constraints) is required in both languages</OtherConstraintsNote2>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -31,7 +31,7 @@
   <OpenLicenseEnglish>An English supported license is required. Accepted values: </OpenLicenseEnglish>
   <OpenLicenseFrench>A French supported license is required. Accepted values: </OpenLicenseFrench>
   <SupplementalInfo>Supplemental Information should be empty or filled in both languages</SupplementalInfo>
-  <Keyword>Keyword is required in both languages</Keyword>
+  <Keyword>One of the Keyword(s) is(are) missing. Keyword is required in both languages</Keyword>
 
   <OtherConstraintsNote2>Note (Other Constraints) is required in both languages</OtherConstraintsNote2>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -31,7 +31,8 @@
   <OpenLicenseEnglish>Une licence en anglais prise en charge est nécessaire. Valeurs acceptées sont : </OpenLicenseEnglish>
   <OpenLicenseFrench>Une licence en français prise en charge est nécessaire. Valeurs acceptées sont : </OpenLicenseFrench>
   <SupplementalInfo>Informations supplémentaires devrait être vide ou rempli en anglais et en français</SupplementalInfo>
-  <Keyword>Un des mots-clés est manquant. Mot Clé est requise dans les deux langues</Keyword>
+  <KeywordMissing>Un des mots-clés est manquant.</KeywordMissing>
+  <Keyword>Mot Clé est requise dans les deux langues</Keyword>
 
   <OtherConstraintsNote2>Autres contraintes devrait être vide ou rempli en anglais et en français</OtherConstraintsNote2>
 

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -31,7 +31,7 @@
   <OpenLicenseEnglish>Une licence en anglais prise en charge est nécessaire. Valeurs acceptées sont : </OpenLicenseEnglish>
   <OpenLicenseFrench>Une licence en français prise en charge est nécessaire. Valeurs acceptées sont : </OpenLicenseFrench>
   <SupplementalInfo>Informations supplémentaires devrait être vide ou rempli en anglais et en français</SupplementalInfo>
-  <Keyword>Mot Clé est requise dans les deux langues</Keyword>
+  <Keyword>Un des mots-clés est manquant. Mot Clé est requise dans les deux langues</Keyword>
 
   <OtherConstraintsNote2>Autres contraintes devrait être vide ou rempli en anglais et en français</OtherConstraintsNote2>
 

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -668,10 +668,10 @@
 
     <!-- Keywords -->
     <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords">
-      <sch:let name="missing" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gco:CharacterString))
+      <sch:let name="missing" value="gmd:MD_Keywords/gmd:keyword[gco:CharacterString = '']
             or (@gco:nilReason)" />
 
-      <sch:let name="missingOtherLang" value="not(string(gmd:MD_Keywords/gmd:keyword[1]/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+      <sch:let name="missingOtherLang" value="gmd:MD_Keywords/gmd:keyword[gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString = '']" />
 
       <sch:assert
         test="not($missing) and not($missingOtherLang)"

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -673,8 +673,13 @@
 
       <sch:let name="missingOtherLang" value="gmd:MD_Keywords/gmd:keyword[gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString = '']" />
 
+      <sch:let name="missingEntireKeyword" value="$missing and $missingOtherLang"/>
+
+      <sch:assert test="not($missingEntireKeyword)"
+            >$loc/strings/KeywordMissing</sch:assert>
+
       <sch:assert
-        test="not($missing) and not($missingOtherLang)"
+        test="($missingEntireKeyword) or (not($missing) and not($missingOtherLang))"
       >$loc/strings/Keyword</sch:assert>
 
     </sch:rule>


### PR DESCRIPTION
For backporting 4.2 of this pull request https://github.com/metadata101/iso19139.ca.HNAP/pull/401