### PR TITLE
Fix ubuntu version used on backport job.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport Bot


### PR DESCRIPTION
This is the error being fixed.

`This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101`

Here is a sample of the error. 
https://github.com/metadata101/iso19139.ca.HNAP/actions/runs/14660449780/job/41143520357

![image](https://github.com/user-attachments/assets/1e41355d-d11f-4fa1-a254-819e070723ae)


https://github.com/metadata101/iso19139.ca.HNAP/actions

![image](https://github.com/user-attachments/assets/944ab42d-e414-4547-bb19-4b4b991b0d7d)



