### PR TITLE
Fix metadata language display in the metadata editor

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -79,10 +79,12 @@
     <for name="gmd:electronicMailAddress" use="email"/>
 
     <for name="gmd:language"
+         xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language"
          use="data-gn-keyword-picker">
       <directiveAttributes data-thesaurus-key="external.theme.ISO_Languages_Countries" data-focus-to-input="false" data-number-of-suggestions="250" data-show-hints-on-focus="true"/>
     </for>
     <for name="gmd:languageCode"
+         xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language/gmd:languageCode"
          use="data-gn-keyword-picker">
       <directiveAttributes data-thesaurus-key="external.theme.ISO_Languages_Countries" data-focus-to-input="false" data-number-of-suggestions="250" data-show-hints-on-focus="true"/>
     </for>


### PR DESCRIPTION
Without the fix the metadata language in the metadata editor displays a dropdown to select a thesaurus:

<img width="763" alt="Screenshot 2025-04-11 at 16 10 27" src="https://github.com/user-attachments/assets/794fe24f-107f-41d7-a061-5574468d73b3" />

Related to https://github.com/metadata101/iso19139.ca.HNAP/pull/414