### PR TITLE
Fix online resource validation messages

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -42,10 +42,10 @@
   <ResourceDescriptionContentTypeFrench>French online resource description content type is not valid. Valid French values are: </ResourceDescriptionContentTypeFrench>
   <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
-  <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
+  <SecurityLevel>Security User Note is not valid. Valid values are: </SecurityLevel>
   <SecurityNoteBothLangRequired>Value is required for Security User Note in both languages</SecurityNoteBothLangRequired>
   <SecurityNoteMismatchedBothLang>Value mismatched for Security User Note in both languages</SecurityNoteMismatchedBothLang>
-  <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
+  <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are: </SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>
   <UseLimitation>Value is required for Use Limitation in both languages</UseLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-multilingual.xml
@@ -36,12 +36,21 @@
 
   <OtherConstraintsNote2>Note (Other Constraints) is required in both languages</OtherConstraintsNote2>
 
-  <ResourceName>Online resource name is required in both language</ResourceName>
+  <ResourceNameEnglish>English online resource name is required</ResourceNameEnglish>
+  <ResourceNameFrench>French online resource name is required</ResourceNameFrench>
   <ResourceDescription>Online resource description is not valid. The format should be: ContentType;Format;Lang</ResourceDescription>
-  <ResourceDescriptionContentTypeEnglish>English online resource description content type is not valid. Valid English values are: </ResourceDescriptionContentTypeEnglish>
-  <ResourceDescriptionContentTypeFrench>French online resource description content type is not valid. Valid French values are: </ResourceDescriptionContentTypeFrench>
-  <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
-  <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
+  <ResourceDescriptionContentTypeMissingEnglish>English online resource description content type is required</ResourceDescriptionContentTypeMissingEnglish>
+  <ResourceDescriptionContentTypeMissingFrench>French online resource description content type is required</ResourceDescriptionContentTypeMissingFrench>
+  <ResourceDescriptionContentTypeInvalidEnglish>English online resource description content type is not valid. Valid English values are: </ResourceDescriptionContentTypeInvalidEnglish>
+  <ResourceDescriptionContentTypeInvalidFrench>French online resource description content type is not valid. Valid French values are: </ResourceDescriptionContentTypeInvalidFrench>
+  <ResourceDescriptionFormatMissingEnglish>English online resource description format is required</ResourceDescriptionFormatMissingEnglish>
+  <ResourceDescriptionFormatMissingFrench>French online resource description format is required</ResourceDescriptionFormatMissingFrench>
+  <ResourceDescriptionFormatInvalidEnglish>English online resource description format is not valid. Valid English values are: </ResourceDescriptionFormatInvalidEnglish>
+  <ResourceDescriptionFormatInvalidFrench>French online resource description format is not valid. Valid French values are: </ResourceDescriptionFormatInvalidFrench>
+  <ResourceDescriptionLanguageMissingEnglish>English online resource description language is required</ResourceDescriptionLanguageMissingEnglish>
+  <ResourceDescriptionLanguageMissingFrench>French online resource description language is required</ResourceDescriptionLanguageMissingFrench>
+  <ResourceDescriptionLanguageInvalidEnglish>English online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguageInvalidEnglish>
+  <ResourceDescriptionLanguageInvalidFrench>French online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguageInvalidFrench>
   <SecurityLevel>Security User Note is not valid. Valid values are: </SecurityLevel>
   <SecurityNoteBothLangRequired>Value is required for Security User Note in both languages</SecurityNoteBothLangRequired>
   <SecurityNoteMismatchedBothLang>Value mismatched for Security User Note in both languages</SecurityNoteMismatchedBothLang>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-non-multilingual.xml
@@ -31,8 +31,8 @@
   <OpenLicense>A supported license is required.</OpenLicense>
   <Keyword>Keyword is required</Keyword>
 
-  <SecurityLevel>Security User Note is not valid. Valid values are:</SecurityLevel>
-  <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are:</SecurityClassificationUserNote>
+  <SecurityLevel>Security User Note is not valid. Valid values are: </SecurityLevel>
+  <SecurityClassificationUserNote>Security User Note is not valid for the classification code selected. Valid values are: </SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Security User Note should be empty for the classification code selected</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>If you indicate 'Other Restrictions' in the 'Access Constraints' or 'Use Constraints' fields, the other constraints for accessing or using the resource should be explained here.</OtherConstraintsNote>
   <UseLimitation>Value is required for Use Limitation</UseLimitation>
@@ -55,7 +55,7 @@
 
   <ResourceDescriptionContentTypeEnglish>English online resource description content type is not valid. Valid English values are: </ResourceDescriptionContentTypeEnglish>
   <ResourceDescriptionContentTypeFrench>French online resource description content type is not valid. Valid French values are: </ResourceDescriptionContentTypeFrench>
