### PR TITLE
Check for Open Government license specifically

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -35,6 +35,11 @@
   <sch:let name="mainLanguageText" value="if ($mainLanguage = 'fra') then 'French' else 'English'"/>
   <sch:let name="altLanguageText" value="if (lower-case($altLanguage) = 'fra') then 'French' else 'English'"/>
 
+  <sch:let name="required-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))
+    //rdf:Description[
+      starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')
+    ]"/>
+
   <xsl:function name="geonet:resourceFormatsList" as="xs:string">
     <xsl:param name="thesaurusDir" as="xs:string"/>
 
@@ -91,12 +96,8 @@
 
     <xsl:variable name="licenseSeparator" select="if ($lang = 'fre') then ' ou ' else ' or '"/>
 
-    <xsl:variable name="open-license-list"
-             select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))
-                //rdf:Description[starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')]"/>
-
     <xsl:variable name="v">
-      <xsl:for-each select="$open-license-list/ns2:prefLabel[@xml:lang=$valueLang]">
+      <xsl:for-each select="$required-licenses/ns2:prefLabel[@xml:lang=$valueLang]">
         <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
         <xsl:value-of select="."/>
         <xsl:if test="position() != last()"><xsl:value-of select="$licenseSeparator"/></xsl:if>
@@ -438,14 +439,12 @@
       <sch:let name="locMsgMain" value="geonet:appendLocaleMessage($loc/strings/*[name() = concat('OpenLicense', $mainLanguageText)], geonet:openLicenseList($thesaurusDir, $mainLanguage2char))"/>
       <sch:let name="locMsgAlt" value="geonet:appendLocaleMessage($loc/strings/*[name() = concat('OpenLicense', $altLanguageText)], geonet:openLicenseList($thesaurusDir, $altLanguage2char))"/>
 
-      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))//rdf:Description[starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')]"/>
-
       <sch:let name="openLicenseMain" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
-          (normalize-space(gco:CharacterString) = $open-licenses/ns2:prefLabel[@xml:lang=$mainLanguage2char])
+          (normalize-space(gco:CharacterString) = $required-licenses/ns2:prefLabel[@xml:lang=$mainLanguage2char])
       ])" />
 
       <sch:let name="openLicenseAlt" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
-          (normalize-space(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]) = $open-licenses/ns2:prefLabel[@xml:lang=$altLanguage2char])
+          (normalize-space(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]) = $required-licenses/ns2:prefLabel[@xml:lang=$altLanguage2char])
       ])" />
 
       <sch:assert

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch
@@ -91,10 +91,12 @@
 
     <xsl:variable name="licenseSeparator" select="if ($lang = 'fre') then ' ou ' else ' or '"/>
 
-    <xsl:variable name="open-license-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
+    <xsl:variable name="open-license-list"
+             select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))
+                //rdf:Description[starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')]"/>
 
     <xsl:variable name="v">
-      <xsl:for-each select="$open-license-list//rdf:Description/ns2:prefLabel[@xml:lang=$valueLang]">
+      <xsl:for-each select="$open-license-list/ns2:prefLabel[@xml:lang=$valueLang]">
         <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
         <xsl:value-of select="."/>
         <xsl:if test="position() != last()"><xsl:value-of select="$licenseSeparator"/></xsl:if>
@@ -436,14 +438,14 @@
       <sch:let name="locMsgMain" value="geonet:appendLocaleMessage($loc/strings/*[name() = concat('OpenLicense', $mainLanguageText)], geonet:openLicenseList($thesaurusDir, $mainLanguage2char))"/>
       <sch:let name="locMsgAlt" value="geonet:appendLocaleMessage($loc/strings/*[name() = concat('OpenLicense', $altLanguageText)], geonet:openLicenseList($thesaurusDir, $altLanguage2char))"/>
 
-      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
+      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))//rdf:Description[starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')]"/>
 
       <sch:let name="openLicenseMain" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
-          (normalize-space(gco:CharacterString) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char])
+          (normalize-space(gco:CharacterString) = $open-licenses/ns2:prefLabel[@xml:lang=$mainLanguage2char])
       ])" />
 
       <sch:let name="openLicenseAlt" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
-          (normalize-space(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char])
+          (normalize-space(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]) = $open-licenses/ns2:prefLabel[@xml:lang=$altLanguage2char])
       ])" />
 
       <sch:assert

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -268,10 +268,12 @@
             |//*[@gco:isoType='gmd:MD_DataIdentification']
             |//*[@gco:isoType='srv:SV_ServiceIdentification']">
 
-      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
+      <sch:let name="open-licenses"
+               value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))
+                //rdf:Description[starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')]"/>
 
       <sch:let name="openLicense" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
-               (normalize-space(gco:CharacterString) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char])])" />
+               (normalize-space(gco:CharacterString) = $open-licenses/ns2:prefLabel[@xml:lang=$mainLanguage2char])])" />
 
 
       <sch:assert

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-non-multilingual.sch
@@ -31,6 +31,11 @@
   <sch:let name="mainLanguageText" value="if ($mainLanguage = 'fra') then 'French' else 'English'"/>
   <sch:let name="mainLanguage2char" value="if ($mainLanguage = 'fra') then 'fr' else 'en'"/>
 
+  <sch:let name="required-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))
+    //rdf:Description[
+      starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')
+    ]"/>
+
   <xsl:function name="geonet:resourceFormatsList" as="xs:string">
     <xsl:param name="thesaurusDir" as="xs:string"/>
 
@@ -267,13 +272,8 @@
     <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification
             |//*[@gco:isoType='gmd:MD_DataIdentification']
             |//*[@gco:isoType='srv:SV_ServiceIdentification']">
-
-      <sch:let name="open-licenses"
-               value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))
-                //rdf:Description[starts-with(@rdf:about, 'http://geonetwork-opensource.org/GC/GC_OpenLicense#')]"/>
-
       <sch:let name="openLicense" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
-               (normalize-space(gco:CharacterString) = $open-licenses/ns2:prefLabel[@xml:lang=$mainLanguage2char])])" />
+               (normalize-space(gco:CharacterString) = $required-licenses/ns2:prefLabel[@xml:lang=$mainLanguage2char])])" />
 
 
       <sch:assert


### PR DESCRIPTION
Currently if we want to add additional licenses we need to update the `GC_Open_Licenses.rdf`. This however introduces an issue as that new license would also cause the record to pass validation.

This PR aims to solve this issue by checking for Open Government licenses specifically instead of checking for any license in the `GC_Open_Licenses.rdf`.

With these changes we can now add additional optional licenses to `GC_Open_Licenses.rdf` to be displayed as suggestions while still requiring at least one Open Government license.

Additionally the required licenses are set using a `required-licenses` variable at the top of the schematron to facilitate customization.