### PR TITLE
translate fra default language to fre in indexing

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -101,7 +101,7 @@
                         gmd:languageCode/gmd:LanguageCode/
                           @codeListValue[normalize-space(.) != '']"/>
     <xsl:variable name="allLanguages">
-      <lang id="default" value="{$mainLanguage}"/>
+      <lang id="default" value="{translate($mainLanguage, 'fra', 'fre')}"/>
       <xsl:for-each select="$otherLanguages">
         <lang id="{../../../@id}" value="{translate(., 'fra', 'fre')}"/>
       </xsl:for-each>


### PR DESCRIPTION
The indexing for several field are marked as langfra which is causing some potential issue because Geonetwork identify "fre" as the three letters French language code not "fra"

![image](https://github.com/user-attachments/assets/85346133-41e0-4bef-847f-235ce7f6729b)


This is mainly causing by parsing the variable from

https://github.com/metadata101/iso19139.ca.HNAP/blob/c1b89e308d1edff91dbda89108fdc81e180219e3/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml#L18

So this pull request will do some pre-transformation based on that fra code to fre.