### PR TITLE
Metadata editor / replace the old online resources panel directive with new directives in GeoNetwork 4.4.x.

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -91,6 +91,82 @@
     "multilingualFields": ["name", "desc"],
     "wmsResources": {
       "addLayerNamesMode": "url"
+    },
+    "associatedResourcesTypes": [{
+      "type": "parent",
+      "label": "linkToParent",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "label": "linkToParent",
+            "params": {
+              "resourceType": ["series"],
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": false}
+        }
+      }
+    }, {
+        "type": "service",
+        "label": "linkToService",
+        "condition": "!gnCurrentEdit.isService",
+        "config": {
+          "sources": {
+            "metadataStore": {
+              "label": "searchAservice",
+              "params": {
+                "resourceType": ["service"],
+                "isTemplate": "n"
+              }
+            },
+            "remoteurl": {"multiple": false}
+          }
+        }
+    }, {
+      "type": "dataset",
+      "label": "linkToDataset",
+      "condition": "gnCurrentEdit.isService",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "params": {
+              "resourceType": ["dataset"],
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": false}
+        }
+      }
+    }, {
+      "type": "source",
+      "label": "linkToSource",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "label": "linkToSource",
+            "params": {
+              "resourceType": ["dataset"],
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": false}
+       }
+      }
+    }, {
+      "type": "siblings",
+      "label": "linkToSibling",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "params": {
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": true}
+        }
+      }
     }
+    ]
   }
 }

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -317,7 +317,24 @@
     <view name="default" default="true" displayTooltips="true" displayTooltipsMode="icon">
       <sidePanel>
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
-        <directive data-gn-onlinesrc-list=""/>
+
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg" />
+
+        <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
+                   data-mode="viewConfig.distributionConfig.layout || ''"
+                   data-editor-config="default"
+                   data-related-config="[{
+                                           title: 'API',
+                                           filter: 'protocol:OGC:.*|OGC API.*|ESRI REST:.*|AMQPS',
+                                           editActions: ['addOnlinesrc']},
+                                         {
+                                            title: 'links',
+                                            filter:'-protocol:OGC:.*|OGC API.*|ESRI:.*|AMQPS',
+                                            editActions: []}]"
+        />
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
       </sidePanel>
 
       <tab id="default" default="true" mode="flat">
@@ -592,7 +609,24 @@
     <view name="advanced">
       <sidePanel>
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
-        <directive data-gn-onlinesrc-list=""/>
+
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg" />
+
+        <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
+                   data-mode="viewConfig.distributionConfig.layout || ''"
+                   data-editor-config="default"
+                   data-related-config="[{
+                                           title: 'API',
+                                           filter: 'protocol:OGC:.*|OGC API.*|ESRI REST:.*|AMQPS',
+                                           editActions: ['addOnlinesrc']},
+                                         {
+                                            title: 'links',
+                                            filter:'-protocol:OGC:.*|OGC API.*|ESRI:.*|AMQPS',
+                                            editActions: []}]"
+        />
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
       </sidePanel>
 
       <tab id="identificationInfo" default="true">

--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -319,7 +319,8 @@
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg" />
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true" />
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
@@ -611,7 +612,8 @@
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg" />
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true" />
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"


### PR DESCRIPTION
The old online resources panel directive is not working fine in 4.4.x, for example fails for parent metadata resources. This pull request uses the new directives added for 4.4.x, that are used already for other metadata schemas like `iso19139`:


![resources-panel-44](https://github.com/user-attachments/assets/9b68c94a-fb5d-446e-84b0-6e485b99857a)


To be able to edit thumbnail details is required also https://github.com/geonetwork/core-geonetwork/pull/8879 and update the related `config-editor.xml` configuration.