### PR TITLE
Add index report to the editor side panel

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/config-editor.xml
@@ -318,6 +318,8 @@
       <sidePanel>
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
 
+        <directive data-gn-index-report="" data-initial-section-states="closed"/>
+
         <directive data-gn-overview-manager=""
                    data-file-types=".png,.gif,.jpeg,.jpg"
                    data-editable-thumbnail="true" />
@@ -610,6 +612,8 @@
     <view name="advanced">
       <sidePanel>
         <directive data-gn-validation-report="" data-initial-show-errors="true" data-initial-show-successes="true" data-initial-section-states="closed"/>
+
+        <directive data-gn-index-report="" data-initial-section-states="closed"/>
 
         <directive data-gn-overview-manager=""
                    data-file-types=".png,.gif,.jpeg,.jpg"


### PR DESCRIPTION
Currently an editor has difficulties identifying and fixing index errors and warnings.

An editor can only see the index errors and warnings from the record view page. This means that if an indexing error or warning is encountered the editor must:

- read the error message in the record view page
- open the editor
- attempt to fix the issue
- save and close the editor
- check the record view page to see if the error went away
  - if the error is still shown or a new error is shown
restart the process

This is not a smooth process for the user.

It would be better if the index errors and warnings could be shown in the editor so the user can quickly identify and fix the issues without leaving the editor.

This PR aims to fix this issue by adding the index report directive introduced in https://github.com/geonetwork/core-geonetwork/pull/8887 to the editor sidepanel:
<img width="1017" height="619" alt="image" src="https://github.com/user-attachments/assets/5df29c2c-f715-467b-9530-0927fbbdc460" />
<img width="1016" height="625" alt="image" src="https://github.com/user-attachments/assets/ccd021bc-3d13-4493-a65e-7497255f02df" />
