### PR TITLE
Fix metadata language shows thesaurus dropdown in basic view

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -816,6 +816,9 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
       <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
+      <xsl:with-param name="directiveAttributes">
+        <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name(),name(*[@codeListValue]), $xpath)"/>
+      </xsl:with-param>
       <xsl:with-param name="name" select="''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>
       <xsl:with-param name="parentEditInfo" select="gn:element"/>


### PR DESCRIPTION
Currently the basic editor view displays the metadata language with a thesaurus selector.
![image](https://github.com/user-attachments/assets/4b5054a4-37ce-4ec5-a3a6-4c84071f4b39)

The thesaurus selector should not be shown as this field should only allow values from `ISO_Languages_Countries`. Additionally this field is read-only so the thesaurus selector does nothing.

The thesaurus selector is shown because the `data-thesaurus-key="external.theme.ISO_Languages_Countries"` directive attribute is not passed to the input in basic/default/flat mode.

This PR aims to fix this issue by updating the custom template to pass the directive attributes which contains the thesaurus key.