### PR TITLE
Duplicate name tile for contains operations on HNAP services

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/labels.xml
@@ -436,11 +436,11 @@
         <description>Identifier used for reference systems</description>
         <label>Identifier</label>
     </element>
-    <element name="gmd:URL" context="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    <element name="gmd:URL" context="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
         <label>Online resource</label>
         <description>On-line information that can be used to contact the responsible individual or organization</description>
     </element>
-    <element name="gmd:URL" context="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+    <element name="gmd:URL" context="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
       <label>Online resource</label>
       <description>On-line information that can be used to contact the responsible individual or organization</description>
     </element>
@@ -2644,7 +2644,7 @@
         <label>Name</label>
         <description/>
     </element>
-    <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:name/gco:attributeType/gco:TypeName/gco:aName">
+    <element name="gco:aName" context="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:name/gco:attributeType/gco:TypeName/gco:aName">
         <label>Type name</label>
         <description/>
         <helper>
@@ -2663,7 +2663,7 @@
 			<option value="TEXT">TEXT</option>
 		</helper>
   </element>
-  <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:valueType/gco:TypeName/gco:aName">
+  <element name="gco:aName" context="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:valueType/gco:TypeName/gco:aName">
     <label>Value type name</label>
     <description/>
     <helper>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/labels.xml
@@ -680,11 +680,11 @@
 
   </element>
 
-  <element name="gmd:URL" context="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+  <element name="gmd:URL" context="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
     <label>Ressource en ligne</label>
     <description>Renseignements électroniques qui permettent de communiquer avec l'organisation ou la personne responsable.</description>
   </element>
-  <element name="gmd:URL" context="gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+  <element name="gmd:URL" context="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
     <label>Ressource en ligne</label>
     <description>Renseignements électroniques qui permettent de communiquer avec l'organisation ou la personne responsable.</description>
   </element>
@@ -1161,7 +1161,7 @@
     <condition/>
 
   </element>
-  <!--<element name="gmd:date" id="362.0" context="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date">
+  <!--<element name="gmd:date" id="362.0" context="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date">
     <label>Date</label>
     <description>Date de référence pour la ressource en question</description>
     <help>Date de référence indiquée sous forme de date (jj.mm.aaaa) et de type de date (création, publication, traitement). Ces informations sont du type CI_Date et sont gérées dans la classe du même nom.</help>
@@ -3471,7 +3471,7 @@
     <condition/>
 
   </element>
-  <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:name/gco:attributeType/gco:TypeName/gco:aName">
+  <element name="gco:aName" context="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:name/gco:attributeType/gco:TypeName/gco:aName">
     <label>Nom du type</label>
     <description/>
     <helper>
@@ -3490,7 +3490,7 @@
       <option value="TEXT">TEXT</option>
     </helper>
   </element>
-  <element name="gco:aName" context="gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:valueType/gco:TypeName/gco:aName">
+  <element name="gco:aName" context="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:containsOperations/srv:SV_OperationMetadata/srv:parameters/srv:SV_Parameter/srv:valueType/gco:TypeName/gco:aName">
     <label>Nom de la valeur de type</label>
     <description/>
     <helper>


### PR DESCRIPTION
Fix the Parameter type name and value type name labels and helper lists in services metadata.

The context must be an absolute XPath if an XPath is used.

<img width="490" height="445" alt="image" src="https://github.com/user-attachments/assets/4ecb93e9-9803-4b4d-a3af-dbbe2fcc415f" />