-  <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are:</ResourceDescriptionFormat>
+  <ResourceDescriptionFormat>Online resource description format is not valid. Valid values are: </ResourceDescriptionFormat>
   <ResourceDescriptionLanguage>Online resource description language is not valid. Should be a comma separated values of ISO-LANG-3 codes</ResourceDescriptionLanguage>
 
   <ElectronicMailFormat>Electronic mail address format is invalid (for example abc@abc.com)</ElectronicMailFormat>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -36,12 +36,21 @@
 
   <OtherConstraintsNote2>Autres contraintes devrait être vide ou rempli en anglais et en français</OtherConstraintsNote2>
 
-  <ResourceName>Le nom des ressources en ligne est obligatoire dans les deux langues</ResourceName>
+  <ResourceNameEnglish>Le nom des ressources en ligne en anglais est obligatoire</ResourceNameEnglish>
+  <ResourceNameFrench>Le nom des ressources en ligne en français est obligatoire</ResourceNameFrench>
   <ResourceDescription>La description des ressources en ligne n'est pas valide. Le format devrait être : TypeContenu;Format;Lang</ResourceDescription>
-  <ResourceDescriptionContentTypeEnglish>Le type de contenu dans la description de la ressource en ligne en anglais n'est pas valide. Les valeurs valides en anglais sont : </ResourceDescriptionContentTypeEnglish>
-  <ResourceDescriptionContentTypeFrench>Le type de contenu dans la description de la ressource en ligne en français n'est pas valide. Les valeurs valides en français sont : </ResourceDescriptionContentTypeFrench>
-  <ResourceDescriptionFormat>Le format dans la description de la ressource en ligne n’est pas valide. Les valeurs valides sont : </ResourceDescriptionFormat>
-  <ResourceDescriptionLanguage>La langue dans la description de la ressource en ligne n’est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguage>
+  <ResourceDescriptionContentTypeMissingEnglish>Le type de contenu dans la description de la ressource en ligne en anglais est obligatoire</ResourceDescriptionContentTypeMissingEnglish>
+  <ResourceDescriptionContentTypeMissingFrench>Le type de contenu dans la description de la ressource en ligne en français est obligatoire</ResourceDescriptionContentTypeMissingFrench>
+  <ResourceDescriptionContentTypeInvalidEnglish>Le type de contenu dans la description de la ressource en ligne en anglais n'est pas valide. Les valeurs valides en anglais sont : </ResourceDescriptionContentTypeInvalidEnglish>
+  <ResourceDescriptionContentTypeInvalidFrench>Le type de contenu dans la description de la ressource en ligne en français n'est pas valide. Les valeurs valides en français sont : </ResourceDescriptionContentTypeInvalidFrench>
+  <ResourceDescriptionFormatMissingEnglish>Le format dans la description de la ressource en ligne en anglais est obligatoire</ResourceDescriptionFormatMissingEnglish>
+  <ResourceDescriptionFormatMissingFrench>Le format dans la description de la ressource en ligne en français est obligatoire</ResourceDescriptionFormatMissingFrench>
+  <ResourceDescriptionFormatInvalidEnglish>Le format dans la description de la ressource en ligne en anglais n'est pas valide. Les valeurs valides en anglais sont : </ResourceDescriptionFormatInvalidEnglish>
+  <ResourceDescriptionFormatInvalidFrench>Le format dans la description de la ressource en ligne en français n'est pas valide. Les valeurs valides en français sont : </ResourceDescriptionFormatInvalidFrench>
+  <ResourceDescriptionLanguageMissingEnglish>La langue dans la description de la ressource en ligne en anglais est obligatoire</ResourceDescriptionLanguageMissingEnglish>
+  <ResourceDescriptionLanguageMissingFrench>La langue dans la description de la ressource en ligne en français est obligatoire</ResourceDescriptionLanguageMissingFrench>
+  <ResourceDescriptionLanguageInvalidEnglish>La langue dans la description de la ressource en ligne en anglais n'est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguageInvalidEnglish>
+  <ResourceDescriptionLanguageInvalidFrench>La langue dans la description de la ressource en ligne en français n'est pas valide. Devrait être des valeurs de code ISO-LANG-3 séparées par des virgules</ResourceDescriptionLanguageInvalidFrench>
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
   <SecurityNoteBothLangRequired>Une valeur est requise pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteBothLangRequired>
   <SecurityNoteMismatchedBothLang>Valeur non concordante pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteMismatchedBothLang>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-multilingual.xml
@@ -45,7 +45,7 @@
   <SecurityLevel>Explications sur les restrictions n’est pas valide. Les valeurs valides sont : </SecurityLevel>
   <SecurityNoteBothLangRequired>Une valeur est requise pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteBothLangRequired>
   <SecurityNoteMismatchedBothLang>Valeur non concordante pour la note d'utilisateur de sécurité dans les deux langues</SecurityNoteMismatchedBothLang>
