### PR TITLE
Change default resource protocol to HTTPS

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -12,7 +12,7 @@
       "process": "onlinesrc-add",
       "fields": {
         "protocol": {
-          "value": "HTTP",
+          "value": "HTTPS",
           "isMultilingual": false,
           "required": true,
           "tooltip": "gmd:protocol"


### PR DESCRIPTION
Change default resource protocol to HTTPS
HTTP is not uses as often anymore so HTTPS should be a better default.

This is a follow up to changes from #461