### PR TITLE
Future creation date check

### DIFF
--- a/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
+++ b/src/main/java/ca/gc/schema/iso19139hnap/util/XslUtilHnap.java
@@ -40,8 +40,10 @@ import org.fao.geonet.utils.Log;
 
 import javax.annotation.Nonnull;
 import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -57,7 +59,7 @@ public class XslUtilHnap {
     /**
      * Compares dates (used for temporal extent dates comparison),
      * managing the different formats allowed: yyyy-mm-dd, yyyy-mm, yyyy.
-     * ported from utils-fn.xsl in ec
+     * ported from utils-fn.xsl in ec and modified to handle timezones
      *
      * @param endDate
      * @param startDate
@@ -69,13 +71,15 @@ public class XslUtilHnap {
             return 1;
         } else {
             try {
-
+                // Ensure all dates are in the same format (yyyy-mm-ddThh:mm:ssZ) for comparison
                 endDate = calculateDate(endDate, false);
                 startDate = calculateDate(startDate, true);
 
-                Date date1Value = DateUtils.parseIso8601DateTimeOrDate(endDate);
-                Date date2Value = DateUtils.parseIso8601DateTimeOrDate(startDate);
+                // Parse the dates
+                Instant date1Value = OffsetDateTime.parse(endDate).toInstant();
+                Instant date2Value = OffsetDateTime.parse(startDate).toInstant();
 
+                // Compare the dates
                 return date1Value.compareTo(date2Value);
 
             } catch (Exception ex) {
@@ -84,38 +88,45 @@ public class XslUtilHnap {
         }
     }
 
-    private static String calculateDate(String dateVal, boolean startDate) throws Exception {
-        if (dateVal.length() == 4) {
+    /**
+     * Calculate the date to the same format (yyyy-mm-ddThh:mm:ssZ) for comparison
+     *
+     * @param dateVal   the date value to calculate
+     * @param startDate true if the date is a start date, false if it's an end date. This is used to determine how to fill in missing values.
+     * @return the calculated date in the format of yyyy-mm-ddThh:mm:ssZ
+     */
+    private static String calculateDate(String dateVal, boolean startDate) {
+        if (dateVal.length() == 4) { // No month
             if (startDate) {
-                dateVal = dateVal + "-01-01T00:00:00Z";
+                dateVal += "-01";
             } else {
-                dateVal = dateVal + "-12-31T23:59:59Z";
-            }
-        } else if (dateVal.length() == 7) {
-            if (startDate) {
-                dateVal = dateVal + "-01T00:00:00Z";
-            } else {
-                dateVal = dateVal + "-01T23:59:59Z";
-
-                Date date1Value = DateUtils.parseIso8601DateTimeOrDate(dateVal);
-
-                // Last day of the month
-                Calendar c = Calendar.getInstance();
-                c.setTime(date1Value);
-                c.set(Calendar.DAY_OF_MONTH, c.getActualMaximum(Calendar.DAY_OF_MONTH));
-
-                dateVal = c.get(Calendar.YEAR) + "-" + (c.get(Calendar.MONTH) + 1) + "-" + c.get(Calendar.DAY_OF_MONTH) + "T23:59:59Z";
-            }
-        } else if (dateVal.length() == 10) {
-            if (startDate) {
-                dateVal = dateVal + "T00:00:0Z";
-            } else {
-                dateVal = dateVal + "T23:59:59Z";
+                dateVal += "-12";
             }
         }
 
-        return dateVal;
+        if (dateVal.length() == 7) { // No day
+            if (startDate) {
+                dateVal += "-01";
+            } else {
+                YearMonth yearMonth = YearMonth.parse(dateVal);
 
+                dateVal += ("-" + yearMonth.lengthOfMonth());
+            }
+        }
+
+        if (dateVal.length() == 10) { // No time
+            if (startDate) {
+                dateVal += "T00:00:00";
+            } else {
+                dateVal += "T23:59:59";
+            }
+        }
+
+        if (dateVal.length() == 19) { // No timezone
+            dateVal += "Z";
+        }
+
+        return dateVal;
     }
 
     /**

--- a/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/eng/schematron-rules-common.xml
@@ -17,6 +17,7 @@
   <InvalidSpatialRepresentationType>Spatial representation code is not valid</InvalidSpatialRepresentationType>
   <PublicationDate>Value is required for Metadata publication date</PublicationDate>
   <CreationDate>Value is required for Metadata creation date</CreationDate>
+  <CreationDateNotInFuture>Creation Date should not be in the future</CreationDateNotInFuture>
   <PublicationDateBeforeCreationDate>Publication Date should be after Creation Date</PublicationDateBeforeCreationDate>
   <MissingDate>Value is required for Date</MissingDate>
   <InvalidDateTypeCode>Date type is not valid</InvalidDateTypeCode>

--- a/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
+++ b/src/main/plugin/iso19139.ca.HNAP/loc/fre/schematron-rules-common.xml
@@ -17,6 +17,7 @@
   <InvalidSpatialRepresentationType>Le code de fréquence de mise à jour n'est pas valide</InvalidSpatialRepresentationType>
   <PublicationDate>Une valeur est nécessaire pour: Métadonnées date de publication</PublicationDate>
   <CreationDate>>Une valeur est nécessaire pour: Métadonnées date de création</CreationDate>
+  <CreationDateNotInFuture>La date de création ne doit pas être dans le futur</CreationDateNotInFuture>
   <PublicationDateBeforeCreationDate>La date de publication doit être postérieure à la date de création</PublicationDateBeforeCreationDate>
   <MissingDate>Une valeur est nécessaire pour la Date</MissingDate>
   <InvalidDateTypeCode>Le code de type de date n'est pas valide</InvalidDateTypeCode>

--- a/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
+++ b/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-common.sch
@@ -272,6 +272,17 @@
       <sch:assert test="$missingPublication or $missingCreation or XslUtilHnap:compareDates($publicationDate, $creationDate) &gt;= 0 ">$loc/strings/PublicationDateBeforeCreationDate</sch:assert>
     </sch:rule>
 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date
+    |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date
+    |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']/gmd:date">
+
+      <sch:let name="creationDate" value="(gco:Date|gco:DateTime)[1]" />
+      <sch:let name="missingCreation" value="not(string($creationDate))" />
+      <sch:let name="now" value="format-dateTime(current-dateTime(), '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01][Z]')" />
+
+      <sch:assert test="not($missingCreation) and XslUtilHnap:compareDates($now, $creationDate) &gt;= 0">$loc/strings/CreationDateNotInFuture</sch:assert>
+    </sch:rule>
+
     <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date
             |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date
             |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date">

--- a/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
+++ b/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
@@ -151,6 +151,48 @@ public class XslUtilHnapTest {
 
     }
 
+    @Test
+    public void compareDates_shouldReturnZero_whenOffsetsRepresentSameInstant() {
+        int result = XslUtilHnap.compareDates("2026-04-10T14:30:00Z", "2026-04-10T10:30:00-04:00");
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void compareDates_shouldReturnPositive_whenEndInstantIsAfterStartInstantWithDifferentOffsets() {
+        int result = XslUtilHnap.compareDates("2026-04-10T14:30:00Z", "2026-04-10T14:30:00-04:00");
+        assertTrue(result > 0);
+    }
+
+    @Test
+    public void compareDates_shouldReturnPositive_whenEndIsAfterStart() {
+        int result = XslUtilHnap.compareDates("2026-04-10T10:30:00-04:00", "2026-04-10T11:32:00Z");
+        assertTrue(result > 0);
+    }
+
+    @Test
+    public void compareDates_shouldReturnNegative_whenEndIsBeforeStart() {
+        int result = XslUtilHnap.compareDates("2026-04-10T10:30:00-04:00", "2026-04-10T11:32:00-04:00");
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void compareDates_shouldReturnZero_whenTimezoneIsMissingAndUtcEquivalentIsUsed() {
+        int result = XslUtilHnap.compareDates("2026-04-10T10:30:00Z", "2026-04-10T10:30:00");
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void compareDates_shouldReturnNegative_whenMonthPrecisionEndIsBeforeNextMonth() {
+        int result = XslUtilHnap.compareDates("2026-02", "2026-03-01T00:00:00Z");
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void compareDates_shouldReturnPositive_whenYearPrecisionEndIsAfterMidYearDate() {
+        int result = XslUtilHnap.compareDates("2026", "2026-06-01T00:00:00Z");
+        assertTrue(result > 0);
+    }
+
     class MyTinyNodeImpl extends TinyNodeImpl {
 
         private String value;

--- a/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
+++ b/src/test/java/ca/gc/schema/iso19139hnap/util/XslUtilHnapTest.java
@@ -159,7 +159,7 @@ public class XslUtilHnapTest {
 
     @Test
     public void compareDates_shouldReturnPositive_whenEndInstantIsAfterStartInstantWithDifferentOffsets() {
-        int result = XslUtilHnap.compareDates("2026-04-10T14:30:00Z", "2026-04-10T14:30:00-04:00");
+        int result = XslUtilHnap.compareDates("2026-04-10T14:30:00-04:00", "2026-04-10T14:30:00Z");
         assertTrue(result > 0);
     }
 


### PR DESCRIPTION
Currently, the creation date validation only checks that a creation date is present. Based on #361, creation dates should also not be in the future.

Additionally, the existing date comparison logic uses DateUtils.parseIso8601DateTimeOrDate, which does not support timezones. This can lead to incorrect comparison results when two datetimes represent different offsets, since they will be interpreted as UTC rather than preserving their actual timezone.

This PR aims to fix this issue by adding a validation to ensure the creation date is not in the future, and by updating the date comparison logic to use OffsetDateTime.parse so timezone-aware datetimes are compared correctly.