### PR TITLE
contactForResource is incorrectly indexed

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -372,6 +372,13 @@
           <xsl:for-each select="gmd:edition/*">
             <xsl:copy-of select="gn-fn-index:add-field('resourceEdition', .)"/>
           </xsl:for-each>
+
+          <!-- Indexing resource contact -->
+          <xsl:apply-templates mode="index-contact-hnap"
+                               select="gmd:citedResponsibleParty">
+            <xsl:with-param name="fieldSuffix" select="'ForResource'"/>
+            <xsl:with-param name="languages" select="$allLanguages"/>
+          </xsl:apply-templates>
         </xsl:for-each>
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', gmd:abstract, $allLanguages)"/>
@@ -380,13 +387,6 @@
           <xsl:copy-of select="gn-fn-index:add-codelist-field(
                                   'cl_resourceCharacterSet', ., $allLanguages)"/>
         </xsl:for-each>
-
-        <!-- Indexing resource contact -->
-        <xsl:apply-templates mode="index-contact-hnap"
-                             select="gmd:pointOfContact">
-          <xsl:with-param name="fieldSuffix" select="'ForResource'"/>
-          <xsl:with-param name="languages" select="$allLanguages"/>
-        </xsl:apply-templates>
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceCredit', gmd:credit, $allLanguages)"/>
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('supplementalInformation', gmd:supplementalInformation, $allLanguages)"/>


### PR DESCRIPTION
Currently the `contactForResource` index field is never set as it uses `gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact` instead of `gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty`.

This causes issues such as a header without any content in the record view:
![image](https://github.com/user-attachments/assets/90e6773a-836a-4d54-b45e-6fc752c4e095)

Another issue is that the contact is not shown as an option in the feedback form.

This PR aims to fix this issue by setting the `contactForResource` to `gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty`.

The following help text suggests that these two should be mapped together:
![image](https://github.com/user-attachments/assets/b1259eb8-01cb-4fa4-942f-877718dda0e0)

After these changes the record view displays like:
![image](https://github.com/user-attachments/assets/39bfcb38-b9af-454a-8ae6-f823f1a375f8)

