### PR TITLE
Skip ZuluDateTime conversion when no timezone is set

### DIFF
--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -157,7 +157,17 @@
       eg. 2017-02-08T13:18:03.138+00:02
       -->
       <xsl:for-each select="(gmd:dateStamp/*[gn-fn-index:is-isoDate(.)])[1]">
-        <dateStamp><xsl:value-of select="date-util:convertToISOZuluDateTime(normalize-space(.))"/></dateStamp>
+        <dateStamp>
+          <xsl:variable name="rawDate" select="normalize-space(.)"/>
+          <xsl:choose>
+            <xsl:when test="contains($rawDate, 'Z') or contains($rawDate, '+') or (contains($rawDate, '-') and string-length(substring-after($rawDate, '-')) &lt; 5)">
+              <xsl:value-of select="date-util:convertToISOZuluDateTime($rawDate)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$rawDate"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </dateStamp>
       </xsl:for-each>
 
 

--- a/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
+++ b/src/main/plugin/iso19139.ca.HNAP/index-fields/index.xsl
@@ -160,7 +160,11 @@
         <dateStamp>
           <xsl:variable name="rawDate" select="normalize-space(.)"/>
           <xsl:choose>
-            <xsl:when test="contains($rawDate, 'Z') or contains($rawDate, '+') or (contains($rawDate, '-') and string-length(substring-after($rawDate, '-')) &lt; 5)">
+            <xsl:when test="
+              contains($rawDate, 'Z') or 
+              contains($rawDate, '+') or 
+              (contains($rawDate, '-') and contains(substring-after($rawDate, ':'), '-'))
+            ">
               <xsl:value-of select="date-util:convertToISOZuluDateTime($rawDate)"/>
             </xsl:when>
             <xsl:otherwise>
@@ -343,8 +347,14 @@
                                                   else if ($dateTypeHNAP = 'RI_368') then 'revision'
                                                   else ''" />
 
-            <xsl:variable name="zuluDate"
-                          select="date-util:convertToISOZuluDateTime($date)"/>
+            <xsl:variable name="zuluDate">
+              <xsl:choose>
+                <xsl:when test="contains($date, 'Z') or contains($date, '+') or (contains($date, '-') and contains(substring-after($date, ':'), '-'))">
+                  <xsl:value-of select="date-util:convertToISOZuluDateTime($date)"/>
+                </xsl:when>
+              </xsl:choose>
+            </xsl:variable>
+
             <resourceDate type="object">
               <xsl:choose>
                 <xsl:when test="$zuluDate != '' and gn-fn-index:is-dateTime($date)">


### PR DESCRIPTION
Do not use convertToISOZuluDateTime when no timezone is indicated in the date.