### PR TITLE
Metadata editor / Fix configuration for service metadata keywords

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -405,8 +405,8 @@
                  or="citedResponsibleParty"/>
 
           <section name="gmd:MD_Keywords">
-            <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords"
-                   in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification"
+            <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:descriptiveKeywords"
+                   in="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification"
                    or="descriptiveKeywords"/>
           </section>
 


### PR DESCRIPTION
The XPATH to define the editor for service metadata keywords was wrong, using the XPATH for dataset metadata keywords.

This causes that the keyword section is displayed empty:

![Screenshot 2025-07-04 at 16 33 12](https://github.com/user-attachments/assets/5bc6bb56-8d4f-4cae-9aaf-50edb4fc4673)

With the fix:

![Screenshot 2025-07-04 at 16 36 02](https://github.com/user-attachments/assets/9b48e822-2b87-4de7-9f4b-3a0cbb9eec97)
