### PR TITLE
fix canada UseGOCOrganisationName org name controller to show errors

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -283,11 +283,7 @@
           </xsl:call-template>
         </xsl:if>
       </xsl:variable>
-
-      <xsl:call-template name="display-error">
-        <xsl:with-param name="listOfErrors" select="$errors"/>
-      </xsl:call-template>
-
+    
     <!--
        This control is a bit different than the rest, so we have to insert
        our own error control.  We use flexbox to give it a similar look

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -294,12 +294,11 @@
        to the "normal" validation output.
     -->
     <div style="display:flex;flex-direction:row">
-      <div style="width:17%"></div>
-      <div style="width:75%">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-8">
         <xsl:copy-of select="$errors"/>
       </div>
-      <div style="width:10%"></div>
-
+      <div class="col-sm-2"></div>
     </div>
   </xsl:template>
 

--- a/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/layout/layout-custom-fields.xsl
@@ -122,6 +122,7 @@
     b) sets up the JSON configuration (see MultiEntryCombiner.js for example JSON).
 -->
   <xsl:template mode="mode-iso19139" match="gmd:organisationName[$UseGOCOrganisationName = 'true' and $schema = 'iso19139.ca.HNAP']" priority="3000"  >
+
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
@@ -271,8 +272,35 @@
            data-label="$labelConfig/label">
       </div>
       <div class="col-sm-1 gn-control"/>
-    </div>
 
+    </div>
+    <!-- start the validation reporting -->
+      <!-- compute errors -->
+      <xsl:variable name="errors">
+        <xsl:if test="$showValidationErrors">
+          <xsl:call-template name="get-errors">
+            <xsl:with-param name="theElement" select="$theElement"/>
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:variable>
+
+      <xsl:call-template name="display-error">
+        <xsl:with-param name="listOfErrors" select="$errors"/>
+      </xsl:call-template>
+
+    <!--
+       This control is a bit different than the rest, so we have to insert
+       our own error control.  We use flexbox to give it a similar look
+       to the "normal" validation output.
+    -->
+    <div style="display:flex;flex-direction:row">
+      <div style="width:17%"></div>
+      <div style="width:75%">
+        <xsl:copy-of select="$errors"/>
+      </div>
+      <div style="width:10%"></div>
+
+    </div>
   </xsl:template>
 
 


### PR DESCRIPTION
See issue https://github.com/metadata101/iso19139.ca.HNAP/issues/465

Since the Government Of Canada OrganisationName (turn on in settings) is a custom control, it wasn't reporting errors.

This PR adds the validation message with the control.

<img width="942" height="413" alt="image" src="https://github.com/user-attachments/assets/987cc28a-a16f-47ab-bfde-be15770e1c85" />

The HTML is a bit "wonky" because normally it would be "inside" the control - but, in this case, its "beside" the control.