### PR TITLE
Add WWW:DOWNLOAD-1.0-http--download 4.4

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -1747,8 +1747,8 @@
         <label>Protocol</label>
         <description>Select the appropriate protocol from the drop down list. If your dataset is available online, then enter its web address in the URL text box.</description>
       <helper sort="true">
-        <option value="HTTP">HTTP</option>
         <option value="HTTPS">HTTPS</option>
+        <option value="HTTP">HTTP</option>
         <option value="FTP">FTP</option>
         <option value="ESRI REST: Map Service">ESRI REST: Map Service</option>
         <option value="ESRI REST: Map Server">ESRI REST: Map Server</option>
@@ -1758,6 +1758,7 @@
         <option value="OGC API – Features">OGC API – Features</option>
         <option value="OGC API – Maps">OGC API – Maps</option>
         <option value="AMQPS">Advanced Message Queuing Protocol</option>
+        <option value="WWW:DOWNLOAD-1.0-http--download">File for download</option>
       </helper>
     </element>
     <element name="gmd:purpose" id="26.0">

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -2418,8 +2418,8 @@
     <label>Protocole</label>
     <description>Sélectionnez le protocole approprié dans la liste déroulante. Si vos données sont disponibles en ligne, entrez leur location Web dans la zone de texte URL.</description>
     <helper sort="true">
-      <option value="HTTP">HTTP</option>
       <option value="HTTPS">HTTPS</option>
+      <option value="HTTP">HTTP</option>
       <option value="FTP">FTP</option>
       <option value="ESRI REST: Map Service">ESRI REST: service de carte</option>
       <option value="ESRI REST: Map Server">ESRI REST: serveur de carte</option>
@@ -2429,6 +2429,7 @@
       <option value="OGC API – Features">API OGC – Entités</option>
       <option value="OGC API – Maps">API OGC – Cartes</option>
       <option value="AMQPS">Protocole avancé de file d'attente de messages</option>
+      <option value="WWW:DOWNLOAD-1.0-http--download">Fichier à télécharger</option>
     </helper>
     <condition/>
 


### PR DESCRIPTION
Add `WWW:DOWNLOAD-1.0-http--download` for the ability to identify records as downloadable and can be hidden based on permissions.

Also moved HTTPS to the top selection box default to first selection and most urls are HTTPS

Replaces #370