-  <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont :</SecurityClassificationUserNote>
+  <SecurityClassificationUserNote>Explications sur les restrictions n’est pas valide pour la restriction de manipulation. Les valeurs valides sont : </SecurityClassificationUserNote>
   <SecurityClassificationUserNoteEmpty>Explications sur les restrictions devrait être vide pour la restriction de manipulation</SecurityClassificationUserNoteEmpty>
   <OtherConstraintsNote>Si vous indiquez «Autres restrictions» dans les champs «Contraintes d'accès» ou «Utiliser les contraintes», les autres contraintes d'accès ou d'utilisation de la ressource doivent être expliquées ici.</OtherConstraintsNote>
   <UseLimitation>Limitation d'utilisation est obligatoire dans les deux langues</UseLimitation>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -884,11 +884,11 @@
 
       <sch:let name="missingResourceNameOtherLang" value="not(string(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
 
-      <sch:let name="locMsgResourceName" value="geonet:prependLocaleMessage($loc/strings/ResourceName, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="locMsgResourceNameMainLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceName', $mainLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgResourceNameAltLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceName', $altLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
 
-      <sch:assert
-        test="not($missingResourceName) and not($missingResourceNameOtherLang)"
-      >$locMsgResourceName</sch:assert>
+      <sch:assert test="not($missingResourceName)">$locMsgResourceNameMainLang</sch:assert>
+      <sch:assert test="not($missingResourceNameOtherLang)">$locMsgResourceNameAltLang</sch:assert>
 
       <!-- ResourceDescription -->
       <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
@@ -911,24 +911,46 @@
 
       <sch:let name="resourceContentTypesListMain" value="geonet:resourceContentTypesList($thesaurusDir,$mainLanguage2char)"/>
       <sch:let name="resourceContentTypesListAlt" value="geonet:resourceContentTypesList($thesaurusDir,$altLanguage2char)"/>
-      <sch:let name="locMsgCtMain" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionContentType', $mainLanguageText)], $resourceContentTypesListMain),  concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
-      <sch:let name="locMsgCtAlt" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionContentType', $altLanguageText)], $resourceContentTypesListAlt),  concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="contentTypeMissing" value="normalize-space($contentType) = ''"/>
+      <sch:let name="contentTypeTranslatedMissing" value="normalize-space($contentTypeTranslated) = ''"/>
 
-      <sch:assert test="$contentType = document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_ContentTypes.rdf'), '\\', '/')))//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]">$locMsgCtMain</sch:assert>
-      <sch:assert test="$contentTypeTranslated = document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_ContentTypes.rdf'), '\\', '/')))//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char]">$locMsgCtAlt</sch:assert>
+      <sch:let name="locMsgContentTypeMissingMainLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionContentTypeMissing', $mainLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgContentTypeMissingAltLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionContentTypeMissing', $altLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgContentTypeInvalidMainLang" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionContentTypeInvalid', $mainLanguageText)], $resourceContentTypesListMain), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgContentTypeInvalidAltLang" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionContentTypeInvalid', $altLanguageText)], $resourceContentTypesListAlt), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+
+      <sch:assert test="not($contentTypeMissing)">$locMsgContentTypeMissingMainLang</sch:assert>
+      <sch:assert test="not($contentTypeTranslatedMissing)">$locMsgContentTypeMissingAltLang</sch:assert>
+      <sch:assert test="$contentTypeMissing or $contentType = document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_ContentTypes.rdf'), '\\', '/')))//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]">$locMsgContentTypeInvalidMainLang</sch:assert>
+      <sch:assert test="$contentTypeTranslatedMissing or $contentTypeTranslated = document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_ContentTypes.rdf'), '\\', '/')))//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char]">$locMsgContentTypeInvalidAltLang</sch:assert>
 
       <sch:let name="formatTranslated" value="subsequence(tokenize($descriptionTranslated, ';'), 2, 1)" />
       <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
-      <sch:let name="locMsg" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/ResourceDescriptionFormat, $resourceFormatsList), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:let name="formatMissing" value="normalize-space($format) = ''"/>
+      <sch:let name="formatTranslatedMissing" value="normalize-space($formatTranslated) = ''"/>
 
-      <sch:assert test="$formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($mainLanguage2char)]/text() = $format and
-                          $formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($altLanguage2char)]/text() = $formatTranslated">$locMsg</sch:assert>
+      <sch:let name="locMsgFormatMissingMainLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionFormatMissing', $mainLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgFormatMissingAltLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionFormatMissing', $altLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgFormatInvalidMainLang" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionFormatInvalid', $mainLanguageText)], $resourceFormatsList), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgFormatInvalidAltLang" value="geonet:prependLocaleMessage(geonet:appendLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionFormatInvalid', $altLanguageText)], $resourceFormatsList), concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
 
