### PR TITLE
Metadata editor / online resources: set the resource name as the layer title when selecting a WMS layer

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.ca.HNAP/config/associated-panel/default.json
@@ -90,7 +90,8 @@
     }],
     "multilingualFields": ["name", "desc"],
     "wmsResources": {
-      "addLayerNamesMode": "url"
+      "addLayerNamesMode": "url",
+      "resourceName": "layerTitle"
     },
     "associatedResourcesTypes": [{
       "type": "parent",


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/6465