-      <sch:let name="locMsgLang" value="geonet:prependLocaleMessage($loc/strings/ResourceDescriptionLanguage, concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))" />
+      <sch:assert test="not($formatMissing)">$locMsgFormatMissingMainLang</sch:assert>
+      <sch:assert test="not($formatTranslatedMissing)">$locMsgFormatMissingAltLang</sch:assert>
+      <sch:assert test="$formatMissing or $formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($mainLanguage2char)]/text() = $format">$locMsgFormatInvalidMainLang</sch:assert>
+      <sch:assert test="$formatTranslatedMissing or $formats-list//rdf:Description/ns2:prefLabel[@xml:lang = normalize-space($altLanguage2char)]/text() = $formatTranslated">$locMsgFormatInvalidAltLang</sch:assert>
 
-      <sch:assert test="normalize-space($language) != '' and normalize-space($languageTranslated) != ''">$locMsgLang</sch:assert>
+      <sch:let name="languageMissing" value="normalize-space($language) = ''"/>
+      <sch:let name="languageTranslatedMissing" value="normalize-space($languageTranslated) = ''"/>
 
-      <sch:assert test="$language_present and $languageTranslated_present">$locMsgLang</sch:assert>
+      <sch:let name="locMsgLanguageMissingMainLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionLanguageMissing', $mainLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgLanguageMissingAltLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionLanguageMissing', $altLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgLanguageInvalidMainLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionLanguageInvalid', $mainLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+      <sch:let name="locMsgLanguageInvalidAltLang" value="geonet:prependLocaleMessage($loc/strings/*[name() = concat('ResourceDescriptionLanguageInvalid', $altLanguageText)], concat(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, ' : '))"/>
+
+      <sch:assert test="not($languageMissing)">$locMsgLanguageMissingMainLang</sch:assert>
+      <sch:assert test="not($languageTranslatedMissing)">$locMsgLanguageMissingAltLang</sch:assert>
+      <sch:assert test="$languageMissing or $language_present">$locMsgLanguageInvalidMainLang</sch:assert>
+      <sch:assert test="$languageMissing or $languageTranslated_present">$locMsgLanguageInvalidAltLang</sch:assert>
 
     </sch:rule>
 
@@ -1097,3 +1119,4 @@
   </sch:pattern>
 
 </sch:schema>
+


### PR DESCRIPTION
With the current online resources validation it can be unclear to the user that there are empty alternate language values. If a user manually inputs `PDF` in the format field without clicking the typeahead suggestion, the French value will not be updated:

![image](https://github.com/user-attachments/assets/7e72b3a3-d4f7-437a-999f-69aec1cb9e48)
![image](https://github.com/user-attachments/assets/ec940ccc-bcc0-4a1e-be80-50f98b3d10b8)

This produces the following validation message:

> .../Sample_Valid.pdf : Online resource description format is not valid. Valid values are:AAC, AIFF, APK, ASCII Grid, AVI, BAG, BMP, BWF, CCT, CDED ASCII, CDF, CDR, COD, CSV, DBD, DBF, DICOM, DNG, DOC, DOCX, DXF, E00, ECW, EDI, EMF, EPS, EPUB2, EPUB3, ESRI REST, EXE, FGDB/GDB, Flat raster binary, GDB, GEOJSON, GeoPDF, GeoRSS, GeoTIF, GIF, GML, GPKG, GRD, GRIB1, GRIB2, HDF, HTML, IATI, IPA, JAR, JFIF, JP2, JPG, JSON, JSONL, JSONLD, KML, KMZ, LAS, LYR, MOV, MP3, MPEG, MPEG-1, MXD, MXF, NetCDF, NT, ODP, ODS, ODT, other, PDF, PDF/A-1, PDF/A-2, PDF/UA, PNG, PPT, PPTX, RDF, RDFa, RSS, RTF, SAR, SAV, SEGY, SHP, SQL, SQLITE, SQLITE3, SVG, TAB, TFW, TIFF, TRIG, TRIX, TTL, TXT, VPF, WAV, WCS, Web App, WFS, WMS, WMTS, WMV, WPS, XLS, XLSM, XLSX, XML, ZIP

This message is confusing as it does not specify it is the French value that is missing. Additionally there is a space missing after the colon in this message.

This PR aims to fix these issues by adding new validation messages specific to missing or invalid values for each language and by implementing these messages in the schematron. Additionally the messages that were missing spaces after colons have been updated with the missing spaces.